### PR TITLE
chore(layout nerdpacks): Update video embeds on project pages to use Wistia

### DIFF
--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-2x2-grid.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-2x2-grid.mdx
@@ -5,7 +5,12 @@ title: "New Relic One Nerdpack Layout 2x2 Grid"
 projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-2x2-grid.json"
 ---
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-3-column.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-3-column.mdx
@@ -6,7 +6,12 @@ projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-3-column.json"
 ---
 
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-3x2-grid.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-3x2-grid.mdx
@@ -6,7 +6,12 @@ projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-3x2-grid.json"
 ---
 
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-4-column.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-4-column.mdx
@@ -6,7 +6,12 @@ projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-4-column.json"
 ---
 
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-4x2-grid.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-4x2-grid.mdx
@@ -5,7 +5,12 @@ title: "New Relic One Nerdpack Layout 4x2 Grid"
 projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-4x2-grid.json"
 ---
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-double-sidebar.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-double-sidebar.mdx
@@ -5,7 +5,12 @@ title: "New Relic One Nerdpack Layout Double Sidebar"
 projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-double-sidebar.json"
 ---
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-standard.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-standard.mdx
@@ -6,7 +6,12 @@ projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-standard.json"
 ---
 
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started

--- a/src/data/project-main-content/newrelic-nr1-nerdpack-layout-t-bone.mdx
+++ b/src/data/project-main-content/newrelic-nr1-nerdpack-layout-t-bone.mdx
@@ -5,7 +5,12 @@ title: "New Relic One Nerdpack Layout T-bone"
 projectConfig: "src/data/projects/newrelic-nr1-nerdpack-layout-t-bone.json"
 ---
 <div className="responsive-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/p5qTjujy0PU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;">
+    <div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;">
+      <iframe src="https://fast.wistia.net/embed/iframe/vg6jkqxhrl?videoFoam=true" title="Nerdpack Layouts Templates Walkthrough Video" allowtransparency="true" frameborder="0" scrolling="no" class="wistia_embed" name="wistia_embed" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width="100%" height="100%"></iframe>
+    </div>
+  </div>
+  <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 </div>
 
 ## Getting Started


### PR DESCRIPTION
I was requested by Kyle Jones that we use the Wisita embed code rather than the YouTube embed code. So I've swapped out the YouTube embed code for the Wistia code in this PR for each of the layout nerdpack project pages.