### PR TITLE
fix(homepage): Don't play 2 videos at once

### DIFF
--- a/src/pages/home-page.module.scss
+++ b/src/pages/home-page.module.scss
@@ -505,7 +505,7 @@ img.play-button {
   }
 }
 
-@media screen and (max-width:xzF 480px) {
+@media screen and (max-width: 480px) {
   .hero-container {
     margin-top: 24px;
   }
@@ -527,6 +527,12 @@ img.play-button {
   .featured-internal-projects-container {
     margin-bottom: 20px
   }
+}
+
+@media screen and (max-width: 375px) {
+    .homepage-hero-heading {
+      font-size: 28px; 
+    }   
 }
 
 // ==============================================================

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -103,9 +103,7 @@ const HomePage = ({ data }) => {
               className={styles.heroVideoIframe}
               width="1000"
               height="562.704471"
-              src={`https://fast.wistia.net/embed/iframe/qc7gkrlltt?videoFoam=true${
-                heroVideoActive ? `&autoplay=1` : ''
-              }`}
+              src="https://fast.wistia.net/embed/iframe/qc7gkrlltt?videoFoam=true"
               frameBorder="0"
               allow="accelerometer; encrypted-media; gyroscope; picture-in-picture; showinfo; modestbranding"
               placeholder=""


### PR DESCRIPTION
In firefox, on desktop, when you hit the play button on the hero it would play both the desktop and mobile video at once. This PR fixes that.