### PR TITLE
fix: use website url for ext-projects when available

### DIFF
--- a/src/components/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Header.spec.js.snap
@@ -36,7 +36,7 @@ Array [
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>

--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -38,7 +38,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -289,7 +289,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>

--- a/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
@@ -38,7 +38,7 @@ exports[`External Projects Page Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -254,7 +254,7 @@ exports[`External Projects Page Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>

--- a/src/pages/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/index.spec.js.snap
@@ -38,7 +38,7 @@ exports[`HomePage Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -394,7 +394,7 @@ exports[`HomePage Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>

--- a/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
@@ -38,7 +38,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -510,7 +510,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>

--- a/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
+++ b/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
@@ -38,7 +38,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -315,7 +315,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>
@@ -361,7 +361,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -638,7 +638,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>
@@ -684,7 +684,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           >
             <a
               className="leftSideLink"
-              href="#"
+              href="/"
             >
               Open Source
             </a>
@@ -1189,7 +1189,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           className="version footerMeta"
         >
           Version 
-          1.0.3
+          1.0.10
         </small>
       </div>
     </section>

--- a/src/templates/external-project-page.js
+++ b/src/templates/external-project-page.js
@@ -117,7 +117,7 @@ const ExternalProjectPage = ({ data }) => {
             <div className={styles.callToActionButtons}>
               <div className={styles.callToActionButtonsContainer}>
                 <a
-                  href={`${project.githubUrl}`}
+                  href={`${get(project, ['website', 'url'], '') || project.githubUrl}`}
                   className="button button-primary"
                   target="__blank"
                   rel="noopener noreferrer"

--- a/src/templates/external-project-page.js
+++ b/src/templates/external-project-page.js
@@ -117,7 +117,8 @@ const ExternalProjectPage = ({ data }) => {
             <div className={styles.callToActionButtons}>
               <div className={styles.callToActionButtonsContainer}>
                 <a
-                  href={`${get(project, ['website', 'url'], '') || project.githubUrl}`}
+                  href={`${get(project, ['website', 'url'], '') ||
+                    project.githubUrl}`}
                   className="button button-primary"
                   target="__blank"
                   rel="noopener noreferrer"


### PR DESCRIPTION
Fix

When a website url is available in the config file, use this link for the `View Website` button.
