### PR TITLE
feat(seo): Add meta tag for swiftype type field for all pages

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -66,6 +66,12 @@ function SEO({ description, lang, meta, title }) {
         {
           name: `twitter:description`,
           content: metaDescription
+        },
+        {
+          class: 'swiftype',
+          name: 'type',
+          'data-type': 'enum',
+          content: 'opensource'
         }
       ].concat(meta)}
     />


### PR DESCRIPTION
The swiftype type field identifies the source website of each record in the swiftype search index. We use that to filter search results to specific websites. Once this is live we can point swiftype at opensource site to index all pages.
