### PR TITLE
fix: standardize bug template 'behavior' spelling to US English.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ assignees: ''
 
 [NOTE]: # ( Please be as specific as possible. )
 
-## Expected Behaviour
+## Expected Behavior
 
 [NOTE]: # ( Tell us what you expected to happen. )
 


### PR DESCRIPTION
Super minor but noticed another non-US English spelling of 'behavior' crept in. I believe we are standardizing on US English for better or worse, so figured I'd throw a quick PR in.
