### PR TITLE
chore: remove extra https://

### DIFF
--- a/src/data/project-main-content/adopt-open-jdk.mdx
+++ b/src/data/project-main-content/adopt-open-jdk.mdx
@@ -7,7 +7,7 @@ projectConfig: "src/data/projects/adopt-open-jdk.json"
 
 ## How New Relic is Involved
 
-New Relic is a [Silver Sponsor](https://https://adoptopenjdk.net/sponsors.html) of [AdoptOpenJDK](https://adoptopenjdk.net) and participates in technical work related to the project, including:
+New Relic is a [Silver Sponsor](https://adoptopenjdk.net/sponsors.html) of [AdoptOpenJDK](https://adoptopenjdk.net) and participates in technical work related to the project, including:
 
 * Performance Regression testing
 * Java Flight Recorder (JFR) and Java Mission Control (JMC)


### PR DESCRIPTION
Fixes silver sponsor link from AdoptOpenJDK page
https://opensource.newrelic.com/projects/adopt-open-jdk