### PR TITLE
chore: adds node-newrelic-koa back as community project.

### DIFF
--- a/src/data/projects/newrelic-node-newrelic-koa.json
+++ b/src/data/projects/newrelic-node-newrelic-koa.json
@@ -1,0 +1,29 @@
+{
+  "name": "node-newrelic-koa",
+  "fullName": "newrelic/node-newrelic-koa",
+  "slug": "newrelic-node-newrelic-koa",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic Koa (Node)",
+  "supportUrl": "https://discuss.newrelic.com/c/support-products-agents/node-js-agent/",
+  "githubUrl": "https://github.com/newrelic/node-newrelic-koa",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/node-newrelic-koa",
+  "iconUrl": null,
+  "shortDescription": "Node.js Agent instumentation for Koa",
+  "description": "Koa framework instrumentation for New Relic's Node.js Agent",
+  "ossCategory": "community-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": [
+    "agent",
+    "exporter",
+    "lib"
+  ],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Koa (Node)",
+    "url": "https://github.com/newrelic/node-newrelic-koa"
+  },
+  "defaultBranch": "main"
+}


### PR DESCRIPTION
* Restores the previous project file, now that the repo has the appropriate licensing, etc.
* Adds default branch.