### PR TITLE
chore: adds node-newrelic-superagent project back as community project.

### DIFF
--- a/src/data/projects/newrelic-node-newrelic-superagent.json
+++ b/src/data/projects/newrelic-node-newrelic-superagent.json
@@ -1,0 +1,29 @@
+{
+  "name": "node-newrelic-superagent",
+  "fullName": "newrelic/node-newrelic-superagent",
+  "slug": "newrelic-node-newrelic-superagent",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic SuperAgent (Node)",
+  "supportUrl": "https://discuss.newrelic.com/c/support-products-agents/node-js-agent/",
+  "githubUrl": "https://github.com/newrelic/node-newrelic-superagent",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/node-newrelic-superagent",
+  "iconUrl": null,
+  "shortDescription": "Node Agent instumentation for SuperAgent",
+  "description": "SuperAgent instrumentation for New Relic's Node Agent",
+  "ossCategory": "community-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": [
+    "agent",
+    "exporter",
+    "lib"
+  ],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic SuperAgent (Node)",
+    "url": "https://github.com/newrelic/node-newrelic-superagent"
+  },
+  "defaultBranch": "main"
+}


### PR DESCRIPTION
- Restores the previous project file, now that the repo has the appropriate licensing, etc.
- Adds default branch.