### PR TITLE
style: Updated CoC capitalization

### DIFF
--- a/src/pages/code-of-conduct-reporting.mdx
+++ b/src/pages/code-of-conduct-reporting.mdx
@@ -31,7 +31,7 @@ export default ({ children, data }) => (
     </Layout>
 );
 
-If you believe someone is violating the [code of conduct](/code-of-conduct), we ask that you report it to the New Relic Open Source Steering Committee by emailing [opensource@newrelic.com](mailto:opensource@newrelic.com). All reports will be kept confidential to the extent possible.
+If you believe someone is violating the [Code of Conduct](/code-of-conduct), we ask that you report it to the New Relic Open Source Steering Committee by emailing [opensource@newrelic.com](mailto:opensource@newrelic.com). All reports will be kept confidential to the extent possible.
 
 If you are unsure whether the incident is a violation, or whether the space where it happened is covered by this [Code of Conduct](/code-of-conduct), we encourage you to still report it. We would much rather have a few extra reports where we decide to take no action, rather than miss a report of an actual violation. We do not look negatively on you if we find the incident is not a violation. And knowing about incidents that are not violations, or that happen outside our spaces, can also help us to improve the [Code of Conduct](/code-of-conduct) or the processes surrounding it.
 


### PR DESCRIPTION
style: Updated "Code of Conduct" capitalization in the first sentence of the reporting guide.