### PR TITLE
chore: adds node-newrelic-aws-sdk back as community project.

### DIFF
--- a/src/data/projects/newrelic-node-newrelic-aws-sdk.json
+++ b/src/data/projects/newrelic-node-newrelic-aws-sdk.json
@@ -1,0 +1,28 @@
+{
+  "name": "node-newrelic-aws-sdk",
+  "fullName": "newrelic/node-newrelic-aws-sdk",
+  "slug": "newrelic-node-newrelic-aws-sdk",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic AWS SDK (Node)",
+  "supportUrl": "https://discuss.newrelic.com/c/support-products-agents/node-js-agent",
+  "githubUrl": "https://github.com/newrelic/node-newrelic-aws-sdk",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/node-newrelic-aws-sdk",
+  "iconUrl": null,
+  "shortDescription": "AWS SDK for Node",
+  "description": "New Relic's official AWS-SDK package instrumentation for use with the Node Agent",
+  "ossCategory": "community-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": [
+    "sdk",
+    "agent"
+  ],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic AWS SDK (Node)",
+    "url": "https://github.com/newrelic/node-newrelic-aws-sdk"
+  },
+  "defaultBranch": "main"
+}


### PR DESCRIPTION
* Restores the previous project file, now that the repo has the appropriate licensing, etc.
* Adds default branch.
