### PR TITLE
fix: ensure dark mode mobile button shows close icon

### DIFF
--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -257,18 +257,20 @@ div.exists-in-active-mobile-menu {
 
   .mobile-menu-button {
     background-image: url('../images/icon-menu-light.svg');
-    
-    div.mobile-menu-active & {
+  }
+
+  div.mobile-menu-active {
+    .mobile-menu-button {
       background-image: url('../images/icon-menu-close-light.svg');
+    }
+
+    .header-dark-mode-toggle svg {
+      fill: transparent;
+      stroke: var(--color-neutrals-800);
     }
   }
 
   .primary-header-nav-link svg {
     display: none;
-  }
-
-  .mobile-menu-active .header-dark-mode-toggle svg {
-    fill: transparent;
-    stroke: var(--color-neutrals-800);
   }
 }


### PR DESCRIPTION
Addresses: https://github.com/newrelic/opensource-website/issues/596

Noticed the mobile nav toggle button wasn't switching between the hamburger and close icons on the live site.

![Screenshot 2020-08-09 at 17 43 52](https://user-images.githubusercontent.com/20293876/89737327-009d8a80-da68-11ea-9d19-dabfecbdb865.jpg)

Looks like the rule currently on line 261 in `src/components/Header.module.scss` will never get applied since the `&` on the right would build to the `CSS` below, which won't match any elements since `.dark-mode` is applied at the base of the DOM tree on `body`:

```css
div.mobile-menu-active :global(.dark-mode) .mobile-menu-button {
  background-image: url("../images/icon-menu-close-light.svg");
}
```

This commit combines two sets of style rules that should apply when the `mobile-menu-active` class is toggled on. I think this makes the rules a bit clearer, and it fixes the live bug.



