### PR TITLE
chore: Restore node-newrelic-mysql back as a experimental project.

### DIFF
--- a/src/data/projects/newrelic-node-newrelic-mysql.json
+++ b/src/data/projects/newrelic-node-newrelic-mysql.json
@@ -1,0 +1,25 @@
+{
+  "name": "node-newrelic-mysql",
+  "fullName": "newrelic/node-newrelic-mysql",
+  "slug": "newrelic-node-newrelic-mysql",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic MySQL (Node)",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic/node-newrelic-mysql",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/node-newrelic-mysql",
+  "iconUrl": null,
+  "shortDescription": "Node Agent instumentation for MySQL",
+  "description": "MySQL instrumentation for New Relic's Node Agent",
+  "ossCategory": "new-relic-experimental",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["agent", "exporter", "lib"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic MySQL (Node)",
+    "url": "https://github.com/newrelic/node-newrelic-mysql"
+	},
+	"defaultBranch": "main"
+}


### PR DESCRIPTION
- Restores the previous project file, now that the repo has the appropriate licensing, etc.
- Adds defaultBranch