### PR TITLE
chore: Add repolinter-action project data

### DIFF
--- a/src/data/project-main-content/newrelic-repolinter-action.mdx
+++ b/src/data/project-main-content/newrelic-repolinter-action.mdx
@@ -1,0 +1,10 @@
+---
+path: "/projects/newrelic/repolinter-action"
+date: "08/14/2020"
+title: "New Relic Repolinter Action"
+projectConfig: "src/data/projects/newrelic-repolinter-action.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/repolinter-action) for setup and usage details.

--- a/src/data/projects/newrelic-repolinter-action.json
+++ b/src/data/projects/newrelic-repolinter-action.json
@@ -1,0 +1,24 @@
+{
+  "name": "repolinter-action",
+  "fullName": "newrelic/repolinter-action",
+  "slug": "newrelic-repolinter-actionn",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "Repolinter Action",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic/repolinter-action",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/repolinter-action",
+  "iconUrl": null,
+  "shortDescription": "Run Repolinter in your CI pipeline",
+  "description": "This action runs Repolinter on your repository. Optionally you can also configure this tool to create GitHub issues with the Repolinter output.",
+  "ossCategory": "new-relic-experimental",
+  "primaryLanguage": "TypeScript",
+  "projectTags": ["tools", "ci", "github-action", "open-source-management"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "Repolinter Action",
+    "url": "https://github.com/newrelic/repolinter-action"
+  }
+}

--- a/src/data/projects/newrelic-wiki-sync-action.json
+++ b/src/data/projects/newrelic-wiki-sync-action.json
@@ -10,7 +10,7 @@
   "supportUrl": "https://discuss.newrelic.com/t/open-source-maintainers-keep-repo-documentation-in-sync-with-the-bi-directional-wiki-sync-github-action/105611",
   "githubUrl": "https://github.com/newrelic/wiki-sync-action",
   "permalink": "https://opensource.newrelic.com/projects/newrelic/wiki-sync-action",
-  "iconUrl": "null",
+  "iconUrl": null,
   "shortDescription": "Sync your documentation and Wiki",
   "description": "A GitHub Action that synchronizes the contents of a directory to the repository's Wiki.",
   "ossCategory": "community-project",


### PR DESCRIPTION
This PR contributes project data for [Repolinter Action](https://github.com/newrelic/repolinter-action) and fixes a typo in Wiki Sync action's project data.
