### PR TITLE
fix: add Gatsby theme New Relic global nav to Open Source site mobile views (#556)

### DIFF
--- a/__mocks__/react-dom.js
+++ b/__mocks__/react-dom.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...jest.requireActual('react-dom'),
+  createPortal: (element) => element,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3755,9 +3755,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.7.0.tgz",
-      "integrity": "sha512-1xNvJFLqUgOIyHvP96v8A1wpWF1rOYJis+oQ43hTUZ/Kl9dFti2JMDnSxnT6Q8pB+Sq1SOjj8+P8MD96nETxGg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.7.1.tgz",
+      "integrity": "sha512-Cc14nytI0BDUh6K7p9j324KxBJEm6SLbqw+hZgEh4ZUv2HEHczxpjJFa4wWaF8JrbqLt33kNqSr1zwtanQ0RLw==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3755,9 +3755,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.6.0.tgz",
-      "integrity": "sha512-pT7fRAYhOgvKN40gZZQsvxEhnyOSzU7P1sVK/YnUUXMiHm7NqNxBDw32qU4YlARVoSnvaosXcMdIMKPCku59UQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.7.0.tgz",
+      "integrity": "sha512-1xNvJFLqUgOIyHvP96v8A1wpWF1rOYJis+oQ43hTUZ/Kl9dFti2JMDnSxnT6Q8pB+Sq1SOjj8+P8MD96nETxGg==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",
@@ -3856,9 +3856,9 @@
           "integrity": "sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw=="
         },
         "xstate": {
-          "version": "4.11.0",
-          "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.11.0.tgz",
-          "integrity": "sha512-v+S3jF2YrM2tFOit8o7+4N3FuFd9IIGcIKHyfHeeNjMlmNmwuiv/IbY9uw7ECifx7H/A9aGLcxPSr0jdjTGDww=="
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.12.0.tgz",
+          "integrity": "sha512-rA66sw2vl9LERQsPE4xTqJP77+gHt/UYi9IqIek9dHlouDwBKTYf5yqp780JAv5n36P1UY9IRNp24rhCCxN6/A=="
         }
       }
     },
@@ -14694,16 +14694,16 @@
       }
     },
     "gatsby-transformer-sharp": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.5.12.tgz",
-      "integrity": "sha512-f9VQVs7WFv3js6oGReJX1WUYxYTfE9CT+VV8tJHJ+uiUQ8JpDHRq4hjDGdhfFgaPjsmdb7Y4gUVOsLsWLitXOg==",
+      "version": "2.5.13",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.5.13.tgz",
+      "integrity": "sha512-3jHVuD0SnOdG+6rk7HjUG1F1UPZZrz33196bDnbaR3YYRh8MMlLkoKH+2oZ/i9SLCxkU1jNBozMJzYMyonHZvg==",
       "requires": {
         "@babel/runtime": "^7.10.3",
         "bluebird": "^3.7.2",
         "fs-extra": "^8.1.0",
         "potrace": "^2.1.8",
         "probe-image-size": "^4.1.1",
-        "semver": "^5.7.1",
+        "semver": "^7.3.2",
         "sharp": "^0.25.1"
       },
       "dependencies": {
@@ -15074,6 +15074,11 @@
           "requires": {
             "jimp": "^0.14.0"
           }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },
@@ -15133,11 +15138,6 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
-        },
         "camelcase-keys": {
           "version": "6.2.2",
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
@@ -15146,13 +15146,6 @@
             "camelcase": "^5.3.1",
             "map-obj": "^4.0.0",
             "quick-lru": "^4.0.1"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            }
           }
         },
         "find-up": {
@@ -15203,17 +15196,15 @@
           "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
         },
         "meow": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-          "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
+          "integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
           "requires": {
             "@types/minimist": "^1.2.0",
-            "arrify": "^2.0.1",
-            "camelcase": "^6.0.0",
             "camelcase-keys": "^6.2.2",
             "decamelize-keys": "^1.1.0",
             "hard-rejection": "^2.1.0",
-            "minimist-options": "^4.0.2",
+            "minimist-options": "4.1.0",
             "normalize-package-data": "^2.5.0",
             "read-pkg-up": "^7.0.1",
             "redent": "^3.0.0",
@@ -15327,13 +15318,6 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-            }
           }
         }
       }
@@ -24165,9 +24149,9 @@
       "integrity": "sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug=="
     },
     "prismjs": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
       "requires": {
         "clipboard": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@newrelic/gatsby-theme-newrelic": "^1.7.0",
+    "@newrelic/gatsby-theme-newrelic": "^1.7.1",
     "date-fns": "^2.14.0",
     "feather-icons": "^4.28.0",
     "gatsby": "^2.24.8",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
-    "@newrelic/gatsby-theme-newrelic": "^1.6.0",
+    "@newrelic/gatsby-theme-newrelic": "^1.7.0",
     "date-fns": "^2.14.0",
     "feather-icons": "^4.28.0",
     "gatsby": "^2.24.8",

--- a/src/components/CookieApprovalDialog.module.scss
+++ b/src/components/CookieApprovalDialog.module.scss
@@ -2,7 +2,7 @@
   width: 100%;
   position: fixed;
   bottom: 0;
-  z-index: 10000;
+  z-index: 500;
   background-color: rgba(28, 42, 47, 0.92);
   box-shadow: 0px -0.249053px 4.26158px rgba(12, 48, 57, 0.0421718),
     0px -0.598509px 10.2412px rgba(12, 48, 57, 0.0605839),

--- a/src/components/Footer.module.scss
+++ b/src/components/Footer.module.scss
@@ -156,7 +156,7 @@
     width: 160px;
     height: 34px;
     background-size: 160px 34px;
-    z-index: 100;
+    z-index: 300;
   }
 }
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -44,15 +44,16 @@ const Header = ({ hasHeaderBg, editLink }) => {
         className={mobileMenuActive ? styles.existsInActiveMobileMenu : ''}
         editUrl={editLink}
         css={css`
-          position: static;
+          ul {
+            line-height: 14px;
+            font-size: 16px;
+          }
 
           a {
             border-bottom: none;
           }
 
-          @media screen and (max-width: 480px) {
-            display: none;
-          }
+          z-index: 1000000;
         `}
       />
       <header

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -53,7 +53,7 @@ const Header = ({ hasHeaderBg, editLink }) => {
             border-bottom: none;
           }
 
-          z-index: 1000000;
+          z-index: 700;
         `}
       />
       <header

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -3,6 +3,7 @@
 }
 
 .primary-header-container {
+  position: relative;
   box-sizing: border-box;
   padding: 20px 0;
   display: flex;
@@ -145,7 +146,7 @@ div.exists-in-active-mobile-menu {
     position: absolute;
     top: 0;
     right: 0;
-    bottom: -500px;
+    bottom: -100vh;
     left: 0;
     z-index: 1000;
     background-color: var(--color-background);

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -83,7 +83,7 @@ a.primary-header-nav-link {
 
 div.exists-in-active-mobile-menu {
   position: relative;
-  z-index: 10000;
+  z-index: 500;
   background-color: var(--color-neutrals-100);
 }
 
@@ -131,7 +131,7 @@ div.exists-in-active-mobile-menu {
     width: 160px;
     height: 34px;
     background-size: 160px 34px;
-    z-index: 10000;
+    z-index: 500;
   }
 
   .primary-header-nav-links {
@@ -148,7 +148,7 @@ div.exists-in-active-mobile-menu {
     right: 0;
     bottom: -100vh;
     left: 0;
-    z-index: 1000;
+    z-index: 400;
     background-color: var(--color-background);
 
     .mobile-menu-button {

--- a/src/components/HomePageHighlights.module.scss
+++ b/src/components/HomePageHighlights.module.scss
@@ -44,7 +44,7 @@
   text-align: center;
   background-color: var(--color-background);
   position: relative;
-  z-index: 100;
+  z-index: 300;
   box-shadow: 0px 1.49432px 1.16225px rgba(27, 81, 87, 0.0140573), 0px 3.59106px 2.79304px rgba(27, 81, 87, 0.0201946), 0px 6.76164px 5.25905px rgba(27, 81, 87, 0.025), 0px 12.0616px 9.38125px rgba(27, 81, 87, 0.0298054), 0px 22.5599px 17.5466px rgba(27, 81, 87, 0.0359427), 0px 54px 42px rgba(27, 81, 87, 0.05);
 
   &:last-child {

--- a/src/components/HomepageCollection.module.scss
+++ b/src/components/HomepageCollection.module.scss
@@ -56,7 +56,7 @@
     position: absolute;
     top: -1px;
     left: 0;
-    z-index: 1000;
+    z-index: 400;
     background-image: url('../images/home-collection-mask.png');
   }
 
@@ -73,7 +73,7 @@
   flex-shrink: 0;
   margin-right: 20px;
   position: relative;
-  z-index: 100;
+  z-index: 300;
   box-shadow: 0px 0.913195px 0.802504px rgba(4, 22, 22, 0.00562291), 0px 2.19453px 1.92853px rgba(4, 22, 22, 0.00807786), 0px 4.13211px 3.63125px rgba(4, 22, 22, 0.01), 0px 7.37098px 6.47753px rgba(4, 22, 22, 0.0119221), 0px 13.7866px 12.1155px rgba(4, 22, 22, 0.0143771), 0px 33px 29px rgba(4, 22, 22, 0.02);
   pointer-events: none;
 
@@ -89,7 +89,7 @@
 }
 
 .cta-button {
-  z-index: 1000;
+  z-index: 400;
   position: absolute;
   left: 50%;
   transform: translate(-50%, 40px);

--- a/src/components/ProjectModule.module.scss
+++ b/src/components/ProjectModule.module.scss
@@ -8,7 +8,7 @@
   text-align: center;
   background-color: var(--color-background);
   position: relative;
-  z-index: 100;
+  z-index: 300;
   border: 1px solid var(--color-neutrals-300);
   box-shadow: 0px 0.249053px 0.553451px rgba(0, 0, 0, 0.00562291), 0px 0.598509px 1.33002px rgba(0, 0, 0, 0.00807786), 0px 1.12694px 2.50431px rgba(0, 0, 0, 0.01), 0px 2.01027px 4.46726px rgba(0, 0, 0, 0.0119221), 0px 3.75998px 8.35552px rgba(0, 0, 0, 0.0143771), 0px 9px 20px rgba(0, 0, 0, 0.02);
   border-radius: 4px;

--- a/src/components/ProjectSearchInput.module.scss
+++ b/src/components/ProjectSearchInput.module.scss
@@ -50,7 +50,7 @@
   display: flex;
   justify-content: center;
   position: relative;
-  z-index: 1;
+  z-index: 100;
 }
 
 .search-filter {

--- a/src/components/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Header.spec.js.snap
@@ -2,11 +2,7 @@
 
 exports[`Header renders correctly 1`] = `
 Array [
-<<<<<<< HEAD
   .emotion-65 {
-=======
-  .emotion-33 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -1129,7 +1125,6 @@ Array [
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-26 .sui-result__title {
   font-size: inherit;
   font-weight: 400;
@@ -1449,24 +1444,6 @@ Array [
   background-color: var(--tertiary-background-color);
   border: 1px solid #a6a6a6;
   border-radius: 4px;
-=======
-.dark-mode .emotion-33 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-33 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-33 {
-    display: none;
-  }
-}
-
-.emotion-32 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1650,11 +1627,7 @@ Array [
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-63 {
-=======
-.emotion-31 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -1668,25 +1641,17 @@ Array [
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-63 > li {
-=======
-.emotion-31 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-<<<<<<< HEAD
 .emotion-58 {
   color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-=======
-.emotion-29 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1697,15 +1662,11 @@ Array [
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-58:hover {
   color: var(--secondary-text-hover-color);
 }
 
 .emotion-57 {
-=======
-.emotion-28 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1717,11 +1678,7 @@ Array [
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-59 {
-=======
-.emotion-30 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1737,11 +1694,7 @@ Array [
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-59:hover {
-=======
-.emotion-30:hover {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   color: var(--secondary-text-hover-color);
 }
 
@@ -1797,19 +1750,11 @@ Array [
 }
 
 <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -2016,7 +1961,6 @@ Array [
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
       >
         <li>
@@ -2026,17 +1970,6 @@ Array [
           >
             <svg
               className="emotion-57"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -2056,11 +1989,7 @@ Array [
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-59"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Header.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Header renders correctly 1`] = `
 Array [
-  .emotion-32 {
+  .emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -12,21 +12,21 @@ Array [
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -40,28 +40,60 @@ Array [
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1180px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -81,7 +113,1472 @@ Array [
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1180px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -91,9 +1588,19 @@ Array [
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -110,17 +1617,17 @@ Array [
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -134,14 +1641,44 @@ Array [
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -150,46 +1687,179 @@ Array [
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-60 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
+}
+
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
 }
 
 <div
-    className=" emotion-32"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -246,11 +1916,11 @@ Array [
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -260,7 +1930,7 @@ Array [
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -270,7 +1940,7 @@ Array [
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -280,7 +1950,7 @@ Array [
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -291,31 +1961,35 @@ Array [
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-63"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-58"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-57"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -324,6 +1998,22 @@ Array [
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>

--- a/src/components/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Header.spec.js.snap
@@ -9,7 +9,7 @@ Array [
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {

--- a/src/components/__tests__/__snapshots__/Header.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Header.spec.js.snap
@@ -9,21 +9,20 @@ Array [
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {

--- a/src/components/nord-prism-theme.css
+++ b/src/components/nord-prism-theme.css
@@ -119,7 +119,7 @@ pre[data-line] {
 }
 pre[class*="language-"] > code[class*="language-"] {
   position: relative;
-  z-index: 1;
+  z-index: 100;
 }
 .line-highlight {
   position: absolute;

--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data Collection Agents Page Renders correctly 1`] = `
-.emotion-32 {
+.emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -11,21 +11,21 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39,28 +39,60 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -80,7 +112,1472 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -90,9 +1587,19 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,17 +1616,17 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -133,14 +1640,44 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -149,49 +1686,182 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-60 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
+}
+
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
 }
 
 <div
   className="layout-container collectionPage"
 >
   <div
-    className=" emotion-32"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -248,11 +1918,11 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -262,7 +1932,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -272,7 +1942,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -282,7 +1952,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -293,31 +1963,35 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-63"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-58"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-57"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -326,6 +2000,22 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>

--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {

--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -8,21 +8,20 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {

--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Data Collection Agents Page Renders correctly 1`] = `
-<<<<<<< HEAD
 .emotion-65 {
-=======
-.emotion-33 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -1128,7 +1124,6 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-26 .sui-result__title {
   font-size: inherit;
   font-weight: 400;
@@ -1448,24 +1443,6 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   background-color: var(--tertiary-background-color);
   border: 1px solid #a6a6a6;
   border-radius: 4px;
-=======
-.dark-mode .emotion-33 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-33 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-33 {
-    display: none;
-  }
-}
-
-.emotion-32 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1649,11 +1626,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-63 {
-=======
-.emotion-31 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -1667,25 +1640,17 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-63 > li {
-=======
-.emotion-31 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-<<<<<<< HEAD
 .emotion-58 {
   color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-=======
-.emotion-29 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1696,15 +1661,11 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-58:hover {
   color: var(--secondary-text-hover-color);
 }
 
 .emotion-57 {
-=======
-.emotion-28 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1716,11 +1677,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-59 {
-=======
-.emotion-30 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1736,11 +1693,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-59:hover {
-=======
-.emotion-30:hover {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   color: var(--secondary-text-hover-color);
 }
 
@@ -1799,19 +1752,11 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   className="layout-container collectionPage"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -2018,7 +1963,6 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
       >
         <li>
@@ -2028,17 +1972,6 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
           >
             <svg
               className="emotion-57"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -2058,11 +1991,7 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-59"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`External Projects Page Renders correctly 1`] = `
-.emotion-34 {
+.emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -11,21 +11,21 @@ exports[`External Projects Page Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-34 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-34 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-34 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-33 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39,28 +39,60 @@ exports[`External Projects Page Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -80,7 +112,1472 @@ exports[`External Projects Page Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -90,9 +1587,19 @@ exports[`External Projects Page Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,17 +1616,17 @@ exports[`External Projects Page Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-32 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -133,14 +1640,17 @@ exports[`External Projects Page Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-32 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-29 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -151,7 +1661,23 @@ exports[`External Projects Page Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -160,49 +1686,182 @@ exports[`External Projects Page Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-31 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-31:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-60 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
+}
+
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
 }
 
 <div
   className="layout-container undefined"
 >
   <div
-    className=" emotion-34"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-33"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -259,11 +1918,11 @@ exports[`External Projects Page Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -273,7 +1932,7 @@ exports[`External Projects Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -283,7 +1942,7 @@ exports[`External Projects Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -293,7 +1952,7 @@ exports[`External Projects Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -304,52 +1963,35 @@ exports[`External Projects Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-32"
+        className="emotion-63"
       >
         <li>
           <a
-            className="emotion-29"
-            href="https://github.com/newrelic/opensource-website/tree/develop/src/pages/code-of-conduct.mdx"
-            rel="noopener noreferrer"
-            target="_blank"
+            className="emotion-58"
+            href="?q="
           >
             <svg
-              className="emotion-28"
+              className="emotion-57"
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <path
-                d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
               />
-              <path
-                d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
               />
             </svg>
           </a>
         </li>
         <li>
           <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
-        </li>
-        <li>
-          <svg
-            className="emotion-31"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -358,6 +2000,22 @@ exports[`External Projects Page Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>

--- a/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
@@ -1166,7 +1166,6 @@ exports[`External Projects Page Renders correctly 1`] = `
   vertical-align: bottom;
 }
 
-<<<<<<< HEAD
 .emotion-26 .sui-result__license {
   font-size: 12px;
   color: #999999;
@@ -1444,24 +1443,6 @@ exports[`External Projects Page Renders correctly 1`] = `
   background-color: var(--tertiary-background-color);
   border: 1px solid #a6a6a6;
   border-radius: 4px;
-=======
-.dark-mode .emotion-35 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-35 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-35 {
-    display: none;
-  }
-}
-
-.emotion-34 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1645,11 +1626,7 @@ exports[`External Projects Page Renders correctly 1`] = `
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-63 {
-=======
-.emotion-33 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -1663,11 +1640,7 @@ exports[`External Projects Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-63 > li {
-=======
-.emotion-33 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
@@ -1704,11 +1677,7 @@ exports[`External Projects Page Renders correctly 1`] = `
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-59 {
-=======
-.emotion-32 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1724,11 +1693,7 @@ exports[`External Projects Page Renders correctly 1`] = `
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-59:hover {
-=======
-.emotion-32:hover {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   color: var(--secondary-text-hover-color);
 }
 
@@ -1787,19 +1752,11 @@ exports[`External Projects Page Renders correctly 1`] = `
   className="layout-container undefined"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-35"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-34"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -2006,11 +1963,7 @@ exports[`External Projects Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
-=======
-        className="emotion-33"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
       >
         <li>
           <a
@@ -2037,37 +1990,8 @@ exports[`External Projects Page Renders correctly 1`] = `
           </a>
         </li>
         <li>
-<<<<<<< HEAD
           <svg
             className="emotion-59"
-=======
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle
-                cx="11"
-                cy="11"
-                r="8"
-              />
-              <line
-                x1="21"
-                x2="16.65"
-                y1="21"
-                y2="16.65"
-              />
-            </svg>
-          </a>
-        </li>
-        <li>
-          <svg
-            className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
@@ -8,21 +8,20 @@ exports[`External Projects Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-34 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-34 a {
-  border-bottom: none;
+.emotion-34 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-34 {
-    display: none;
-  }
+.emotion-34 a {
+  border-bottom: none;
 }
 
 .emotion-33 {

--- a/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
@@ -8,7 +8,7 @@ exports[`External Projects Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {

--- a/src/pages/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HomePage Renders correctly 1`] = `
-.emotion-32 {
+.emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -11,21 +11,21 @@ exports[`HomePage Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39,28 +39,60 @@ exports[`HomePage Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -80,7 +112,1472 @@ exports[`HomePage Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -90,9 +1587,19 @@ exports[`HomePage Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,17 +1616,17 @@ exports[`HomePage Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -133,14 +1640,44 @@ exports[`HomePage Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -149,35 +1686,25 @@ exports[`HomePage Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-33 {
+.emotion-60 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -199,22 +1726,74 @@ exports[`HomePage Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
   color: var(--color-white);
-  border-color: var(--color-brand-800);
-  background-color: var(--color-brand-800);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
 }
 
-.dark-mode .emotion-33 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
 }
 
-.dark-mode .emotion-33 {
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-66 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+}
+
+.emotion-66:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-66:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.dark-mode .emotion-66 {
   border-color: transparent;
 }
 
-.emotion-33.emotion-33.emotion-33:after {
+.emotion-66.emotion-66.emotion-66:after {
   display: none;
 }
 
@@ -222,17 +1801,116 @@ exports[`HomePage Renders correctly 1`] = `
   className="layout-container undefined"
 >
   <div
-    className=" emotion-32"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -289,11 +1967,11 @@ exports[`HomePage Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -303,7 +1981,7 @@ exports[`HomePage Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -313,7 +1991,7 @@ exports[`HomePage Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -323,7 +2001,7 @@ exports[`HomePage Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -334,31 +2012,35 @@ exports[`HomePage Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-63"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-58"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-57"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -367,6 +2049,22 @@ exports[`HomePage Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>
@@ -599,7 +2297,7 @@ exports[`HomePage Renders correctly 1`] = `
         onMouseOver={[Function]}
       >
         <a
-          className="ctaButton emotion-33 emotion-34"
+          className="ctaButton emotion-66 emotion-61"
           href="/instrumentation"
         >
           <span

--- a/src/pages/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/index.spec.js.snap
@@ -8,21 +8,20 @@ exports[`HomePage Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {

--- a/src/pages/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/index.spec.js.snap
@@ -1221,7 +1221,6 @@ exports[`HomePage Renders correctly 1`] = `
   height: 100%;
 }
 
-<<<<<<< HEAD
 .emotion-26 .sui-results-per-page__label {
   margin-right: 8px;
 }
@@ -1444,24 +1443,6 @@ exports[`HomePage Renders correctly 1`] = `
   background-color: var(--tertiary-background-color);
   border: 1px solid #a6a6a6;
   border-radius: 4px;
-=======
-.dark-mode .emotion-33 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-33 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-33 {
-    display: none;
-  }
-}
-
-.emotion-32 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1645,11 +1626,7 @@ exports[`HomePage Renders correctly 1`] = `
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-63 {
-=======
-.emotion-31 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -1663,25 +1640,17 @@ exports[`HomePage Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-63 > li {
-=======
-.emotion-31 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-<<<<<<< HEAD
 .emotion-58 {
   color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-=======
-.emotion-29 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1692,15 +1661,11 @@ exports[`HomePage Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-58:hover {
   color: var(--secondary-text-hover-color);
 }
 
 .emotion-57 {
-=======
-.emotion-28 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1712,15 +1677,7 @@ exports[`HomePage Renders correctly 1`] = `
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-59 {
-=======
-.emotion-28:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-30 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1736,7 +1693,6 @@ exports[`HomePage Renders correctly 1`] = `
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
@@ -1793,13 +1749,6 @@ exports[`HomePage Renders correctly 1`] = `
 }
 
 .emotion-66 {
-=======
-.emotion-30:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-34 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1835,7 +1784,6 @@ exports[`HomePage Renders correctly 1`] = `
   transform: translate3d(0,-1px,0);
 }
 
-<<<<<<< HEAD
 .emotion-66:hover {
   color: var(--color-white);
   background-color: var(--color-brand-500);
@@ -1846,19 +1794,6 @@ exports[`HomePage Renders correctly 1`] = `
 }
 
 .emotion-66.emotion-66.emotion-66:after {
-=======
-.dark-mode .emotion-34 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-34 {
-  border-color: transparent;
-}
-
-.emotion-34.emotion-34.emotion-34:after {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: none;
 }
 
@@ -1866,19 +1801,11 @@ exports[`HomePage Renders correctly 1`] = `
   className="layout-container undefined"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -2085,7 +2012,6 @@ exports[`HomePage Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
       >
         <li>
@@ -2095,17 +2021,6 @@ exports[`HomePage Renders correctly 1`] = `
           >
             <svg
               className="emotion-57"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -2125,11 +2040,7 @@ exports[`HomePage Renders correctly 1`] = `
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-59"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2386,11 +2297,7 @@ exports[`HomePage Renders correctly 1`] = `
         onMouseOver={[Function]}
       >
         <a
-<<<<<<< HEAD
           className="ctaButton emotion-66 emotion-61"
-=======
-          className="ctaButton emotion-34 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           href="/instrumentation"
         >
           <span

--- a/src/pages/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/index.spec.js.snap
@@ -8,7 +8,7 @@ exports[`HomePage Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {

--- a/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OSS Category Page Renders correctly 1`] = `
-.emotion-32 {
+.emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -11,21 +11,21 @@ exports[`OSS Category Page Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39,28 +39,60 @@ exports[`OSS Category Page Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -80,7 +112,1472 @@ exports[`OSS Category Page Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -90,9 +1587,19 @@ exports[`OSS Category Page Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,17 +1616,17 @@ exports[`OSS Category Page Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -133,14 +1640,44 @@ exports[`OSS Category Page Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -149,35 +1686,69 @@ exports[`OSS Category Page Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-60 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
 }
 
-.emotion-33 {
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-66 {
   margin-bottom: 1rem;
 }
 
@@ -185,17 +1756,116 @@ exports[`OSS Category Page Renders correctly 1`] = `
   className="layout-container undefined"
 >
   <div
-    className=" emotion-32"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -252,11 +1922,11 @@ exports[`OSS Category Page Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -266,7 +1936,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -276,7 +1946,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -286,7 +1956,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -297,31 +1967,35 @@ exports[`OSS Category Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-63"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-58"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-57"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -330,6 +2004,22 @@ exports[`OSS Category Page Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>
@@ -438,7 +2128,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
             Categories
           </h4>
           <ul
-            className="categorySidebarList emotion-33"
+            className="categorySidebarList emotion-66"
           >
             <li
               className="categorySidebarItem"

--- a/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
@@ -1124,7 +1124,6 @@ exports[`OSS Category Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-26 .sui-result__title {
   font-size: inherit;
   font-weight: 400;
@@ -1444,24 +1443,6 @@ exports[`OSS Category Page Renders correctly 1`] = `
   background-color: var(--tertiary-background-color);
   border: 1px solid #a6a6a6;
   border-radius: 4px;
-=======
-.dark-mode .emotion-33 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-33 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-33 {
-    display: none;
-  }
-}
-
-.emotion-32 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1645,11 +1626,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-63 {
-=======
-.emotion-31 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -1663,25 +1640,17 @@ exports[`OSS Category Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-63 > li {
-=======
-.emotion-31 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-<<<<<<< HEAD
 .emotion-58 {
   color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-=======
-.emotion-29 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1692,15 +1661,11 @@ exports[`OSS Category Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-58:hover {
   color: var(--secondary-text-hover-color);
 }
 
 .emotion-57 {
-=======
-.emotion-28 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1712,11 +1677,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-59 {
-=======
-.emotion-30 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1732,7 +1693,6 @@ exports[`OSS Category Page Renders correctly 1`] = `
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
@@ -1789,13 +1749,6 @@ exports[`OSS Category Page Renders correctly 1`] = `
 }
 
 .emotion-66 {
-=======
-.emotion-30:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-34 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin-bottom: 1rem;
 }
 
@@ -1803,19 +1756,11 @@ exports[`OSS Category Page Renders correctly 1`] = `
   className="layout-container undefined"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -2022,7 +1967,6 @@ exports[`OSS Category Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
       >
         <li>
@@ -2032,17 +1976,6 @@ exports[`OSS Category Page Renders correctly 1`] = `
           >
             <svg
               className="emotion-57"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -2062,11 +1995,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-59"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2199,11 +2128,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
             Categories
           </h4>
           <ul
-<<<<<<< HEAD
             className="categorySidebarList emotion-66"
-=======
-            className="categorySidebarList emotion-34"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           >
             <li
               className="categorySidebarItem"

--- a/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
@@ -8,21 +8,20 @@ exports[`OSS Category Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {

--- a/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
@@ -8,7 +8,7 @@ exports[`OSS Category Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {

--- a/src/pages/collection.module.scss
+++ b/src/pages/collection.module.scss
@@ -1,6 +1,5 @@
 .collection-page {
   height: auto;
-  overflow: hidden;
   position: relative;
 }
 
@@ -28,7 +27,7 @@
     position: absolute;
     left: 0;
     content: "";
-    height: 10000px;
+    height: 100vh;
     background-color: var(--color-neutrals-100);
     width: 100%;
     transform: skewY(-2deg) translateY(-70px);

--- a/src/pages/collection.module.scss
+++ b/src/pages/collection.module.scss
@@ -104,7 +104,7 @@
       position: absolute;
       top: -1px;
       right: -9px;
-      z-index: 1000; 
+      z-index: 400; 
       background: linear-gradient(270deg, var(--color-neutrals-100) 34.6%, rgba(244, 245, 245, 0) 78.29%);
     }
   }

--- a/src/pages/home-page.module.scss
+++ b/src/pages/home-page.module.scss
@@ -136,7 +136,7 @@
     pointer-events: none;
     opacity: 0;
     border-radius: 4px;
-    z-index: 1;
+    z-index: 100;
     transition: opacity 1s var(--ease-out-quad);
     transition-delay: .5s;
     
@@ -171,7 +171,7 @@ img.play-button {
   transition: transform .4s var(--ease-out-quad), opacity .4s var(--ease-out-quad), box-shadow .35s var(--ease-out-quad);
   transition-delay: .025s;
   transform: scale(.9) translateZ(20px);
-  z-index: 10;
+  z-index: 200;
   user-select: none;
   
   .homepage-hero-video &:hover {
@@ -196,7 +196,7 @@ img.play-button {
   overflow:hidden;
 
   .hero-container {
-    z-index: 100000; 
+    z-index: 600; 
     transform: all .2s var(--ease-out-quad);
   }
 
@@ -232,7 +232,7 @@ img.play-button {
   }
 
   .video-modal-overlay {
-    z-index: 10000;
+    z-index: 500;
     opacity: .9;
     pointer-events: inherit;
   }
@@ -242,7 +242,7 @@ img.play-button {
     opacity: 1;
     overflow: visible;
     position: absolute;
-    z-index: 1000000;
+    z-index: 700;
     transform: scale(0.49) translate(-52%, -52%);
     pointer-events: all;
 

--- a/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
+++ b/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
@@ -139,13 +139,8 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   height: 1rem;
 }
 
-<<<<<<< HEAD
 .emotion-27 {
   max-width: 1236px;
-=======
-.emotion-31 {
-  margin: 0;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   padding: 0;
   margin: 0 auto;
 }
@@ -163,7 +158,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   height: calc(100vh - 6rem);
 }
 
-<<<<<<< HEAD
 .emotion-26 .rc-pagination {
   font-family: 'Arial';
   -webkit-user-select: none;
@@ -186,38 +180,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
 
 .emotion-26 .rc-pagination > li {
   list-style: none;
-=======
-.emotion-31 > li {
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  margin-left: 1rem;
-  color: var(--secondary-text-color);
-}
-
-.emotion-29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-28 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
 }
 
 .emotion-26 .rc-pagination-total-text {
@@ -229,7 +191,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   margin: 0 8px 0 0;
 }
 
-<<<<<<< HEAD
 .emotion-26 .rc-pagination:after {
   content: ' ';
   display: block;
@@ -240,16 +201,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
 }
 
 .emotion-26 .rc-pagination-item {
-=======
-.emotion-30 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   cursor: pointer;
   border-radius: 6px;
   min-width: 28px;
@@ -425,7 +376,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   text-align: center;
 }
 
-<<<<<<< HEAD
 .emotion-26 .rc-pagination-prev a:after {
   content: '\\2039';
   display: block;
@@ -522,35 +472,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   font-weight: 500;
   text-align: center;
   touch-action: manipulation;
-=======
-.emotion-30:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-39 {
-  margin-bottom: 1rem;
-}
-
-.emotion-34 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  border-radius: 3px;
-  font-family: var(--primary-font-family);
-  line-height: 1;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   cursor: pointer;
   background-image: none;
   border: 1px solid transparent;
@@ -574,7 +495,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   border-color: #d9d9d9;
 }
 
-<<<<<<< HEAD
 .emotion-26 .rc-pagination-options-quick-jumper button:hover,
 .emotion-26 .rc-pagination-options-quick-jumper button:active,
 .emotion-26 .rc-pagination-options-quick-jumper button:focus {
@@ -623,33 +543,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   font-weight: 500;
   text-align: center;
   touch-action: manipulation;
-=======
-.dark-mode .emotion-34 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
-}
-
-.emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  border-radius: 3px;
-  font-family: var(--primary-font-family);
-  line-height: 1;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   cursor: pointer;
   background-image: none;
   border: 1px solid transparent;
@@ -673,7 +566,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   border-color: #d9d9d9;
 }
 
-<<<<<<< HEAD
 .emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
 .emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
 .emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
@@ -691,18 +583,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
 
 .emotion-26 html {
   box-sizing: border-box;
-=======
-.dark-mode .emotion-37 {
-  color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-37 {
-  border-color: transparent;
-}
-
-.emotion-36 {
-  margin-right: 0.5rem;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
 }
 
 .emotion-26 *,
@@ -1958,19 +1838,11 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   className="layout-container projectPageLayout"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -2177,7 +2049,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
       >
         <li>
@@ -2187,17 +2058,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           >
             <svg
               className="emotion-57"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -2217,11 +2077,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-59"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -2386,21 +2242,13 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           className="callToActionContainer"
         >
           <div
-<<<<<<< HEAD
             className="callToActionButtons emotion-71"
-=======
-            className="callToActionButtons emotion-39"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           >
             <div
               className="callToActionButtonsContainer"
             >
               <a
-<<<<<<< HEAD
                 className="emotion-66 emotion-61"
-=======
-                className="emotion-34 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
                 target="__blank"
@@ -2408,21 +2256,13 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
                 View Website
               </a>
               <a
-<<<<<<< HEAD
                 className="emotion-69 emotion-61"
-=======
-                className="emotion-37 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
               >
                 <img
                   alt="GitHub logo"
-<<<<<<< HEAD
                   className="emotion-68"
-=======
-                  className="emotion-36"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                   src="test-file-stub"
                 />
                 GitHub
@@ -2546,7 +2386,6 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
 `;
 
 exports[`Open Telemetry Page Renders correctly 1`] = `
-<<<<<<< HEAD
 .emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
@@ -3626,10 +3465,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   border-radius: 4px;
   box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
   overflow-wrap: break-word;
-=======
-.emotion-33 {
-  background-color: var(--color-neutrals-100);
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   overflow: hidden;
 }
 
@@ -4028,7 +3863,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   transform: none;
 }
 
-<<<<<<< HEAD
 .emotion-26 .sui-select__dropdown-indicator {
   display: -webkit-box;
   display: -webkit-flex;
@@ -4056,24 +3890,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
 }
 
 .emotion-26 .sui-select__option {
-=======
-.dark-mode .emotion-33 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-33 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-33 {
-    display: none;
-  }
-}
-
-.emotion-32 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4195,11 +4011,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-63 {
-=======
-.emotion-31 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -4213,25 +4025,17 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-63 > li {
-=======
-.emotion-31 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-<<<<<<< HEAD
 .emotion-58 {
   color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-=======
-.emotion-29 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4242,15 +4046,11 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-58:hover {
   color: var(--secondary-text-hover-color);
 }
 
 .emotion-57 {
-=======
-.emotion-28 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -4262,11 +4062,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-59 {
-=======
-.emotion-30 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -4282,7 +4078,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
@@ -4343,17 +4138,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
 }
 
 .emotion-66 {
-=======
-.emotion-30:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-39 {
-  margin-bottom: 1rem;
-}
-
-.emotion-34 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4389,22 +4173,12 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   transform: translate3d(0,-1px,0);
 }
 
-<<<<<<< HEAD
 .emotion-66:hover {
   color: var(--color-white);
   background-color: var(--color-brand-500);
 }
 
 .emotion-69 {
-=======
-.dark-mode .emotion-34 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
-}
-
-.emotion-37 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4431,7 +4205,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   white-space: nowrap;
 }
 
-<<<<<<< HEAD
 .emotion-69:hover {
   -webkit-transform: translate3d(0,-1px,0);
   -ms-transform: translate3d(0,-1px,0);
@@ -4443,17 +4216,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
 }
 
 .emotion-68 {
-=======
-.dark-mode .emotion-37 {
-  color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-37 {
-  border-color: transparent;
-}
-
-.emotion-36 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin-right: 0.5rem;
 }
 
@@ -4461,19 +4223,11 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   className="layout-container projectPageLayout"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
       className="emotion-64"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-28"
@@ -4680,7 +4434,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-63"
       >
         <li>
@@ -4690,17 +4443,6 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           >
             <svg
               className="emotion-57"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -4720,11 +4462,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-59"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -4889,21 +4627,13 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           className="callToActionContainer"
         >
           <div
-<<<<<<< HEAD
             className="callToActionButtons emotion-71"
-=======
-            className="callToActionButtons emotion-39"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           >
             <div
               className="callToActionButtonsContainer"
             >
               <a
-<<<<<<< HEAD
                 className="emotion-66 emotion-61"
-=======
-                className="emotion-34 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
                 target="__blank"
@@ -4911,21 +4641,13 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
                 View Website
               </a>
               <a
-<<<<<<< HEAD
                 className="emotion-69 emotion-61"
-=======
-                className="emotion-37 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
               >
                 <img
                   alt="GitHub logo"
-<<<<<<< HEAD
                   className="emotion-68"
-=======
-                  className="emotion-36"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                   src="test-file-stub"
                 />
                 GitHub
@@ -5049,18 +4771,13 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
 `;
 
 exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
-<<<<<<< HEAD
 .emotion-72 {
-=======
-.emotion-33 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
   position: sticky;
   top: 0;
   z-index: 80;
-<<<<<<< HEAD
   z-index: 1000000;
 }
 
@@ -6496,27 +6213,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   background-color: var(--tertiary-background-color);
   border: 1px solid #a6a6a6;
   border-radius: 4px;
-=======
-  position: static;
-}
-
-.dark-mode .emotion-33 {
-  background-color: var(--color-dark-100);
-}
-
-.emotion-33 a {
-  border-bottom: none;
-}
-
-@media screen and (max-width:480px) {
-  .emotion-33 {
-    display: none;
-  }
-}
-
-.emotion-32 {
-  height: 30px;
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6700,11 +6396,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   color: var(--color-dark-700);
 }
 
-<<<<<<< HEAD
 .emotion-70 {
-=======
-.emotion-31 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -6718,25 +6410,17 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-70 > li {
-=======
-.emotion-31 > li {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-<<<<<<< HEAD
 .emotion-65 {
   color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-=======
-.emotion-29 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6747,15 +6431,11 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   align-items: center;
 }
 
-<<<<<<< HEAD
 .emotion-65:hover {
   color: var(--secondary-text-hover-color);
 }
 
 .emotion-64 {
-=======
-.emotion-28 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -6767,15 +6447,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   cursor: pointer;
 }
 
-<<<<<<< HEAD
 .emotion-66 {
-=======
-.emotion-28:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-30 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -6791,7 +6463,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   transition: all 0.2s ease-out;
 }
 
-<<<<<<< HEAD
 .emotion-66:hover {
   color: var(--secondary-text-hover-color);
 }
@@ -6852,17 +6523,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
 }
 
 .emotion-73 {
-=======
-.emotion-30:hover {
-  color: var(--secondary-text-hover-color);
-}
-
-.emotion-39 {
-  margin-bottom: 1rem;
-}
-
-.emotion-34 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6898,22 +6558,12 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   transform: translate3d(0,-1px,0);
 }
 
-<<<<<<< HEAD
 .emotion-73:hover {
   color: var(--color-white);
   background-color: var(--color-brand-500);
 }
 
 .emotion-76 {
-=======
-.dark-mode .emotion-34 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
-}
-
-.emotion-37 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6940,7 +6590,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   white-space: nowrap;
 }
 
-<<<<<<< HEAD
 .emotion-76:hover {
   -webkit-transform: translate3d(0,-1px,0);
   -ms-transform: translate3d(0,-1px,0);
@@ -7002,21 +6651,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
 }
 
 .emotion-81 {
-=======
-.dark-mode .emotion-37 {
-  color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-37 {
-  border-color: transparent;
-}
-
-.emotion-36 {
-  margin-right: 0.5rem;
-}
-
-.emotion-42 {
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7046,7 +6680,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   background-color: var(--color-neutrals-100);
 }
 
-<<<<<<< HEAD
 .emotion-81:hover {
   -webkit-transform: translate3d(0,-1px,0);
   -ms-transform: translate3d(0,-1px,0);
@@ -7066,31 +6699,17 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
 .dark-mode .emotion-81:hover {
   color: var(--color-brand-200);
   background-color: rgba(112,204,210,0.17);
-=======
-.dark-mode .emotion-42 {
-  color: var(--color-white);
-  border-color: var(--color-dark-100);
-  background-color: var(--color-dark-100);
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
 }
 
 <div
   className="layout-container projectPageLayout"
 >
   <div
-<<<<<<< HEAD
     className=" emotion-72"
     data-swiftype-index={false}
   >
     <div
       className="emotion-71"
-=======
-    className=" emotion-33"
-    data-swiftype-index={false}
-  >
-    <div
-      className="emotion-32"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
     >
       <div
         className="emotion-35"
@@ -7355,7 +6974,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-<<<<<<< HEAD
         className="emotion-70"
       >
         <li>
@@ -7365,17 +6983,6 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           >
             <svg
               className="emotion-64"
-=======
-        className="emotion-31"
-      >
-        <li>
-          <a
-            className="emotion-29"
-            href="?q="
-          >
-            <svg
-              className="emotion-28"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -7395,11 +7002,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
         </li>
         <li>
           <svg
-<<<<<<< HEAD
             className="emotion-66"
-=======
-            className="emotion-30"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -7609,21 +7212,13 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           className="callToActionContainer"
         >
           <div
-<<<<<<< HEAD
             className="callToActionButtons emotion-78"
-=======
-            className="callToActionButtons emotion-39"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           >
             <div
               className="callToActionButtonsContainer"
             >
               <a
-<<<<<<< HEAD
                 className="emotion-73 emotion-68"
-=======
-                className="emotion-34 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
                 target="__blank"
@@ -7631,21 +7226,13 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
                 View Website
               </a>
               <a
-<<<<<<< HEAD
                 className="emotion-76 emotion-68"
-=======
-                className="emotion-37 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
               >
                 <img
                   alt="GitHub logo"
-<<<<<<< HEAD
                   className="emotion-75"
-=======
-                  className="emotion-36"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
                   src="test-file-stub"
                 />
                 GitHub
@@ -7964,22 +7551,14 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
         className="ctaContainer"
       >
         <button
-<<<<<<< HEAD
           className="approvalButton emotion-73 emotion-68"
-=======
-          className="approvalButton emotion-34 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           onClick={[Function]}
           type="button"
         >
           Yes
         </button>
         <button
-<<<<<<< HEAD
           className="ignoreButton emotion-81 emotion-68"
-=======
-          className="ignoreButton emotion-42 emotion-35"
->>>>>>> b61bcd7f034ce46a961d06edd8828a5c1905eab7
           onClick={[Function]}
           type="button"
         >

--- a/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
+++ b/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
@@ -8,21 +8,20 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {
@@ -694,21 +693,20 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {
@@ -1380,21 +1378,20 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  position: static;
+  z-index: 1000000;
 }
 
 .dark-mode .emotion-32 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 a {
-  border-bottom: none;
+.emotion-32 ul {
+  line-height: 14px;
+  font-size: 16px;
 }
 
-@media screen and (max-width:480px) {
-  .emotion-32 {
-    display: none;
-  }
+.emotion-32 a {
+  border-bottom: none;
 }
 
 .emotion-31 {

--- a/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
+++ b/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Adopt OpenJDK Renders correctly 1`] = `
-.emotion-32 {
+.emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -11,21 +11,21 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -39,28 +39,60 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -80,7 +112,1472 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -90,9 +1587,19 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,17 +1616,17 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -133,14 +1640,44 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -149,39 +1686,73 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-60 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
 }
 
-.emotion-38 {
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-71 {
   margin-bottom: 1rem;
 }
 
-.emotion-33 {
+.emotion-66 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -203,18 +1774,26 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
   color: var(--color-white);
-  border-color: var(--color-brand-800);
-  background-color: var(--color-brand-800);
+  background-color: var(--color-brand-600);
 }
 
-.dark-mode .emotion-33 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
+.emotion-66:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
 }
 
-.emotion-36 {
+.emotion-66:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-69 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -236,20 +1815,22 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  color: var(--color-brand-800);
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+}
+
+.emotion-69:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.dark-mode .emotion-69 {
   border-color: transparent;
-  background-color: transparent;
 }
 
-.dark-mode .emotion-36 {
-  color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-36 {
-  border-color: transparent;
-}
-
-.emotion-35 {
+.emotion-68 {
   margin-right: 0.5rem;
 }
 
@@ -257,17 +1838,116 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   className="layout-container projectPageLayout"
 >
   <div
-    className=" emotion-32"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -324,11 +2004,11 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -338,7 +2018,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -348,7 +2028,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -358,7 +2038,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -369,31 +2049,35 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-63"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-58"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-57"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -402,6 +2086,22 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>
@@ -542,13 +2242,13 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
           className="callToActionContainer"
         >
           <div
-            className="callToActionButtons emotion-38"
+            className="callToActionButtons emotion-71"
           >
             <div
               className="callToActionButtonsContainer"
             >
               <a
-                className="emotion-33 emotion-34"
+                className="emotion-66 emotion-61"
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
                 target="__blank"
@@ -556,13 +2256,13 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
                 View Website
               </a>
               <a
-                className="emotion-36 emotion-34"
+                className="emotion-69 emotion-61"
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
               >
                 <img
                   alt="GitHub logo"
-                  className="emotion-35"
+                  className="emotion-68"
                   src="test-file-stub"
                 />
                 GitHub
@@ -686,7 +2386,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
 `;
 
 exports[`Open Telemetry Page Renders correctly 1`] = `
-.emotion-32 {
+.emotion-65 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -696,21 +2396,21 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-65 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-65 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-65 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-64 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -724,28 +2424,60 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-28 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -765,7 +2497,1472 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-27 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
 .emotion-26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-26 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-26 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-26 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-26 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-26 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-26 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .rc-pagination-jump-prev:after,
+.emotion-26 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after,
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-26 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-26 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon,
+.emotion-26 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-26 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-26 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next,
+.emotion-26 .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-26 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-26 .rc-pagination-prev,
+.emotion-26 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-prev a,
+.emotion-26 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-26 .rc-pagination-prev a:after,
+.emotion-26 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-26 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-26 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-26 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-26 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-26 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-options-quick-jumper button:hover,
+.emotion-26 .rc-pagination-options-quick-jumper button:active,
+.emotion-26 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-prev,
+.emotion-26 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-26 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-26 .rc-pagination-item-after-jump-prev,
+  .emotion-26 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-26 html {
+  box-sizing: border-box;
+}
+
+.emotion-26 *,
+.emotion-26 *:before,
+.emotion-26 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-26 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-26 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-26 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-26 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-26 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-26 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-26 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-26 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-26 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-26 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-26 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-26 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-26 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-26 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-26 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-26 .sui-facet-view-more:hover,
+.emotion-26 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-26 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-26 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-26 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-26 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-26 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-26 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-26 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-26 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-26 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-26 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-26 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-26 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-26 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-26 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-26 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-26 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-26 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-26 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-26 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-26 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-26 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-26 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-26 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-26 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-26 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-26 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-26 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-26 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-26 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-26 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-26 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-26 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-26 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-26 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-26 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-26 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-26 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-26 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-26 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-26 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-26 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-26 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-26 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-26 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-26 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-26 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-26 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-26 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-26 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-26 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-26 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-26 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-26 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-26 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-56 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-56::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-56::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-55 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -775,9 +3972,19 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-55 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -794,17 +4001,17 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-51:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-51:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-63 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -818,14 +4025,44 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-63 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-58 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-58:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-57 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-59 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -834,39 +4071,73 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-59:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-60 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
 }
 
-.emotion-38 {
+.emotion-60:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-60:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-71 {
   margin-bottom: 1rem;
 }
 
-.emotion-33 {
+.emotion-66 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -888,18 +4159,26 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
   color: var(--color-white);
-  border-color: var(--color-brand-800);
-  background-color: var(--color-brand-800);
+  background-color: var(--color-brand-600);
 }
 
-.dark-mode .emotion-33 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
+.emotion-66:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
 }
 
-.emotion-36 {
+.emotion-66:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-69 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -921,20 +4200,22 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  color: var(--color-brand-800);
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+}
+
+.emotion-69:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.dark-mode .emotion-69 {
   border-color: transparent;
-  background-color: transparent;
 }
 
-.dark-mode .emotion-36 {
-  color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-36 {
-  border-color: transparent;
-}
-
-.emotion-35 {
+.emotion-68 {
   margin-right: 0.5rem;
 }
 
@@ -942,17 +4223,116 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   className="layout-container projectPageLayout"
 >
   <div
-    className=" emotion-32"
+    className=" emotion-65"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-64"
     >
+      <div
+        className="emotion-28"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-27"
+        >
+          <div
+            className="emotion-26"
+          />
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-56"
       >
         <a
-          className="emotion-21"
+          className="emotion-50"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -1009,11 +4389,11 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-55"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1023,7 +4403,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1033,7 +4413,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1043,7 +4423,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-51"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1054,31 +4434,35 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-63"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-58"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-57"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-59"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1087,6 +4471,22 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-62"
+        >
+          <a
+            className="emotion-60 emotion-61"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>
@@ -1227,13 +4627,13 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
           className="callToActionContainer"
         >
           <div
-            className="callToActionButtons emotion-38"
+            className="callToActionButtons emotion-71"
           >
             <div
               className="callToActionButtonsContainer"
             >
               <a
-                className="emotion-33 emotion-34"
+                className="emotion-66 emotion-61"
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
                 target="__blank"
@@ -1241,13 +4641,13 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
                 View Website
               </a>
               <a
-                className="emotion-36 emotion-34"
+                className="emotion-69 emotion-61"
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
               >
                 <img
                   alt="GitHub logo"
-                  className="emotion-35"
+                  className="emotion-68"
                   src="test-file-stub"
                 />
                 GitHub
@@ -1371,7 +4771,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
 `;
 
 exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
-.emotion-32 {
+.emotion-72 {
   background-color: var(--color-neutrals-100);
   overflow: hidden;
   position: -webkit-sticky;
@@ -1381,21 +4781,21 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   z-index: 1000000;
 }
 
-.dark-mode .emotion-32 {
+.dark-mode .emotion-72 {
   background-color: var(--color-dark-100);
 }
 
-.emotion-32 ul {
+.emotion-72 ul {
   line-height: 14px;
   font-size: 16px;
 }
 
-.emotion-32 a {
+.emotion-72 a {
   border-bottom: none;
 }
 
-.emotion-31 {
-  height: 30px;
+.emotion-71 {
+  height: 36px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1409,28 +4809,60 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   padding: 0;
 }
 
-.emotion-27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  height: 100%;
+.emotion-35 {
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  background-color: var(--primary-background-color);
+  opacity: 0;
+  -webkit-transform: scale(1.04);
+  -ms-transform: scale(1.04);
+  transform: scale(1.04);
+  -webkit-transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  transition: 0.5s cubic-bezier(0.215,0.61,0.355,1);
+  visibility: hidden;
 }
 
-.emotion-21 {
+.emotion-25 {
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  outline: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  -webkit-transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  transition: 0.3s cubic-bezier(0.075,0.82,0.165,1);
+  padding: 0.25rem 0;
+  height: 30px;
+}
+
+.emotion-25:hover {
+  background-color: var(--secondary-background-color);
+  color: var(--tertiary-text-color);
+}
+
+.emotion-24 {
+  max-width: 1236px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-right: 1rem;
+  margin: 0 auto;
+  padding: 0;
+  height: 100%;
 }
 
 .emotion-20 {
@@ -1450,7 +4882,1472 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   fill: #70ccd3;
 }
 
-.emotion-26 {
+.emotion-23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.emotion-21 {
+  margin-right: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.emotion-22 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1rem;
+  height: 1rem;
+}
+
+.emotion-34 {
+  max-width: 1236px;
+  padding: 0;
+  margin: 0 auto;
+}
+
+.emotion-33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 950px;
+  margin: 3rem auto;
+  height: calc(100vh - 6rem);
+}
+
+.emotion-33 .rc-pagination {
+  font-family: 'Arial';
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 1rem;
+  font-size: 1rem;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  margin-top: 1rem;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.emotion-33 .rc-pagination > li {
+  list-style: none;
+}
+
+.emotion-33 .rc-pagination-total-text {
+  float: left;
+  height: 30px;
+  line-height: 30px;
+  list-style: none;
+  padding: 0;
+  margin: 0 8px 0 0;
+}
+
+.emotion-33 .rc-pagination:after {
+  content: ' ';
+  display: block;
+  height: 0;
+  clear: both;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.emotion-33 .rc-pagination-item {
+  cursor: pointer;
+  border-radius: 6px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  text-align: center;
+  list-style: none;
+  float: left;
+  border: 1px solid #d9d9d9;
+  background-color: #fff;
+  margin: 0rem 1rem;
+}
+
+.emotion-33 .rc-pagination-item a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--link-color);
+}
+
+.emotion-33 .rc-pagination-item:hover {
+  border-color: #2db7f5;
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .rc-pagination-item:hover a {
+  color: var(--link-color);
+}
+
+.emotion-33 .rc-pagination-item-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-33 .rc-pagination-item-disabled:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-33 .rc-pagination-item-disabled:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-33 .rc-pagination-item-active {
+  background-color: #2db7f5;
+  border-color: #2db7f5;
+}
+
+.emotion-33 .rc-pagination-item-active a {
+  color: #fff;
+}
+
+.emotion-33 .rc-pagination-item-active:hover a {
+  color: #fff;
+}
+
+.emotion-33 .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-33 .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .rc-pagination-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .rc-pagination-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-33 .rc-pagination-jump-prev:after,
+.emotion-33 .rc-pagination-jump-next:after {
+  content: '\\2022\\2022\\2022';
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-33 .rc-pagination-jump-prev:hover:after,
+.emotion-33 .rc-pagination-jump-next:hover:after {
+  color: var(--link-color) !important;
+}
+
+.emotion-33 .rc-pagination-jump-prev:hover:after {
+  content: '\\AB';
+}
+
+.emotion-33 .rc-pagination-jump-next:hover:after {
+  content: '\\BB';
+}
+
+.emotion-33 .rc-pagination-jump-prev-custom-icon,
+.emotion-33 .rc-pagination-jump-next-custom-icon {
+  position: relative;
+}
+
+.emotion-33 .rc-pagination-jump-prev-custom-icon:after,
+.emotion-33 .rc-pagination-jump-next-custom-icon:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+  content: '\\2022\\2022\\2022';
+  opacity: 1;
+  display: block;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  color: #ccc;
+  font-size: 12px;
+  margin-top: 1px;
+}
+
+.emotion-33 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-prev,
+.emotion-33 .rc-pagination-jump-next-custom-icon .custom-icon-jump-prev,
+.emotion-33 .rc-pagination-jump-prev-custom-icon .custom-icon-jump-next,
+.emotion-33 .rc-pagination-jump-next-custom-icon .custom-icon-jump-next {
+  opacity: 0;
+  -webkit-transition: all 0.2s;
+  transition: all 0.2s;
+}
+
+.emotion-33 .rc-pagination-jump-prev-custom-icon:hover:after,
+.emotion-33 .rc-pagination-jump-next-custom-icon:hover:after {
+  opacity: 0;
+  color: #ccc;
+}
+
+.emotion-33 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-prev,
+.emotion-33 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-prev,
+.emotion-33 .rc-pagination-jump-prev-custom-icon:hover .custom-icon-jump-next,
+.emotion-33 .rc-pagination-jump-next-custom-icon:hover .custom-icon-jump-next {
+  opacity: 1;
+  color: #2db7f5;
+}
+
+.emotion-33 .rc-pagination-prev,
+.emotion-33 .rc-pagination-jump-prev,
+.emotion-33 .rc-pagination-jump-next {
+  margin-right: 8px;
+}
+
+.emotion-33 .rc-pagination-prev,
+.emotion-33 .rc-pagination-next,
+.emotion-33 .rc-pagination-jump-prev,
+.emotion-33 .rc-pagination-jump-next {
+  cursor: pointer;
+  color: #666;
+  font-size: 10px;
+  border-radius: 6px;
+  list-style: none;
+  min-width: 28px;
+  height: 28px;
+  line-height: 28px;
+  float: left;
+  text-align: center;
+}
+
+.emotion-33 .rc-pagination-prev a:after {
+  content: '\\2039';
+  display: block;
+}
+
+.emotion-33 .rc-pagination-next a:after {
+  content: '\\203A';
+  display: block;
+}
+
+.emotion-33 .rc-pagination-prev,
+.emotion-33 .rc-pagination-next {
+  border: 1px solid #d9d9d9;
+  font-size: 18px;
+}
+
+.emotion-33 .rc-pagination-prev a,
+.emotion-33 .rc-pagination-next a {
+  color: #666;
+}
+
+.emotion-33 .rc-pagination-prev a:after,
+.emotion-33 .rc-pagination-next a:after {
+  margin-top: -1px;
+}
+
+.emotion-33 .rc-pagination-disabled {
+  cursor: not-allowed;
+}
+
+.emotion-33 .rc-pagination-disabled a {
+  color: #ccc;
+}
+
+.emotion-33 .rc-pagination-disabled .rc-pagination-item,
+.emotion-33 .rc-pagination-disabled .rc-pagination-prev,
+.emotion-33 .rc-pagination-disabled .rc-pagination-next {
+  cursor: not-allowed;
+}
+
+.emotion-33 .rc-pagination-disabled .rc-pagination-item:hover,
+.emotion-33 .rc-pagination-disabled .rc-pagination-prev:hover,
+.emotion-33 .rc-pagination-disabled .rc-pagination-next:hover {
+  border-color: #d9d9d9;
+}
+
+.emotion-33 .rc-pagination-disabled .rc-pagination-item:hover a,
+.emotion-33 .rc-pagination-disabled .rc-pagination-prev:hover a,
+.emotion-33 .rc-pagination-disabled .rc-pagination-next:hover a {
+  color: #d9d9d9;
+}
+
+.emotion-33 .rc-pagination-disabled .rc-pagination-jump-prev,
+.emotion-33 .rc-pagination-disabled .rc-pagination-jump-next {
+  pointer-events: none;
+}
+
+.emotion-33 .rc-pagination-options {
+  float: left;
+  margin-left: 15px;
+}
+
+.emotion-33 .rc-pagination-options-size-changer {
+  float: left;
+  width: 80px;
+}
+
+.emotion-33 .rc-pagination-options-quick-jumper {
+  float: left;
+  margin-left: 16px;
+  height: 28px;
+  line-height: 28px;
+}
+
+.emotion-33 .rc-pagination-options-quick-jumper input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 3px 12px;
+  width: 50px;
+  height: 28px;
+}
+
+.emotion-33 .rc-pagination-options-quick-jumper input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-33 .rc-pagination-options-quick-jumper button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 15px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 28px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-33 .rc-pagination-options-quick-jumper button:hover,
+.emotion-33 .rc-pagination-options-quick-jumper button:active,
+.emotion-33 .rc-pagination-options-quick-jumper button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-prev,
+.emotion-33 .rc-pagination-simple .rc-pagination-next {
+  border: none;
+  height: 24px;
+  line-height: 24px;
+  margin: 0;
+  font-size: 18px;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager {
+  float: left;
+  margin-right: 8px;
+  list-style: none;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager .rc-pagination-slash {
+  margin: 0 10px;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager input {
+  margin: 0 8px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-radius: 6px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  padding: 5px 8px;
+  min-height: 20px;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager input:hover {
+  border-color: #2db7f5;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager button {
+  display: inline-block;
+  margin: 0 8px;
+  font-weight: 500;
+  text-align: center;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 0 8px;
+  font-size: 12px;
+  border-radius: 6px;
+  height: 26px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  transition: all 0.3s cubic-bezier(0.645,0.045,0.355,1);
+  position: relative;
+  color: rgba(0,0,0,0.65);
+  background-color: #fff;
+  border-color: #d9d9d9;
+}
+
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager button:hover,
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager button:active,
+.emotion-33 .rc-pagination-simple .rc-pagination-simple-pager button:focus {
+  color: #2db7f5;
+  background-color: #fff;
+  border-color: #2db7f5;
+}
+
+@media only screen and (max-width:1024px) {
+  .emotion-33 .rc-pagination-item-after-jump-prev,
+  .emotion-33 .rc-pagination-item-before-jump-next {
+    display: none;
+  }
+}
+
+.emotion-33 html {
+  box-sizing: border-box;
+}
+
+.emotion-33 *,
+.emotion-33 *:before,
+.emotion-33 *:after {
+  box-sizing: inherit;
+}
+
+.emotion-33 .sui-layout {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-33 .sui-layout-header {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.emotion-33 .sui-layout-body {
+  background: #fcfcfc;
+}
+
+.emotion-33 .sui-layout-body:after {
+  content: '';
+  height: 80px;
+  width: 100%;
+  display: block;
+  position: relative;
+  background: linear-gradient(to bottom,#fcfcfc 0%,#ffffff 100%);
+  -webkit-filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc',endColorstr='#ffffff',GradientType=0 );
+}
+
+@media (max-width:800px) {
+  .emotion-33 .sui-layout-body:after {
+    display: none;
+  }
+}
+
+.emotion-33 .sui-layout-body__inner {
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 24px;
+}
+
+@media (max-width:800px) {
+  .emotion-33 .sui-layout-body__inner {
+    display: block;
+    padding: 0 15px;
+  }
+}
+
+.emotion-33 .sui-layout-main {
+  width: 76%;
+  padding: 32px 0 32px 32px;
+}
+
+@media (max-width:800px) {
+  .emotion-33 .sui-layout-main {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+.emotion-33 .sui-layout-main-header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-33 .sui-layout-main-header__inner {
+  font-size: 12px;
+  color: #4a4b4b;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.emotion-33 .sui-layout-main-footer {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.emotion-33 .sui-search-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: red;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-33 .sui-search-error.no-error {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: calc(100vh - 180px);
+}
+
+.emotion-33 .sui-facet {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.emotion-33 .sui-facet + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-33 .sui-sorting + .sui-facet {
+  margin-top: 32px;
+}
+
+.emotion-33 .sui-facet__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #8b9bad;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  padding: 0;
+}
+
+.emotion-33 .sui-facet__list {
+  line-height: 1.5;
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.emotion-33 .sui-facet__count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 20px;
+  display: inline-block;
+  padding-top: 2px;
+}
+
+.emotion-33 .sui-multi-checkbox-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-33 .sui-multi-checkbox-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-33 .sui-multi-checkbox-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-33 .sui-multi-checkbox-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-33 .sui-multi-checkbox-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-33 .sui-facet-view-more {
+  display: block;
+  cursor: pointer;
+  color: var(--link-color);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+  border: unset;
+  padding: unset;
+  background: unset;
+}
+
+.emotion-33 .sui-facet-view-more:hover,
+.emotion-33 .sui-facet-view-more:focus {
+  background-color: var(--tertiary-background-color);
+  outline: 4px solid var(--tertiary-background-color);
+}
+
+.emotion-33 .sui-facet-search {
+  margin: 6px 0px 0px 0px;
+}
+
+.emotion-33 .sui-facet-search__text-input {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+  margin: 0;
+  font-family: inherit;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  outline: none;
+}
+
+.emotion-33 .sui-facet-search__text-input:focus {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-33 .sui-boolean-facet {
+  color: var(--link-color);
+  font-size: 13px;
+  margin: 8px 0;
+}
+
+.emotion-33 .sui-boolean-facet__option-label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.emotion-33 .sui-boolean-facet__option-input-wrapper {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-33 .sui-boolean-facet__checkbox {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.emotion-33 .sui-boolean-facet__option-count {
+  color: #888888;
+  font-size: 0.85em;
+  margin-left: 24px;
+}
+
+.emotion-33 .sui-single-option-facet {
+  font-size: 13px;
+  margin: 8px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emotion-33 .sui-single-option-facet__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-33 .sui-single-option-facet__link {
+  color: var(--link-color);
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  list-style: none;
+  padding: 0;
+  font-weight: bold;
+}
+
+.emotion-33 .sui-single-option-facet__link:after {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  top: -1px;
+  left: -5px;
+  width: calc(100% + 10px);
+  height: calc(100% + 2px);
+  background: rgba(37,139,248,0.08);
+  pointer-events: none;
+}
+
+.emotion-33 .sui-single-option-facet__link:focus {
+  color: var(--link-color);
+  font-weight: bold;
+  outline: none;
+}
+
+.emotion-33 .sui-single-option-facet__link:hover {
+  color: var(--link-color);
+  font-weight: bold;
+}
+
+.emotion-33 .sui-single-option-facet__link:hover:after {
+  opacity: 1;
+}
+
+.emotion-33 .sui-single-option-facet__selected {
+  font-weight: 900;
+  list-style: none;
+}
+
+.emotion-33 .sui-single-option-facet__selected a {
+  font-weight: 100;
+  padding: 0 2px;
+}
+
+.emotion-33 .sui-single-option-facet__remove {
+  color: #666;
+  margin-left: 10px;
+}
+
+.emotion-33 .sui-paging > li {
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.emotion-33 .sui-paging .rc-pagination-disabled a {
+  color: #ccc;
+  opacity: 0.5;
+}
+
+.emotion-33 .sui-paging .rc-pagination-item a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-33 .sui-paging .rc-pagination-item:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-item:hover a {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-33 .sui-paging .rc-pagination-item-active a {
+  color: var(--link-color);
+  font-weight: 700;
+}
+
+.emotion-33 .sui-paging .rc-pagination-item-active:hover {
+  background: transparent;
+  cursor: not-allowed;
+}
+
+.emotion-33 .sui-paging .rc-pagination-item-active:hover a {
+  color: var(--link-color);
+  cursor: not-allowed;
+}
+
+.emotion-33 .sui-paging .rc-pagination-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-jump-next:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-jump-next:hover a {
+  color: var(--link-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-jump-next:hover:after {
+  color: var(--link-color);
+  content: '\\BB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-33 .sui-paging .rc-pagination-jump-prev:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-jump-prev:hover a {
+  color: var(--link-color);
+}
+
+.emotion-33 .sui-paging .rc-pagination-jump-prev:hover:after {
+  color: var(--link-color);
+  content: '\\AB';
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.emotion-33 .sui-paging-info {
+  margin: 1rem 0;
+  color: var(--primary-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 12px;
+  display: inline-block;
+}
+
+.emotion-33 .sui-result {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style: none;
+  padding: 24px 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: block;
+  background: transparent;
+  border-radius: 4px;
+  box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
+}
+
+.emotion-33 .sui-result a {
+  color: var(--link-color);
+}
+
+.emotion-33 .sui-result + .sui-result {
+  margin-top: 0;
+}
+
+.emotion-33 .sui-result em {
+  position: relative;
+  color: var(--link-color);
+  font-weight: 700;
+  font-style: inherit;
+}
+
+.emotion-33 .sui-result em:after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: calc(100% + 6px);
+  height: calc(100% + 6px);
+  background: rgba(0,126,138,0.2);
+  pointer-events: none;
+}
+
+.emotion-33 .sui-result__header {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-33 .sui-result__title {
+  font-size: inherit;
+  font-weight: 400;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-33 .sui-result__title-link {
+  color: var(--link-color);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-33 .sui-result__key {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 14px;
+  -webkit-flex: 0 1 50%;
+  -ms-flex: 0 1 50%;
+  flex: 0 1 50%;
+  color: #777777;
+}
+
+.emotion-33 .sui-result__key:before {
+  content: '';
+}
+
+.emotion-33 .sui-result__key:after {
+  content: '": ';
+}
+
+.emotion-33 .sui-result__value {
+  font-weight: 400;
+  font-size: 14px;
+}
+
+.emotion-33 .sui-result__version {
+  font-size: 12px;
+  display: inline;
+  vertical-align: bottom;
+}
+
+.emotion-33 .sui-result__license {
+  font-size: 12px;
+  color: #999999;
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 4px 4px 3px 4px;
+}
+
+.emotion-33 .sui-result__body {
+  line-height: 1.5;
+  margin-top: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-33 .sui-result__body p {
+  margin: 0;
+}
+
+.emotion-33 .sui-result__details {
+  list-style: none;
+  padding: 12px 24px;
+  padding-left: 0;
+}
+
+.emotion-33 .sui-results-container {
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-33 .sui-results-per-page {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #4a4b4b;
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+}
+
+.emotion-33 .sui-results-per-page__label {
+  margin-right: 8px;
+}
+
+.emotion-33 .sui-results-per-page .sui-select__control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-33 .sui-results-per-page .sui-select__control input {
+  position: absolute;
+}
+
+.emotion-33 .sui-search-box {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+}
+
+.emotion-33 .sui-search-box__submit {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 16px;
+  margin-left: 10px;
+  text-shadow: rgba(0,0,0,0.05) 0px 1px 2px;
+  color: white;
+  border: none;
+  box-shadow: rgba(0,0,0,0.05) 0px 0px 0px 1px inset,rgba(59,69,79,0.05) 0px 1px 0px;
+  background: linear-gradient(#2da0fa,#3158ee) #2f7cf4;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.emotion-33 .sui-search-box__submit:hover {
+  box-shadow: rgba(0,0,0,0.3) 0px 0px 0px 1px inset,rgba(59,69,79,0.3) 0px 2px 4px;
+  background: linear-gradient(#3cabff,#4063f0) #3d84f7;
+}
+
+.emotion-33 .live-filtering .sui-search-box__submit {
+  display: none;
+}
+
+.emotion-33 .sui-search-box__wrapper {
+  width: 100%;
+  height: 100%;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  border-radius: 3px;
+  position: relative;
+}
+
+.emotion-33 .sui-search-box__text-input {
+  border-radius: 4px;
+  border: none;
+  padding: 0;
+  outline: none;
+  position: relative;
+  font-family: inherit;
+  font-size: 14px;
+  width: 100%;
+}
+
+.emotion-33 .sui-search-box__text-input:focus {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid var(--link-color);
+  border-left: 1px solid var(--link-color);
+  border-right: 1px solid var(--link-color);
+  border-bottom: 1px solidvar(--link-color);
+}
+
+.emotion-33 .autocomplete .sui-search-box__text-input {
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container {
+  display: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  left: 0;
+  right: 0;
+  top: 110%;
+  margin: 0;
+  padding: 24px 0 12px 0;
+  line-height: 1.5;
+  background: transparent;
+  position: absolute;
+  box-shadow: rgba(59,69,79,0.3) 0px 2px 4px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.emotion-33 .autocomplete .sui-search-box__autocomplete-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 24px 0;
+  background: transparent;
+  border-radius: 3px;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container ul:last-child {
+  padding: 0;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container li {
+  margin: 0 12px;
+  font-size: 0.9em;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container li em {
+  font-style: normal;
+  background: #edf0fd;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container li:hover {
+  background: var(--link-color);
+}
+
+.emotion-33 .sui-search-box__autocomplete-container li:hover em {
+  background: transparent;
+}
+
+.emotion-33 .sui-search-box__autocomplete-container li[aria-selected='true'] {
+  background: var(--link-color);
+}
+
+.emotion-33 .sui-search-box__autocomplete-container li[aria-selected='true'] em {
+  background: transparent;
+}
+
+.emotion-33 .sui-search-box__section-title {
+  font-size: 0.7em;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: normal;
+  padding: 0 0 4px 24px;
+  text-transform: uppercase;
+}
+
+.emotion-33 .sui-sorting {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  display: inline-block;
+  width: 100%;
+}
+
+.emotion-33 .sui-sorting__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+}
+
+.emotion-33 .sui-select {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.emotion-33 .sui-select--inline {
+  margin-top: 0;
+}
+
+.emotion-33 .sui-select--is-disabled {
+  opacity: 0.5;
+}
+
+.emotion-33 .sui-select__control {
+  background-color: var(--tertiary-background-color);
+  border: 1px solid #a6a6a6;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.emotion-33 .sui-select__control--is-focused {
+  border: 1px solid var(--link-color);
+}
+
+.emotion-33 .sui-select__value-container {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.emotion-33 .sui-select__value-container--has-value {
+  font-weight: 700;
+}
+
+.emotion-33 .sui-select__placeholder {
+  white-space: nowrap;
+  position: static;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.emotion-33 .sui-select__dropdown-indicator {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  width: 32px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-33 .sui-select__option-count {
+  color: #888888;
+  font-size: 0.8em;
+}
+
+.emotion-33 .sui-select__option-label {
+  color: var(--link-color);
+}
+
+.emotion-33 .sui-select__option {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 400;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.emotion-33 .sui-select__option--is-selected {
+  background: #ffffff;
+  font-weight: 700;
+}
+
+.emotion-33 .sui-select__option--is-selected .sui-search-select__option-label {
+  position: relative;
+}
+
+.emotion-33 .sui-select__option:hover {
+  background: var(--tertiary-background-color);
+}
+
+.emotion-63 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+@media screen and (max-width:585px) {
+  .emotion-63::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    height: 100%;
+    width: 2rem;
+    pointer-events: none;
+    background: linear-gradient( to right,rgba(244,245,245,0),var(--color-neutrals-100) );
+  }
+
+  .dark-mode .emotion-63::after {
+    background: linear-gradient( to right,rgba(34,53,60,0),var(--color-dark-100) );
+  }
+}
+
+.emotion-57 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.emotion-62 {
   height: 100%;
   margin: 0;
   padding: 0;
@@ -1460,9 +6357,19 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   display: flex;
   list-style-type: none;
   white-space: nowrap;
+  overflow-x: auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-22 {
+.emotion-62 > li {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1479,17 +6386,17 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   transition: 0.2s;
 }
 
-.emotion-22:hover {
+.emotion-58:hover {
   background-color: var(--color-neutrals-200);
   color: var(--color-neutrals-700);
 }
 
-.dark-mode .emotion-22:hover {
+.dark-mode .emotion-58:hover {
   background-color: var(--color-dark-200);
   color: var(--color-dark-700);
 }
 
-.emotion-30 {
+.emotion-70 {
   margin: 0;
   padding: 0;
   display: -webkit-box;
@@ -1503,14 +6410,44 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   align-items: center;
 }
 
-.emotion-30 > li {
+.emotion-70 > li {
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
   margin-left: 1rem;
   color: var(--secondary-text-color);
 }
 
-.emotion-28 {
+.emotion-65 {
+  color: var(--secondary-text-color);
+  -webkit-transition: all 0.2s ease-out;
+  transition: all 0.2s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-65:hover {
+  color: var(--secondary-text-hover-color);
+}
+
+.emotion-64 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 0.875rem;
+  height: 0.875rem;
+  display: block;
+  cursor: pointer;
+}
+
+.emotion-66 {
   fill: none;
   stroke: currentColor;
   stroke-width: 2;
@@ -1519,39 +6456,73 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   width: 0.875rem;
   height: 0.875rem;
   cursor: pointer;
+  display: block;
+  cursor: pointer;
+  color: var(--secondary-text-color);
   -webkit-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
 }
 
-.emotion-28:hover {
+.emotion-66:hover {
   color: var(--secondary-text-hover-color);
 }
 
-.emotion-29 {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  width: 0.875rem;
-  height: 0.875rem;
-  cursor: pointer;
-  cursor: pointer;
-  -webkit-transition: all 0.2s ease-out;
-  transition: all 0.2s ease-out;
-  color: var(--secondary-text-color);
+.emotion-69 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
-.emotion-29:hover {
-  color: var(--secondary-text-hover-color);
+.emotion-67 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border-width: 1px;
+  border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
 }
 
-.emotion-38 {
+.emotion-67:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-67:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-78 {
   margin-bottom: 1rem;
 }
 
-.emotion-33 {
+.emotion-73 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1573,18 +6544,26 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
   color: var(--color-white);
-  border-color: var(--color-brand-800);
-  background-color: var(--color-brand-800);
+  background-color: var(--color-brand-600);
 }
 
-.dark-mode .emotion-33 {
-  color: var(--primary-background-color);
-  background-color: var(--color-brand-400);
-  border-color: var(--color-brand-400);
+.emotion-73:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
 }
 
-.emotion-36 {
+.emotion-73:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+.emotion-76 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1606,24 +6585,72 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  color: var(--color-brand-800);
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+}
+
+.emotion-76:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.dark-mode .emotion-76 {
   border-color: transparent;
-  background-color: transparent;
 }
 
-.dark-mode .emotion-36 {
-  color: var(--color-brand-400);
-}
-
-.dark-mode .emotion-36 {
-  border-color: transparent;
-}
-
-.emotion-35 {
+.emotion-75 {
   margin-right: 0.5rem;
 }
 
-.emotion-41 {
+.emotion-32 .sui-search-box__text-input {
+  border: none;
+  padding: 0;
+}
+
+.emotion-30 {
+  position: relative;
+  width: 100%;
+  --icon-size: 1.5rem;
+}
+
+.emotion-27 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+  stroke: var(--primary-text-color);
+  height: var(--icon-size);
+  width: var(--icon-size);
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.emotion-28 {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--primary-background-color);
+  color: var(--primary-text-color);
+  font-size: 1.25rem;
+  padding: 1rem calc(1.5rem + var(--icon-size));
+}
+
+.emotion-28:focus {
+  outline: none;
+  border: 1px solid rgba(0,126,138,0.6);
+  box-shadow: 0 0 0 4px rgba(0,126,138,0.1);
+}
+
+.emotion-81 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1645,32 +6672,207 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  color: var(--color-neutrals-800);
-  border-color: var(--color-neutrals-100);
+  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  white-space: nowrap;
+  border: 0;
+  color: var(--color-neutrals-700);
   background-color: var(--color-neutrals-100);
 }
 
-.dark-mode .emotion-41 {
-  color: var(--color-white);
-  border-color: var(--color-dark-100);
-  background-color: var(--color-dark-100);
+.emotion-81:hover {
+  -webkit-transform: translate3d(0,-1px,0);
+  -ms-transform: translate3d(0,-1px,0);
+  transform: translate3d(0,-1px,0);
+}
+
+.emotion-81:hover {
+  color: var(--color-brand-600);
+  background: rgba(112,204,210,0.17);
+}
+
+.dark-mode .emotion-81 {
+  color: var(--color-dark-700);
+  background-color: var(--color-dark-200);
+}
+
+.dark-mode .emotion-81:hover {
+  color: var(--color-brand-200);
+  background-color: rgba(112,204,210,0.17);
 }
 
 <div
   className="layout-container projectPageLayout"
 >
   <div
-    className=" emotion-32"
+    className=" emotion-72"
     data-swiftype-index={false}
   >
     <div
-      className="emotion-31"
+      className="emotion-71"
     >
+      <div
+        className="emotion-35"
+      >
+        <div
+          className="emotion-25"
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <div
+            className="emotion-24"
+          >
+            <svg
+              className="emotion-20"
+              viewBox="0 0 79 15"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                className="emotion-0 emotion-1"
+                d="M27.3532 11.5262L25.2123 7.0377C24.7012 5.97415 24.1763 4.77276 23.9971 4.20652L23.9558 4.24788C24.0247 5.04845 24.0385 6.05686 24.0523 6.89879L24.1074 11.5252H22.5466V1.97021H24.3418L26.6618 6.63794C27.104 7.52123 27.5176 8.6537 27.6427 9.09587L27.684 9.05451C27.6427 8.57099 27.5462 7.20418 27.5462 6.33362L27.5186 1.97021H29.0243V11.5262H27.3532Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M31.8682 8.44694V8.55722C31.8682 9.52427 32.2277 10.5454 33.5945 10.5454C34.2434 10.5454 34.8096 10.3111 35.3345 9.85511L35.9283 10.7808C35.1967 11.4022 34.3537 11.7065 33.4153 11.7065C31.4409 11.7065 30.1981 10.2846 30.1981 8.04718C30.1981 6.81822 30.46 6.0028 31.0687 5.3125C31.6349 4.66356 32.3252 4.37302 33.2096 4.37302C33.8999 4.37302 34.535 4.55222 35.1288 5.09088C35.7364 5.64333 36.0407 6.49905 36.0407 8.12883V8.44694H31.8682ZM33.2085 5.51927C32.3528 5.51927 31.883 6.19578 31.883 7.32825H34.465C34.465 6.19578 33.9677 5.51927 33.2085 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M44.1176 11.5538H42.6946L41.8388 8.33667C41.6183 7.50853 41.3829 6.4312 41.3829 6.4312H41.3553C41.3553 6.4312 41.245 7.1215 40.8994 8.4056L40.0574 11.5538H38.6355L36.7289 4.636L38.2347 4.42923L38.9939 7.81285C39.1869 8.68235 39.3533 9.64941 39.3533 9.64941H39.3947C39.3947 9.64941 39.5325 8.73749 39.7955 7.7715L40.6936 4.54057H42.1856L42.9724 7.68879C43.2629 8.82126 43.4145 9.67698 43.4145 9.67698H43.4559C43.4559 9.67698 43.6213 8.61343 43.8016 7.79907L44.5194 4.53951H46.0941L44.1176 11.5538Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M54.9428 11.5262L54.1147 10.0481C53.4519 8.87425 53.0098 8.21152 52.4849 7.68664C52.3057 7.50744 52.1668 7.41095 51.8635 7.39716V11.5262H50.3037V1.97021H53.2176C55.3585 1.97021 56.3244 3.21296 56.3244 4.7049C56.3244 6.07171 55.4412 7.3293 53.9492 7.3293C54.2949 7.5085 54.9301 8.4342 55.4263 9.23478L56.8355 11.5262H54.9428ZM52.7341 3.25432H51.8635V6.27954H52.6779C53.506 6.27954 53.9482 6.16926 54.2387 5.87872C54.5006 5.61681 54.6671 5.21599 54.6671 4.71868C54.6671 3.75163 54.1422 3.25432 52.7341 3.25432Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M58.9203 8.44694V8.55722C58.9203 9.52427 59.2798 10.5454 60.6466 10.5454C61.2955 10.5454 61.8618 10.3111 62.3867 9.85511L62.9805 10.7808C62.2488 11.4022 61.4058 11.7065 60.4674 11.7065C58.493 11.7065 57.2502 10.2846 57.2502 8.04718C57.2502 6.81822 57.5122 6.0028 58.1208 5.3125C58.687 4.66356 59.3773 4.37302 60.2617 4.37302C60.952 4.37302 61.5871 4.55222 62.1809 5.09088C62.7885 5.64333 63.0929 6.49905 63.0929 8.12883V8.44694H58.9203ZM60.2596 5.51927C59.4038 5.51927 58.9341 6.19578 58.9341 7.32825H61.5161C61.5161 6.19578 61.0188 5.51927 60.2596 5.51927Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M65.9346 11.6789C64.4013 11.6789 64.4013 10.2983 64.4013 9.70453V3.75164C64.4013 2.79837 64.3599 2.28834 64.2634 1.70832L65.8243 1.36264C65.9346 1.79103 65.9483 2.37105 65.9483 3.2819V9.20616C65.9483 10.1456 65.9897 10.2973 66.1 10.4627C66.1827 10.5868 66.4181 10.6557 66.5973 10.573L66.8454 11.5125C66.5697 11.6238 66.2802 11.6789 65.9346 11.6789Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M68.5728 3.5035C68.0204 3.5035 67.592 3.04754 67.592 2.49509C67.592 1.92886 68.0341 1.4729 68.6004 1.4729C69.139 1.4729 69.595 1.91507 69.595 2.49509C69.5939 3.04754 69.138 3.5035 68.5728 3.5035ZM67.8125 11.5262V4.64975L69.3458 4.373V11.5262H67.8125Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M73.6954 11.7065C71.7899 11.7065 70.7264 10.3673 70.7264 8.1161C70.7264 5.57547 72.2459 4.36029 73.8057 4.36029C74.5649 4.36029 75.1173 4.53949 75.7387 5.11951L74.9795 6.12792C74.5649 5.75467 74.2065 5.58925 73.8057 5.58925C73.3221 5.58925 72.9213 5.83738 72.7008 6.29334C72.494 6.72172 72.4113 7.37067 72.4113 8.24017C72.4113 9.19343 72.5629 9.80102 72.881 10.1456C73.1016 10.3938 73.4335 10.5465 73.8067 10.5465C74.2903 10.5465 74.76 10.3121 75.2149 9.85616L75.9328 10.7819C75.2976 11.416 74.6349 11.7065 73.6954 11.7065Z"
+              />
+              <path
+                className="emotion-0 emotion-1"
+                d="M77.2286 11.68C76.6687 11.68 76.2085 11.2283 76.2085 10.6546C76.2085 10.0841 76.6687 9.62924 77.2286 9.62924C77.7884 9.62924 78.2486 10.0841 78.2486 10.6546C78.2486 11.2272 77.7874 11.68 77.2286 11.68ZM77.2286 9.83283C76.7928 9.83283 76.4428 10.1965 76.4428 10.6546C76.4428 11.1127 76.7928 11.4817 77.2286 11.4817C77.6644 11.4817 78.0175 11.1127 78.0175 10.6546C78.0164 10.1965 77.6633 9.83283 77.2286 9.83283ZM77.429 11.2219C77.3844 11.1445 77.3654 11.1148 77.3219 11.0321C77.2084 10.8253 77.1734 10.767 77.1321 10.7511C77.1215 10.7458 77.1098 10.7426 77.096 10.7426V11.223H76.8702V10.0725H77.2975C77.5011 10.0725 77.6368 10.2082 77.6368 10.4086C77.6368 10.5825 77.5212 10.7225 77.3802 10.7257C77.4025 10.7447 77.4131 10.7564 77.4269 10.7755C77.4926 10.8582 77.7025 11.2219 77.7025 11.2219H77.429ZM77.3081 10.2739C77.2837 10.2655 77.2339 10.257 77.1787 10.257H77.096V10.5687H77.1734C77.2731 10.5687 77.3166 10.5571 77.3473 10.5295C77.3749 10.5019 77.3919 10.4606 77.3919 10.4139C77.3908 10.3429 77.3632 10.2952 77.3081 10.2739Z"
+              />
+              <path
+                className="emotion-18"
+                d="M17.159 5.6486C16.3489 1.92142 11.8784 -0.271419 7.17568 0.751833C2.47296 1.77403 -0.682686 5.62527 0.127433 9.3514C0.937552 13.0786 5.40805 15.2714 10.1108 14.2482C14.8135 13.226 17.9691 9.37578 17.159 5.6486ZM8.64322 10.9356C6.74517 10.9356 5.20764 9.39699 5.20764 7.5C5.20764 5.603 6.74623 4.06441 8.64322 4.06441C10.5402 4.06441 12.0788 5.60194 12.0788 7.5C12.0788 9.39805 10.5402 10.9356 8.64322 10.9356Z"
+              />
+              <path
+                className="emotion-19"
+                d="M9.40328 2.69022C6.6792 2.69022 4.47046 4.89896 4.47046 7.62303C4.47046 10.3471 6.6792 12.5559 9.40328 12.5559C12.1284 12.5559 14.3372 10.3471 14.3372 7.62303C14.3361 4.89896 12.1274 2.69022 9.40328 2.69022ZM8.64299 10.5009C6.98564 10.5009 5.64216 9.15738 5.64216 7.50003C5.64216 5.84268 6.98564 4.4992 8.64299 4.4992C10.3003 4.4992 11.6438 5.84268 11.6438 7.50003C11.6438 9.15738 10.3003 10.5009 8.64299 10.5009Z"
+              />
+            </svg>
+            <div
+              className="emotion-23"
+            >
+              <span
+                className="emotion-21"
+              >
+                Close
+              </span>
+              <svg
+                className="emotion-22"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="emotion-34"
+        >
+          <div
+            className="emotion-33"
+          >
+            <form
+              aria-expanded={false}
+              aria-haspopup="listbox"
+              aria-labelledby="downshift-1-label"
+              aria-owns={null}
+              onSubmit={[Function]}
+              role="combobox"
+            >
+              <div
+                className="sui-search-box"
+              >
+                <div
+                  className="sui-search-box__wrapper emotion-32"
+                >
+                  <div
+                    className="sui-search-box__text-input  emotion-30 emotion-31"
+                    size="large"
+                  >
+                    <svg
+                      className="emotion-26 emotion-27"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle
+                        cx="11"
+                        cy="11"
+                        r="8"
+                      />
+                      <line
+                        x1="21"
+                        x2="16.65"
+                        y1="21"
+                        y2="16.65"
+                      />
+                    </svg>
+                    <input
+                      aria-activedescendant={null}
+                      aria-autocomplete="list"
+                      aria-controls={null}
+                      aria-labelledby="downshift-1-label"
+                      autoComplete="off"
+                      className="emotion-28 emotion-29"
+                      id="downshift-1-input"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="Search"
+                      size="large"
+                      type="text"
+                      value=""
+                    />
+                    
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
       <nav
-        className="emotion-27"
+        className="emotion-63"
       >
         <a
-          className="emotion-21"
+          className="emotion-57"
           href="https://newrelic.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -1727,11 +6929,11 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           </svg>
         </a>
         <ul
-          className="emotion-26"
+          className="emotion-62"
         >
           <li>
             <a
-              className="emotion-22"
+              className="emotion-58"
               href="https://developer.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1741,7 +6943,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-58"
               href="https://opensource.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1751,7 +6953,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-58"
               href="https://docs.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1761,7 +6963,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           </li>
           <li>
             <a
-              className="emotion-22"
+              className="emotion-58"
               href="https://discuss.newrelic.com/"
               rel="noopener noreferrer"
               target="_blank"
@@ -1772,31 +6974,35 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
         </ul>
       </nav>
       <ul
-        className="emotion-30"
+        className="emotion-70"
       >
         <li>
-          <svg
-            className="emotion-28"
-            onClick={[Function]}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <a
+            className="emotion-65"
+            href="?q="
           >
-            <circle
-              cx="11"
-              cy="11"
-              r="8"
-            />
-            <line
-              x1="21"
-              x2="16.65"
-              y1="21"
-              y2="16.65"
-            />
-          </svg>
+            <svg
+              className="emotion-64"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+              <line
+                x1="21"
+                x2="16.65"
+                y1="21"
+                y2="16.65"
+              />
+            </svg>
+          </a>
         </li>
         <li>
           <svg
-            className="emotion-29"
+            className="emotion-66"
             onClick={[Function]}
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -1805,6 +7011,22 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
               d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
             />
           </svg>
+        </li>
+        <li
+          className="emotion-69"
+        >
+          <a
+            className="emotion-67 emotion-68"
+            href="https://newrelic.com/signup"
+            rel="noopener noreferrer"
+            size="extraSmall"
+            target="_blank"
+            variant="primary"
+          >
+            <span>
+              Sign up
+            </span>
+          </a>
         </li>
       </ul>
     </div>
@@ -1990,13 +7212,13 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
           className="callToActionContainer"
         >
           <div
-            className="callToActionButtons emotion-38"
+            className="callToActionButtons emotion-78"
           >
             <div
               className="callToActionButtonsContainer"
             >
               <a
-                className="emotion-33 emotion-34"
+                className="emotion-73 emotion-68"
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
                 target="__blank"
@@ -2004,13 +7226,13 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
                 View Website
               </a>
               <a
-                className="emotion-36 emotion-34"
+                className="emotion-76 emotion-68"
                 href="https://github.com/AdoptOpenJDK"
                 rel="noopener noreferrer"
               >
                 <img
                   alt="GitHub logo"
-                  className="emotion-35"
+                  className="emotion-75"
                   src="test-file-stub"
                 />
                 GitHub
@@ -2329,14 +7551,14 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
         className="ctaContainer"
       >
         <button
-          className="approvalButton emotion-33 emotion-34"
+          className="approvalButton emotion-73 emotion-68"
           onClick={[Function]}
           type="button"
         >
           Yes
         </button>
         <button
-          className="ignoreButton emotion-41 emotion-34"
+          className="ignoreButton emotion-81 emotion-68"
           onClick={[Function]}
           type="button"
         >

--- a/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
+++ b/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {
@@ -2393,7 +2393,7 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-65 {
@@ -4778,7 +4778,7 @@ exports[`W3C Distributed Tracing Working Group Renders correctly 1`] = `
   position: sticky;
   top: 0;
   z-index: 80;
-  z-index: 1000000;
+  z-index: 700;
 }
 
 .dark-mode .emotion-72 {

--- a/src/templates/project-page.module.scss
+++ b/src/templates/project-page.module.scss
@@ -182,7 +182,7 @@ p.call-to-action-description {
 
   &:last-child {
     position: relative;
-    z-index: 10;
+    z-index: 200;
   }
 
   img {


### PR DESCRIPTION
These changes should address: https://github.com/newrelic/opensource-website/issues/556

The global nav should now mirror the experience on https://developer.newrelic.com/ as requested in the bug ticket.

I can see the global Gatsby theme nav was disabled on mobile views and set to be `static` rather than `sticky`. I caught and resolved a couple complications from removing the mobile `display: none` rule, but it's worth some manual exploration to confirm there aren't regressions I didn't clock.

### Notes

1.  My changes in 16f614f modify some styles that link back to changes in https://github.com/newrelic/opensource-website/commit/637f7e09d307757a2ea3fe35e0cac1e5642fc203, which I'm not familiar with. Might be worth someone close to that work giving this MR's changes a glance

2. I added a `z-index` for the `GlobalHeader` that hopefully matches the repo’s convention (10, 100, 1000, etc.) I went with the highest I could find, but in looking it up, I'm not 100% convinced that `.iframe-container` class (where I grabbed the `z-index: 1000000` value from) is being used. Still went with it to be better safe than sorry. Without the `z-index` a number of the homepage elements will display at a higher layer than the `GlobalHeader`.

3. While working on this, I noticed and raised an issue that should be addressed on the Gatsby theme repo: https://github.com/newrelic/gatsby-theme-newrelic/issues/79