### PR TITLE
Add nr1 vscode extension to projects

### DIFF
--- a/src/data/project-main-content/newrelic-nr1-vscode-extension.mdx
+++ b/src/data/project-main-content/newrelic-nr1-vscode-extension.mdx
@@ -1,0 +1,16 @@
+---
+path: "/projects/newrelic/nr1-vscode-extension"
+date: "2020-08-17"
+title: "NR1 VSCode Extension"
+---
+
+## Getting Started
+
+1. Fork this repository.
+2. Open project in VS Code.
+3. Hit `F5` to compile and launch the extension in debug mode. This will open a new VS Code window in which you can open the Command Palette and try out the commands.
+4. Make your changes in a new branch.
+5. Commit and push your changes.
+6. Open a pull request with a description of the changes. Feel free to include anything that could make our review easier (screenshots, demo gifs, etc.).
+
+Find the detailed instructions for getting started in the project [README](https://github.com/newrelic/nr1-vscode-extension).

--- a/src/data/projects/newrelic-nr1-vscode-extension.json
+++ b/src/data/projects/newrelic-nr1-vscode-extension.json
@@ -1,0 +1,24 @@
+{
+  "name": "nr1-vscode-extension",
+  "fullName": "newrelic/nr1-vscode-extension",
+  "slug": "newrelic-nr1-vscode-extension",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "NR1 VSCode Extension",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic/nr1-vscode-extension",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/nr1-vscode-extension",
+  "iconUrl": null,
+  "shortDescription": "Build and deploy New Relic apps directly from VS Code",
+  "description": "Build and deploy New Relic apps directly from VS Code",
+  "ossCategory": "community-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["dev-toolkit", "tools"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "Visual Studio Marketplace",
+    "url": "https://marketplace.visualstudio.com/items?itemName=new-relic.nr1"
+  }
+}


### PR DESCRIPTION
This PR adds a project entry for the NR1 VSCode Extension 

<img width="1080" alt="Screen Shot 2020-08-17 at 5 05 06 PM" src="https://user-images.githubusercontent.com/39655074/90455781-cfe2d400-e0ab-11ea-96bf-cb98ce55decb.png">

