### PR TITLE
Ensure header has backdrop that goes the full browser viewport

### DIFF
--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -3,7 +3,6 @@
 }
 
 .primary-header-container {
-  position: relative;
   box-sizing: border-box;
   padding: 20px 0;
   display: flex;


### PR DESCRIPTION
## Description

Ensure the header backdrop expands to the full browser viewport.

## Screenshots

**Before**
<img width="1920" alt="Screen Shot 2020-08-20 at 3 21 13 PM" src="https://user-images.githubusercontent.com/565661/90831584-ea5dbd00-e2f8-11ea-913a-015176bb1ad7.png">

**After**
<img width="1920" alt="Screen Shot 2020-08-20 at 3 21 23 PM" src="https://user-images.githubusercontent.com/565661/90831605-f6497f00-e2f8-11ea-97a3-ef49cd24826a.png">

