### PR TITLE
chore: update OSS category for some repositories (address #620)

### DIFF
--- a/src/data/project-main-content/newrelic-nri-statsd.mdx
+++ b/src/data/project-main-content/newrelic-nri-statsd.mdx
@@ -1,0 +1,62 @@
+---
+path: "/projects/newrelic/nri-statsd"
+date: "08/28/2020"
+title: "New Relic StatsD Integration"
+projectConfig: "src/data/projects/newrelic-nri-statsd.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/nri-statsd) for setup and usage details.
+
+<!--
+
+import { Link } from 'gatsby';
+
+<div className="responsive-video">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/7wnav6Fu9T0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<Link to="/cta">Install</Link>
+
+## [Optional] Features
+
+### [Optional] Feature 1
+
+### [Optional] Feature 2
+
+## [Required] Getting Started
+
+### [Optional] Code example highlighting an extension or customization point
+
+This is how you extend New Relic Infrastructure Memcached Integration in following way.
+
+```js
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// I'm a comment;
+const aMadeUpFunction = () => {
+if (myArray.length !== 100) {
+  myArray.map((item, i) => item * i);
+} else {
+  return null
+}
+};
+```
+### [Optional] More details about the project
+
+## [Optional] What people are saying
+
+Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit.
+
+> [name="Leslie Webb"] Vitae enim egestas egestas at gravida arcu, amet in. Facilisis at
+massa amet, aliquet dui semper. Sit placerat sed et ornare faucibus
+egestas sit nisl, diam.
+
+> [name="Bildad the Shuhite"] Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+vestibulum. Maecenas faucibus mollis interdum. Maecenas sed diam
+eget risus varius blandit sit amet non magna.
+-->

--- a/src/data/project-main-content/newrelic-nri-winservices.mdx
+++ b/src/data/project-main-content/newrelic-nri-winservices.mdx
@@ -1,0 +1,62 @@
+---
+path: "/projects/newrelic/nri-winservices"
+date: "08/28/2020"
+title: "New Relic Windows Services integration"
+projectConfig: "src/data/projects/newrelic-nri-winservices.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/nri-winservices) for setup and usage details.
+
+<!--
+
+import { Link } from 'gatsby';
+
+<div className="responsive-video">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/7wnav6Fu9T0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<Link to="/cta">Install</Link>
+
+## [Optional] Features
+
+### [Optional] Feature 1
+
+### [Optional] Feature 2
+
+## [Required] Getting Started
+
+### [Optional] Code example highlighting an extension or customization point
+
+This is how you extend New Relic Infrastructure Memcached Integration in following way.
+
+```js
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// I'm a comment;
+const aMadeUpFunction = () => {
+if (myArray.length !== 100) {
+  myArray.map((item, i) => item * i);
+} else {
+  return null
+}
+};
+```
+### [Optional] More details about the project
+
+## [Optional] What people are saying
+
+Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit.
+
+> [name="Leslie Webb"] Vitae enim egestas egestas at gravida arcu, amet in. Facilisis at
+massa amet, aliquet dui semper. Sit placerat sed et ornare faucibus
+egestas sit nisl, diam.
+
+> [name="Bildad the Shuhite"] Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+vestibulum. Maecenas faucibus mollis interdum. Maecenas sed diam
+eget risus varius blandit sit amet non magna.
+-->

--- a/src/data/projects/newrelic-aws-log-ingestion.json
+++ b/src/data/projects/newrelic-aws-log-ingestion.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "AWS log ingestion",
   "description": "AWS Serverless application that sends log data from CloudWatch Logs to New Relic Infrastructure - Cloud Integrations.",
-  "ossCategory": "new-relic-experimental",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Python",
-  "projectTags": ["logging"],
+  "projectTags": [
+    "logging"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "aws log-ingestion",

--- a/src/data/projects/newrelic-go-agent.json
+++ b/src/data/projects/newrelic-go-agent.json
@@ -15,9 +15,11 @@
   "iconUrl": null,
   "shortDescription": "The official New Relic agent for Golang",
   "description": "Allows you to monitor your Go applications with New Relic",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["agent"],
+  "projectTags": [
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Go Agent",

--- a/src/data/projects/newrelic-infrastructure-agent.json
+++ b/src/data/projects/newrelic-infrastructure-agent.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Install the Infra agent",
   "description": "Collects inventory data and metrics of your hosts and sends it to the New Relic platform",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri", "agent"],
+  "projectTags": [
+    "nri",
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Agent",

--- a/src/data/projects/newrelic-infrastructure-bundle.json
+++ b/src/data/projects/newrelic-infrastructure-bundle.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Install the Infra agent",
   "description": "New Relic Infrastructure containerised agent bundle",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Shell",
-  "projectTags": ["nri", "tools"],
+  "projectTags": [
+    "nri",
+    "tools"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Bundle",

--- a/src/data/projects/newrelic-java-log-extensions.json
+++ b/src/data/projects/newrelic-java-log-extensions.json
@@ -15,9 +15,11 @@
   "iconUrl": null,
   "shortDescription": "Extensions for Java logging",
   "description": "Source for the New Relic Java log framework extensions.",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Java",
-  "projectTags": ["logging"],
+  "projectTags": [
+    "logging"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Java Logging",

--- a/src/data/projects/newrelic-k8s-metadata-injection.json
+++ b/src/data/projects/newrelic-k8s-metadata-injection.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Kubernetes metadata in APM Services",
   "description": "Kubernetes metadata injection for New Relic APM to make a linkage between APM and Infrastructure data.",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["exporter", "k8"],
+  "projectTags": [
+    "exporter",
+    "k8"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "Kubernetes Metadata Injection",

--- a/src/data/projects/newrelic-k8s-webhook-cert-manager.json
+++ b/src/data/projects/newrelic-k8s-webhook-cert-manager.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Generate compatible certificates",
   "description": "Generate certificate suitable for use with any Kubernetes Mutating Webhook.",
-  "ossCategory": "example-code",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Shell",
-  "projectTags": ["k8", "tools"],
+  "projectTags": [
+    "k8",
+    "tools"
+  ],
   "acceptsContributions": false,
   "website": {
     "title": "Kubernetes Webhook Certificate Manager",

--- a/src/data/projects/newrelic-newrelic-dotnet-agent.json
+++ b/src/data/projects/newrelic-newrelic-dotnet-agent.json
@@ -15,9 +15,11 @@
   "iconUrl": null,
   "shortDescription": "Automated instrumentation for .NET",
   "description": "The official New Relic agent for .NET",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": ".NET",
-  "projectTags": ["agent"],
+  "projectTags": [
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic .NET Agent",

--- a/src/data/projects/newrelic-newrelic-java-agent.json
+++ b/src/data/projects/newrelic-newrelic-java-agent.json
@@ -6,13 +6,10 @@
     "title": "New Relic Java agent",
     "url": "https://github.com/newrelic/newrelic-java-agent"
   },
-
   "githubUrl": "https://github.com/newrelic/newrelic-java-agent",
   "contributingGuideUrl": "https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md",
-
   "fullName": "newrelic/newrelic-java-agent",
   "slug": "newrelic-newrelic-java-agent",
-
   "owner": {
     "login": "newrelic",
     "type": "Organization"
@@ -22,9 +19,10 @@
   "defaultBranch": "main",
   "iconUrl": null,
   "description": "The New Relic Java agent monitors your applications to help you improve the customer experience and make data-driven business decisions.",
-
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Java",
-  "projectTags": ["agent"],
+  "projectTags": [
+    "agent"
+  ],
   "acceptsContributions": true
 }

--- a/src/data/projects/newrelic-newrelic-logenricher-dotnet.json
+++ b/src/data/projects/newrelic-newrelic-logenricher-dotnet.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Extensions for common .NET logging frameworks",
   "description": "Extensions supporting New Relic Logging (Logs In Context)",
-  "ossCategory": "example-code",
+  "ossCategory": "community-plus",
   "primaryLanguage": "C#",
-  "projectTags": ["logging"],
+  "projectTags": [
+    "logging"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Logging Extensions for .NET",

--- a/src/data/projects/newrelic-newrelic-monolog-logenricher-php.json
+++ b/src/data/projects/newrelic-newrelic-monolog-logenricher-php.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Integrate PHP Monolog to New Relic Logs",
   "description": "Monolog components to enable New Relic Logs",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "PHP",
-  "projectTags": ["logging"],
+  "projectTags": [
+    "logging"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "Monolog for New Relic Logs",

--- a/src/data/projects/newrelic-newrelic-python-agent.json
+++ b/src/data/projects/newrelic-newrelic-python-agent.json
@@ -15,9 +15,11 @@
   "iconUrl": null,
   "shortDescription": "Automated instrumentation for Python",
   "description": "The official New Relic agent for Python",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Python",
-  "projectTags": ["agent"],
+  "projectTags": [
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Python Agent",

--- a/src/data/projects/newrelic-newrelic-ruby-agent.json
+++ b/src/data/projects/newrelic-newrelic-ruby-agent.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "New Relic's Ruby Agent",
   "description": "The New Relic Ruby agent monitors your applications to help you identify and solve performance issues. You can also extend the agent's performance monitoring to collect and analyze business data to help you improve the customer experience and make data-driven business decisions.",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Ruby",
-  "projectTags": ["agent"],
+  "projectTags": [
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Ruby Agent",

--- a/src/data/projects/newrelic-newrelic-winston-logenricher-node.json
+++ b/src/data/projects/newrelic-newrelic-winston-logenricher-node.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Log Enricher for the New Relic Node Agent",
   "description": "New Relic's Winston log enricher for use with the Node Agent",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["logging", "exporter"],
+  "projectTags": [
+    "logging",
+    "exporter"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Winston Log Enricher",

--- a/src/data/projects/newrelic-node-newrelic-aws-sdk.json
+++ b/src/data/projects/newrelic-node-newrelic-aws-sdk.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "AWS SDK for Node",
   "description": "New Relic's official AWS-SDK package instrumentation for use with the Node Agent",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["sdk", "agent"],
+  "projectTags": [
+    "sdk",
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic AWS SDK (Node)",

--- a/src/data/projects/newrelic-node-newrelic-koa.json
+++ b/src/data/projects/newrelic-node-newrelic-koa.json
@@ -13,9 +13,13 @@
   "iconUrl": null,
   "shortDescription": "Node.js Agent instumentation for Koa",
   "description": "Koa framework instrumentation for New Relic's Node.js Agent",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["agent", "exporter", "lib"],
+  "projectTags": [
+    "agent",
+    "exporter",
+    "lib"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Koa (Node)",

--- a/src/data/projects/newrelic-node-newrelic-mysql.json
+++ b/src/data/projects/newrelic-node-newrelic-mysql.json
@@ -13,13 +13,17 @@
   "iconUrl": null,
   "shortDescription": "Node Agent instumentation for MySQL",
   "description": "MySQL instrumentation for New Relic's Node Agent",
-  "ossCategory": "new-relic-experimental",
+  "ossCategory": "community-plus",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["agent", "exporter", "lib"],
+  "projectTags": [
+    "agent",
+    "exporter",
+    "lib"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic MySQL (Node)",
     "url": "https://github.com/newrelic/node-newrelic-mysql"
-	},
-	"defaultBranch": "main"
+  },
+  "defaultBranch": "main"
 }

--- a/src/data/projects/newrelic-node-newrelic-superagent.json
+++ b/src/data/projects/newrelic-node-newrelic-superagent.json
@@ -13,9 +13,13 @@
   "iconUrl": null,
   "shortDescription": "Node Agent instumentation for SuperAgent",
   "description": "SuperAgent instrumentation for New Relic's Node Agent",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["agent", "exporter", "lib"],
+  "projectTags": [
+    "agent",
+    "exporter",
+    "lib"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic SuperAgent (Node)",

--- a/src/data/projects/newrelic-node-newrelic.json
+++ b/src/data/projects/newrelic-node-newrelic.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Automated instrumentation for Node.js",
   "description": "New Relic Node.js Agent",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["agent"],
+  "projectTags": [
+    "agent"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Node Agent",

--- a/src/data/projects/newrelic-nri-apache.json
+++ b/src/data/projects/newrelic-nri-apache.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for the Apache web server",
   "description": "Capture critical performance metrics and inventory reported by Apache web server",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Apache Integration",

--- a/src/data/projects/newrelic-nri-cassandra.json
+++ b/src/data/projects/newrelic-nri-cassandra.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Apache Cassandra databases",
   "description": "Capture critical performance metrics and inventory reported by Apache Cassandra databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Cassandra Integration",

--- a/src/data/projects/newrelic-nri-consul.json
+++ b/src/data/projects/newrelic-nri-consul.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Hashicorp Consul clusters",
   "description": "Capture critical performance metrics and inventory reported by Hashicorp Consul clusters",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Consul Integration",

--- a/src/data/projects/newrelic-nri-couchbase.json
+++ b/src/data/projects/newrelic-nri-couchbase.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Apache Couchbase clusters",
   "description": "Capture critical performance metrics and inventory reported by Apache Couchbase clusters",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Couchbase Integration",

--- a/src/data/projects/newrelic-nri-discovery-kubernetes.json
+++ b/src/data/projects/newrelic-nri-discovery-kubernetes.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Automatically discover containers running inside Kubernetes",
   "description": "New Relic Infrastructure integration for auto-discovery of Kubernetes containers",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Kubernetes Auto-Discovery",

--- a/src/data/projects/newrelic-nri-docker.json
+++ b/src/data/projects/newrelic-nri-docker.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Docker Integration for New Relic Infrastructure",
   "description": "Reports status and metrics of Docker containers running into a Host",
-  "ossCategory": "new-relic-experimental",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Docker Integration",

--- a/src/data/projects/newrelic-nri-ecs.json
+++ b/src/data/projects/newrelic-nri-ecs.json
@@ -15,9 +15,12 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Amazon ECS.",
   "description": "Collects metrics from ECS clusters and containers in AWS.",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri", "infrastructure"],
+  "projectTags": [
+    "nri",
+    "infrastructure"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Integration for Amazon ECS",

--- a/src/data/projects/newrelic-nri-elasticsearch.json
+++ b/src/data/projects/newrelic-nri-elasticsearch.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Elasticsearch clusters",
   "description": "Capture critical performance metrics and inventory reported by Elasticsearch clusters",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Elasticsearch Integration",

--- a/src/data/projects/newrelic-nri-f5.json
+++ b/src/data/projects/newrelic-nri-f5.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for F5 BIG-IP",
   "description": "New Relic Infrastructure Integration for F5 BIG-IP",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure F5 Integration",

--- a/src/data/projects/newrelic-nri-flex.json
+++ b/src/data/projects/newrelic-nri-flex.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Application-agnostic, all-in-one New Relic integration",
   "description": "Instrument any application that exposes metrics over a standard protocol with New Relic",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Flex",

--- a/src/data/projects/newrelic-nri-haproxy.json
+++ b/src/data/projects/newrelic-nri-haproxy.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "New Relic Infrastructure Integration for HAProxy",
   "description": "Reports status and metrics for HAProxy service",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure HAProxy Integration",

--- a/src/data/projects/newrelic-nri-jmx.json
+++ b/src/data/projects/newrelic-nri-jmx.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "JMX metrics to New Relic",
   "description": "The New Relic Infrastructure Integration for JMX flexibly monitors any application that exposes metrics via JMX",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure JMX Integration",

--- a/src/data/projects/newrelic-nri-kafka.json
+++ b/src/data/projects/newrelic-nri-kafka.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Collect data on Brokers, Topics, Producers, and Consumer",
   "description": "Captures critical performance metrics and inventory reported by Kafka clusters",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Kafka Integration",

--- a/src/data/projects/newrelic-nri-kube-events.json
+++ b/src/data/projects/newrelic-nri-kube-events.json
@@ -15,9 +15,13 @@
   "iconUrl": null,
   "shortDescription": "Router for Kubernetes Events.",
   "description": "Event router for the Kubernetes project. The event router serves as an active watcher of event resource in the Kubernetes system, which takes those events and pushes them to a list of configured sinks.",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri", "infrastructure", "k8"],
+  "projectTags": [
+    "nri",
+    "infrastructure",
+    "k8"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Integration for Kubernetes Events ",

--- a/src/data/projects/newrelic-nri-kubernetes.json
+++ b/src/data/projects/newrelic-nri-kubernetes.json
@@ -15,9 +15,13 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Kubernetes.",
   "description": "Instruments the container orchestration layer by reporting metrics from Kubernetes objects. It gives you visibility about Kubernetes namespaces, deployments, replica sets, nodes, pods, and containers",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri", "infrastructure", "k8"],
+  "projectTags": [
+    "nri",
+    "infrastructure",
+    "k8"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Integration for Kubernetes ",

--- a/src/data/projects/newrelic-nri-memcached.json
+++ b/src/data/projects/newrelic-nri-memcached.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Report status and metrics for Memcached services",
   "description": "Capture critical performance metrics and status by memcached services",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Memcached Integration",

--- a/src/data/projects/newrelic-nri-mongodb.json
+++ b/src/data/projects/newrelic-nri-mongodb.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for MongoDB databases",
   "description": "Capture critical performance metrics and inventory reported by MongoDB databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure MongoDB Integration",

--- a/src/data/projects/newrelic-nri-mssql.json
+++ b/src/data/projects/newrelic-nri-mssql.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Microsoft SQL Server databases",
   "description": "Capture critical performance metrics and inventory reported by Microsoft SQL Server databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Microsoft SQL Server Integration",

--- a/src/data/projects/newrelic-nri-mysql.json
+++ b/src/data/projects/newrelic-nri-mysql.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for MySQL databases",
   "description": "Capture critical performance metrics and inventory reported by MySQL databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure MySQL Integration",

--- a/src/data/projects/newrelic-nri-nagios.json
+++ b/src/data/projects/newrelic-nri-nagios.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring data from Nagios",
   "description": "Capture critical performance metrics and inventory reported by Nagios",
-  "ossCategory": "new-relic-experimental",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Nagios Integration",

--- a/src/data/projects/newrelic-nri-nginx.json
+++ b/src/data/projects/newrelic-nri-nginx.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Nginx web servers",
   "description": "Capture critical performance metrics and inventory reported by Nginx web servers",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Nginx Integration",

--- a/src/data/projects/newrelic-nri-oracledb.json
+++ b/src/data/projects/newrelic-nri-oracledb.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Oracle databases",
   "description": "Capture critical performance metrics and inventory reported by Oracle databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Oracle Database Integration",

--- a/src/data/projects/newrelic-nri-postgresql.json
+++ b/src/data/projects/newrelic-nri-postgresql.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for PostgreSQL databases",
   "description": "Capture critical performance metrics and inventory reported by PostgreSQL databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure PostgreSQL Integration",

--- a/src/data/projects/newrelic-nri-prometheus.json
+++ b/src/data/projects/newrelic-nri-prometheus.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Send Prometheus metrics to New Relic",
   "description": "Fetch metrics in the Prometheus metrics inside or outside Kubernetes and send them to New Relic",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri", "opentelemetry"],
+  "projectTags": [
+    "nri",
+    "opentelemetry"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Prometheus OpenMetrics Integration",

--- a/src/data/projects/newrelic-nri-rabbitmq.json
+++ b/src/data/projects/newrelic-nri-rabbitmq.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "RabitMQ metrics and inventory to New Relic",
   "description": "Capture critical performance metrics and inventory reported by the RabbitMQ Management plugin",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure RabbitMQ Integration",

--- a/src/data/projects/newrelic-nri-redis.json
+++ b/src/data/projects/newrelic-nri-redis.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Redis databases",
   "description": "Capture critical performance metrics and inventory reported by Redis databases",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Redis Integration",

--- a/src/data/projects/newrelic-nri-snmp.json
+++ b/src/data/projects/newrelic-nri-snmp.json
@@ -13,9 +13,12 @@
   "iconUrl": null,
   "shortDescription": "Monitoring data from SNMP servers",
   "description": "Capture critical performance metrics and inventory reported by SNMP servers",
-  "ossCategory": "new-relic-experimental",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri", "network"],
+  "projectTags": [
+    "nri",
+    "network"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure SNMP Integration",

--- a/src/data/projects/newrelic-nri-statsd.json
+++ b/src/data/projects/newrelic-nri-statsd.json
@@ -1,0 +1,26 @@
+{
+  "name": "nri-statsd",
+  "fullName": "newrelic/nri-statsd",
+  "slug": "newrelic-nri-statsd",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic StatsD Integration",
+  "supportUrl": "https://discuss.newrelic.com/c/support-products-agents/new-relic-infrastructure",
+  "githubUrl": "https://github.com/newrelic/nri-statsd",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/nri-statsd",
+  "defaultBranch": "master",
+  "contributingGuideUrl": "https://github.com/newrelic/nri-statsd/blob/master/CONTRIBUTING.md",
+  "iconUrl": null,
+  "shortDescription": "Easily get StatsD data into New Relic",
+  "description": "The StatsD integration lets you easily get StatsD data into New Relic. You can also add any arbitrary tags (key-value pairs) to your data. Once your data are in New Relic, you can query your data and create custom charts and dashboards.",
+  "ossCategory": "community-plus",
+  "primaryLanguage": "Shell",
+  "projectTags": ["nri"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic StatsD Integration",
+    "url": "https://github.com/newrelic/nri-statsd"
+  }
+}

--- a/src/data/projects/newrelic-nri-varnish.json
+++ b/src/data/projects/newrelic-nri-varnish.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for Varnish caching",
   "description": "Capture critical performance metrics and inventory reported by Varnish caching",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Varnish Integration",

--- a/src/data/projects/newrelic-nri-vsphere.json
+++ b/src/data/projects/newrelic-nri-vsphere.json
@@ -13,9 +13,11 @@
   "iconUrl": null,
   "shortDescription": "Monitoring for the VMware vSphere",
   "description": "Captures critical summary metrics and inventory data by connecting to the vCenter or to an ESXi Host",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": ["nri"],
+  "projectTags": [
+    "nri"
+  ],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure VMware vSpere Integration",

--- a/src/data/projects/newrelic-nri-winservices.json
+++ b/src/data/projects/newrelic-nri-winservices.json
@@ -1,0 +1,26 @@
+{
+  "name": "nri-winservices",
+  "fullName": "newrelic/nri-winservices",
+  "slug": "newrelic-nri-winservices",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic Windows Services integration",
+  "supportUrl": "https://discuss.newrelic.com/c/support-products-agents/new-relic-infrastructure",
+  "githubUrl": "https://github.com/newrelic/nri-winservices",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/nri-winservices",
+  "defaultBranch": "master",
+  "contributingGuideUrl": "https://github.com/newrelic/nri-winservices/blob/master/CONTRIBUTING.md",
+  "iconUrl": null,
+  "shortDescription": "Windows services Integration for New Relic Infrastructure",
+  "description": "New Relic's Windows Services integration collects data from the services running on your Windows hosts into our platform. You can check the state, status, and start mode of each service, find out which hosts are running a service, add services to workloads, set up alerts for services, and more.",
+  "ossCategory": "community-plus",
+  "primaryLanguage": "Go",
+  "projectTags": ["nri"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Windows Services integration",
+    "url": "https://github.com/newrelic/nri-winservices"
+  }
+}


### PR DESCRIPTION
This PR addresses https://github.com/newrelic/opensource-website/issues/620 by changing the following repositories categories to `community-plus`:
* go-agent
* infrastructure-agent
* newrelic-dotnet-agent
* newrelic-python-agent
* newrelic-ruby-agent
* node-newrelic
* newrelic-java-agent
* infrastructure-bundle
* java-log-extensions
* newrelic-logenricher-dotnet
* newrelic-monolog-logenricher-php
* newrelic-winston-logenricher-node
* node-newrelic-aws-sdk
* node-newrelic-koa
* node-newrelic-mysql
* node-newrelic-superagent
* nri-apache
* nri-cassandra
* nri-consul
* nri-couchbase
* nri-discovery-kubernetes
* nri-docker
* nri-ecs
* nri-elasticsearch
* nri-f5
* nri-flex
* nri-haproxy
* nri-jmx
* nri-kafka
* nri-kube-events
* nri-kubernetes
* nri-memcached
* nri-mongodb
* nri-mssql
* nri-mysql
* nri-nagios
* nri-nginx
* nri-oracledb
* nri-postgresql
* nri-prometheus
* nri-rabbitmq
* nri-redis
* nri-snmp
* nri-varnish
* nri-vsphere
* aws-log-ingestion
* k8s-metadata-injection
* k8s-webhook-cert-manager

The following repositories were added to the opensource-website and given the category of Community Plus:
* nri-statsd
* nri-winservices
