### PR TITLE
chore: upgreade newrelic-node-native-metrics to community-plus

### DIFF
--- a/src/data/projects/newrelic-node-native-metrics.json
+++ b/src/data/projects/newrelic-node-native-metrics.json
@@ -13,7 +13,7 @@
   "iconUrl": null,
   "shortDescription": "Native Metrics for the Node Agent",
   "description": "Optional native module for collecting low-level Node & V8 metrics",
-  "ossCategory": "community-project",
+  "ossCategory": "community-plus",
   "primaryLanguage": "C++",
   "projectTags": ["agent", "exporter"],
   "acceptsContributions": true,


### PR DESCRIPTION
This PR upgrades newrelic-node-native-metrics to the community-plus category.
