### PR TITLE
chore: Reverting newrelic/node-newrelic-mysql to Experimental

### DIFF
--- a/src/data/projects/newrelic-node-newrelic-mysql.json
+++ b/src/data/projects/newrelic-node-newrelic-mysql.json
@@ -13,7 +13,7 @@
   "iconUrl": null,
   "shortDescription": "Node Agent instumentation for MySQL",
   "description": "MySQL instrumentation for New Relic's Node Agent",
-  "ossCategory": "community-plus",
+  "ossCategory": "new-relic-experimental",
   "primaryLanguage": "JavaScript",
   "projectTags": [
     "agent",


### PR DESCRIPTION
This PR reverts the `newrelic/node-newrelic-mysql` package back to `new-relic-experimental`.  The `community-plus` categorization was incorrect and related to the existence of the "in agent" MySQL instrumentation.  We regret the error. 