### PR TITLE
chore: Add newrelic-jfr-reporter repo to OSS site

### DIFF
--- a/src/data/project-main-content/newrelic-newrelic-jfr-reporter.mdx
+++ b/src/data/project-main-content/newrelic-newrelic-jfr-reporter.mdx
@@ -1,0 +1,16 @@
+---
+path: "/projects/newrelic/newrelic-jfr-reporter"
+date: "09/10/2020"
+title: "New Relic JFR Reporter Extension"
+projectConfig: "src/data/projects/newrelic-newrelic-jfr-reporter.json"
+---
+
+import { Link } from 'gatsby';
+
+Java agent extension to send JFR data to MELT endpoints via telemetry SDK.
+
+# Getting Started
+
+Go to the <Link to="https://github.com/newrelic/newrelic-jfr-reporter/blob/main/README.md">README</Link> for setup, usage details, and a complete list of features.
+
+

--- a/src/data/projects/newrelic-newrelic-jfr-reporter.json
+++ b/src/data/projects/newrelic-newrelic-jfr-reporter.json
@@ -1,0 +1,26 @@
+{
+  "name": "newrelic-jfr-reporter",
+  "fullName": "newrelic/newrelic-jfr-reporter",
+  "slug": "newrelic-newrelic-jfr-reporter",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic JFR Reporter Extension",
+  "supportUrl": "https://discuss.newrelic.com/tags/javaagent",
+  "githubUrl": "https://github.com/newrelic/newrelic-jfr-reporter",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/newrelic-jfr-reporter",
+  "defaultBranch": "main",
+  "contributingGuideUrl": "https://github.com/newrelic/newrelic-jfr-reporter/blob/main/CONTRIBUTING.md",
+  "iconUrl": null,
+  "shortDescription": "New Relic JFR Reporter Extension",
+  "description": "Java agent extension to send JFR data to MELT endpoints via telemetry SDK",
+  "ossCategory": "community-project",
+  "primaryLanguage": "Java",
+  "projectTags": ["agent", "exporter", "opentelemetry"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic JFR Reporter Extension",
+    "url": "https://github.com/newrelic/newrelic-jfr-reporter"
+  }
+}


### PR DESCRIPTION
Adds newly open sourced repo: https://github.com/newrelic/newrelic-jfr-reporter