### PR TITLE
DO NOT MERGE YET chore: add adobe node-openwhisk-newrelic project

### DIFF
--- a/src/data/projects/adobe-node-openwhisk-newrelic.json
+++ b/src/data/projects/adobe-node-openwhisk-newrelic.json
@@ -1,0 +1,23 @@
+{
+  "name": "node-openwhisk-newrelic",
+  "fullName": "adobe/node-openwhisk-newrelic",
+  "slug": "adobe-node-openwhisk-newrelic",
+  "owner": {
+    "login": "adobe",
+    "type": "Organization"
+  },
+  "title": "Node OpenWhisk New Relic",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/adobe/node-openwhisk-newrelic",
+  "permalink": "https://opensource.newrelic.com/projects/adobe/node-openwhisk-newrelic",
+  "iconUrl": null,
+  "shortDescription": "Apache OpenWhisk to New Relic",
+  "description": "Library for gathering metrics from Apache OpenWhisk actions and sending them to New Relic.",
+  "ossCategory": "tbd",
+  "primaryLanguage": "JavaScript",
+  "projectTags": [ "agent" ],
+  "website": {
+    "title": "Node OpenWhisk New Relic",
+    "url": "https://github.com/adobe/node-openwhisk-newrelic"
+  }
+}


### PR DESCRIPTION
Adding external open source New Relic integration from Adobe. We need to adjust processes to include project-stats for `outside` configs.

cc: @n-zimmermann
