### PR TITLE
chore(newrelic-node-apollo-server-plugin): add New Relic Apollo Serve…

### DIFF
--- a/src/data/project-main-content/newrelic-newrelic-node-apollo-server-plugin.mdx
+++ b/src/data/project-main-content/newrelic-newrelic-node-apollo-server-plugin.mdx
@@ -1,0 +1,62 @@
+---
+path: "/projects/newrelic/newrelic-node-apollo-server-plugin"
+date: "10/23/2020"
+title: "New Relic Apollo Server plugin"
+projectConfig: "src/data/projects/newrelic-newrelic-node-apollo-server-plugin.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/newrelic-node-apollo-server-plugin) for setup and usage details.
+
+<!--
+
+import { Link } from 'gatsby';
+
+<div className="responsive-video">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/7wnav6Fu9T0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<Link to="/cta">Install</Link>
+
+## [Optional] Features
+
+### [Optional] Feature 1
+
+### [Optional] Feature 2
+
+## [Required] Getting Started
+
+### [Optional] Code example highlighting an extension or customization point
+
+This is how you extend New Relic Node Agent in following way.
+
+```js
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// I'm a comment;
+const aMadeUpFunction = () => {
+if (myArray.length !== 100) {
+  myArray.map((item, i) => item * i);
+} else {
+  return null
+}
+};
+```
+### [Optional] More details about the project
+
+## [Optional] What people are saying
+
+Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit.
+
+> [name="Leslie Webb"] Vitae enim egestas egestas at gravida arcu, amet in. Facilisis at
+massa amet, aliquet dui semper. Sit placerat sed et ornare faucibus
+egestas sit nisl, diam.
+
+> [name="Bildad the Shuhite"] Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+vestibulum. Maecenas faucibus mollis interdum. Maecenas sed diam
+eget risus varius blandit sit amet non magna.
+-->

--- a/src/data/projects/newrelic-newrelic-node-apollo-server-plugin.json
+++ b/src/data/projects/newrelic-newrelic-node-apollo-server-plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "newrelic-node-apollo-server-plugin",
+  "fullName": "newrelic/newrelic-node-apollo-server-plugin",
+  "slug": "newrelic-newrelic-node-apollo-server-plugin",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic Apollo Server plugin",
+  "supportUrl": "https://discuss.newrelic.com/tags/c/telemetry-data-platform/agents/nodeagent",
+  "githubUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/newrelic-node-apollo-server-plugin",
+  "defaultBranch": "main",
+  "contributingGuideUrl": null,
+  "iconUrl": null,
+  "shortDescription": "New Relic's official Apollo Server plugin.",
+  "description": "New Relic's official Apollo Server plugin for use with the Node.js agent.",
+  "ossCategory": "community-plus",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["agent"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Apollo Server plugin",
+    "url": "https://github.com/newrelic/newrelic-node-apollo-server-plugin"
+  }
+}


### PR DESCRIPTION
Adds the new [Apollo GraphQL plugin](https://github.com/newrelic/newrelic-node-apollo-server-plugin) to the website