### PR TITLE
chore: added Quickstarts project

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,7 @@ jobs:
           if [ -z "$PROJECT_FILES" ]; then
             echo "No project json files detected."
           else
-            echo ::set-env name=PROJECT_FILES::$PROJECT_FILES
+            echo name=PROJECT_FILES::$PROJECT_FILES >>$GITHUB_ENV
           fi
 
       - name: Run Project Tags Check
@@ -128,7 +128,7 @@ jobs:
               // Set Error Annotation for Results
               if (errors.length > 0) {
                 core.setFailed(
-                `There are errors with the <projectTags> mapping. For more info, visit https://github.com/newrelic/opensource-website/wiki/Contributing-Project-Data#note-about-projectTags. 
+                `There are errors with the <projectTags> mapping. For more info, visit https://github.com/newrelic/opensource-website/wiki/Contributing-Project-Data#note-about-projectTags.
                 Errors: ${JSON.stringify(errors, null, 2)}`)
               }
             }

--- a/src/data/projects/newrelic-experimental-quickstarts.json
+++ b/src/data/projects/newrelic-experimental-quickstarts.json
@@ -1,0 +1,24 @@
+{
+  "name": "quickstarts",
+  "fullName": "newrelic-experimental/quickstarts",
+  "slug": "newrelic-experimental-quickstarts",
+  "owner": {
+    "login": "newrelic-experimental",
+    "type": "Organization"
+  },
+  "title": "New Relic Quickstarts",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic-experimental/quickstarts",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic-experimental/quickstarts",
+  "iconUrl": null,
+  "shortDescription": "New Relic quickstarts",
+  "description": "A Community repository of New Relic dashboards, alerts, and installation instructions.",
+  "ossCategory": "new-relic-one-catalog-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["template"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Quickstarts",
+    "url": "https://github.com/newrelic-experimental/quickstarts"
+  }
+}

--- a/src/data/projects/newrelic-experimental-quickstarts.json
+++ b/src/data/projects/newrelic-experimental-quickstarts.json
@@ -12,7 +12,7 @@
   "permalink": "https://opensource.newrelic.com/projects/newrelic-experimental/quickstarts",
   "iconUrl": null,
   "shortDescription": "New Relic quickstarts",
-  "description": "A Community repository of New Relic dashboards, alerts, and installation instructions.",
+  "description": "A community repository of New Relic dashboards, alerts, and installation instructions.",
   "ossCategory": "new-relic-one-catalog-project",
   "primaryLanguage": "JavaScript",
   "projectTags": ["template"],


### PR DESCRIPTION
adds the quickstarts project to the OSS Site
set env to new GH format based on this article: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
