### PR TITLE
fix: support multi-line env var

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,9 @@ jobs:
           if [ -z "$PROJECT_FILES" ]; then
             echo "No project json files detected."
           else
-            echo name=PROJECT_FILES::$PROJECT_FILES >>$GITHUB_ENV
+            echo "PROJECT_FILES<<EOF" >> $GITHUB_ENV
+            echo $PROJECT_FILES >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
           fi
 
       - name: Run Project Tags Check


### PR DESCRIPTION
@jpvajda This is an additional fix for the set-env fix you applied earlier. I borrowed this same code for some work we're doing in the open-install-library. For this: 

`PROJECT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "src/data/projects" || true)`

If multiple lines match that grep statement, the env-var needs to be set like I've included in this PR. 

open-install-library ref: https://github.com/newrelic/open-install-library/commit/4081ea23aad0c9adfed204ca6232c8f09d4f928d#diff-252ba10f2c12f181d79ca1f94e44360061f4a28a8b52c7a7f0bc3f152f2564be