### PR TITLE
chore: updated infra tags

### DIFF
--- a/src/data/project-tags/project-tags.json
+++ b/src/data/project-tags/project-tags.json
@@ -56,10 +56,6 @@
     "slug": "logging"
   },
   {
-    "title": "Infrastructure",
-    "slug": "infrastructure"
-  },
-  {
     "title": "Library",
     "slug": "lib"
   },

--- a/src/data/projects/newrelic-experimental-newrelic-kafka-playground.json
+++ b/src/data/projects/newrelic-experimental-newrelic-kafka-playground.json
@@ -17,7 +17,7 @@
   "description": "Using standard configuration management tools, deploy a full Kafka cluster to AWS, complete with producer and consumer applications.  Instrumented end-to-end with New Relic.",
   "ossCategory": "new-relic-experimental",
   "primaryLanguage": "Java",
-  "projectTags": ["tools", "infrastructure", "terraform"],
+  "projectTags": ["tools", "nri", "terraform"],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Kafka Playground",

--- a/src/data/projects/newrelic-infra-identity-client-go.json
+++ b/src/data/projects/newrelic-infra-identity-client-go.json
@@ -17,7 +17,7 @@
   "description": "Go auto-generated client for the OpenAPI Infrastructure Identity Client",
   "ossCategory": "community-project",
   "primaryLanguage": "Go",
-  "projectTags": ["infrastructure", "lib"],
+  "projectTags": ["nri", "lib"],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Infrastructure Identity - Go lang client",

--- a/src/data/projects/newrelic-nr1-cloud-optimize.json
+++ b/src/data/projects/newrelic-nr1-cloud-optimize.json
@@ -15,7 +15,7 @@
   "description": "Identify right-sizing opportunities and potential savings of your cloud environment (AWS, GCP, or Azure)",
   "ossCategory": "new-relic-one-catalog-project",
   "primaryLanguage": "JavaScript",
-  "projectTags": ["nr1-app", "infrastructure"],
+  "projectTags": ["nr1-app", "nri"],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic One Cloud Optimize",

--- a/src/data/projects/newrelic-nri-ecs.json
+++ b/src/data/projects/newrelic-nri-ecs.json
@@ -17,10 +17,7 @@
   "description": "Collects metrics from ECS clusters and containers in AWS.",
   "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": [
-    "nri",
-    "infrastructure"
-  ],
+  "projectTags": ["nri"],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Integration for Amazon ECS",

--- a/src/data/projects/newrelic-nri-kube-events.json
+++ b/src/data/projects/newrelic-nri-kube-events.json
@@ -17,11 +17,7 @@
   "description": "Event router for the Kubernetes project. The event router serves as an active watcher of event resource in the Kubernetes system, which takes those events and pushes them to a list of configured sinks.",
   "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": [
-    "nri",
-    "infrastructure",
-    "k8"
-  ],
+  "projectTags": ["nri", "k8"],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Integration for Kubernetes Events ",

--- a/src/data/projects/newrelic-nri-kubernetes.json
+++ b/src/data/projects/newrelic-nri-kubernetes.json
@@ -17,11 +17,7 @@
   "description": "Instruments the container orchestration layer by reporting metrics from Kubernetes objects. It gives you visibility about Kubernetes namespaces, deployments, replica sets, nodes, pods, and containers",
   "ossCategory": "community-plus",
   "primaryLanguage": "Go",
-  "projectTags": [
-    "nri",
-    "infrastructure",
-    "k8"
-  ],
+  "projectTags": ["nri", "k8"],
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Integration for Kubernetes ",

--- a/src/data/projects/newrelic-terraform-newrelic-apm.json
+++ b/src/data/projects/newrelic-terraform-newrelic-apm.json
@@ -14,7 +14,7 @@
   "shortDescription": "Terraform provider APM",
   "description": "Terraform module for New Relic application monitoring",
   "ossCategory": "community-project",
-  "projectTags": ["infrastructure"],
+  "projectTags": ["nri"],
   "primaryLanguage": "HCL",
   "acceptsContributions": true,
   "website": {


### PR DESCRIPTION
This PR removes the infrastructure tag and replaces each of those projects with the nri (New Relic Infrastructure) tag for consistency with how we tag these projects. 

Issue: https://github.com/newrelic/opensource-website/issues/459