### PR TITLE
chore: Change the link to oss-categories page to include / at the end…

### DIFF
--- a/src/templates/project-page.js
+++ b/src/templates/project-page.js
@@ -411,7 +411,7 @@ const ProjectPage = (props) => {
             {ossCategory && (
               <div className={styles.callToActionCategorySpecification}>
                 <h5 className={styles.callToActionCategory}>
-                  <Link to="/oss-category" rel="noopener noreferrer">
+                  <Link to="/oss-category/" rel="noopener noreferrer">
                     {project.ossCategory.title}
                   </Link>
                 </h5>


### PR DESCRIPTION
…, so anchor links will work after redirect. This should solve the anchor issue on the oss-categories page when you arrive there from any project page.