### PR TITLE
Add visualization project tag and visualization repos

### DIFF
--- a/src/data/project-tags/project-tags.json
+++ b/src/data/project-tags/project-tags.json
@@ -110,5 +110,9 @@
   {
     "title": "Mobile",
     "slug": "mobile"
+  }, 
+  {
+    "title": "Visualizations", 
+    "slug": "visualizations"
   }
 ]

--- a/src/data/projects/newrelic-experimental-nerd-vlog-demo-visualization.json
+++ b/src/data/projects/newrelic-experimental-nerd-vlog-demo-visualization.json
@@ -1,0 +1,26 @@
+{
+  "name": "nerd-vlog-demo-visualization",
+  "fullName": "newrelic-experimental/nerd-vlog-demo-visualization",
+  "slug": "newrelic-experimental-nerd-vlog-demo-visualization",
+  "owner": {
+    "login": "newrelic-experimental",
+    "type": "Organization"
+  },
+  "title": "Nerd Log Demo Visualization",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic-experimental/nerd-vlog-demo-visualization",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic-experimental/nerd-vlog-demo-visualization",
+  "defaultBranch": "main",
+  "contributingGuideUrl": "https://github.com/newrelic-experimental/nerd-vlog-demo-visualization/blob/main/CONTRIBUTING.md",
+  "iconUrl": "https://github.com/newrelic-experimental/nerd-vlog-demo-visualization/blob/main/icon.png?raw=true",
+  "shortDescription": "Example Nerdpack with a Visualization",
+  "description": "This is an example Nerdpack with a Visualization that was built during the NerdLog session the last week of February 2021.",
+  "ossCategory": "new-relic-one-catalog-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["visualization"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "Nerd Log Demo Visualization",
+    "url": "https://github.com/newrelic-experimental/nerd-vlog-demo-visualization"
+  }
+}

--- a/src/data/projects/newrelic-experimental-nerd-vlog-demo-visualization.json
+++ b/src/data/projects/newrelic-experimental-nerd-vlog-demo-visualization.json
@@ -15,7 +15,7 @@
   "iconUrl": "https://github.com/newrelic-experimental/nerd-vlog-demo-visualization/blob/main/icon.png?raw=true",
   "shortDescription": "Example Nerdpack with a Visualization",
   "description": "This is an example Nerdpack with a Visualization that was built during the NerdLog session the last week of February 2021.",
-  "ossCategory": "new-relic-one-catalog-project",
+  "ossCategory": "new-relic-experimental",
   "primaryLanguage": "JavaScript",
   "projectTags": ["visualization"],
   "acceptsContributions": true,

--- a/src/data/projects/newrelic-experimental-nr1-funnelz.json
+++ b/src/data/projects/newrelic-experimental-nr1-funnelz.json
@@ -1,0 +1,26 @@
+{
+  "name": "nr1-funnelz",
+  "fullName": "newrelic-experimental/nr1-funnelz",
+  "slug": "newrelic-experimental-nr1-funnelz",
+  "owner": {
+    "login": "newrelic-experimental",
+    "type": "Organization"
+  },
+  "title": "nr1-funnelz",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic-experimental/nr1-funnelz",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic-experimental/nr1-funnelz",
+  "defaultBranch": "main",
+  "contributingGuideUrl": null,
+  "iconUrl": "https://github.com/newrelic-experimental/nr1-funnelz/blob/main/icon.png?raw=true",
+  "shortDescription": "NewRelic nr1 funnel visualization, based on funnel-graph.js",
+  "description": "NewRelic nr1 funnel visualization, based on funnel-graph.js",
+  "ossCategory": "new-relic-experimental",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["visualization"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "nr1-funnelz",
+    "url": "https://github.com/newrelic-experimental/nr1-funnelz"
+  }
+}


### PR DESCRIPTION
## Summary 
Adds a visualization project tag! We're trying to get visualizations their own project tag on the opensource website and begin to add more repos that hopefully users can refer to when building their own visualizations! 

Additionally this adds two visualization repos to the opensource website: 
* nr1-funnelz 
* Nerd Log Demo Visualization

<img width="1427" alt="Screen Shot 2021-03-18 at 7 31 26 PM" src="https://user-images.githubusercontent.com/38332422/111710716-92e8e680-8820-11eb-8fdb-16c9e56b059c.png">
