### PR TITLE
chore: missing yarn configurations

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,8 +26,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -65,8 +65,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -154,8 +154,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -200,8 +200,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,8 +26,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -65,8 +65,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -154,8 +154,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -200,8 +200,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 

--- a/.github/workflows/project-stats.yml
+++ b/.github/workflows/project-stats.yml
@@ -73,8 +73,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 

--- a/.github/workflows/project-stats.yml
+++ b/.github/workflows/project-stats.yml
@@ -73,8 +73,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -62,8 +62,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -133,8 +133,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn.lock
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -62,8 +62,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -133,8 +133,8 @@ jobs:
         env:
           cache-name: node-modules
         with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.yarn.lock
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/node_modules') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 

--- a/.releaserc
+++ b/.releaserc
@@ -11,7 +11,7 @@
             "npmPublish": false
         }],
         ["@semantic-release/git", {
-            "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+            "assets": ["CHANGELOG.md", "package.json", "yarn.lock"],
             "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
         }]
     ],


### PR DESCRIPTION
This PR fixes some settings in the yml files that were still pointing to the package-lock.json file and also corrects the path to be yarn.lock. 