### PR TITLE
chore: removed old gdpr package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "feather-icons": "^4.28.0",
     "gatsby": "^2.32.8",
     "gatsby-image": "^2.11.0",
-    "gatsby-plugin-gdpr-tracking": "https://github.com/tangollama/gatsby-plugin-gdpr-tracking.git",
     "gatsby-plugin-manifest": "^2.12.0",
     "gatsby-plugin-mdx": "^1.10.0",
     "gatsby-plugin-offline": "^3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7860,13 +7860,6 @@ gatsby-plugin-emotion@^4.3.10:
     "@babel/runtime" "^7.12.5"
     "@emotion/babel-preset-css-prop" "^10.0.27"
 
-"gatsby-plugin-gdpr-tracking@https://github.com/tangollama/gatsby-plugin-gdpr-tracking.git":
-  version "1.1.0"
-  resolved "https://github.com/tangollama/gatsby-plugin-gdpr-tracking.git#be29d416f3e2a29a5e9a3b243da2acd0de7a3fac"
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    js-cookie "^2.2.1"
-
 gatsby-plugin-layout@^1.8.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-layout/-/gatsby-plugin-layout-1.10.0.tgz#6b058e51d995d33ee0d020f6f136878a3d5a7c39"


### PR DESCRIPTION
This PR removes the old gdpr package we used for cookie consent as we now have that built into our theme.