### PR TITLE
fix: update node version in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12
 
       - name: Download Cached Deps
         id: cache-node-modules


### PR DESCRIPTION
Some of the workflows were still specifying node 10, this updates them all to node 12.