### PR TITLE
chore: Changing all relevant references of master to main branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     branches:
       - develop
-      - master
+      - main
   repository_dispatch:
-    types: [pull-request-develop, pull-request-master]
+    types: [pull-request-develop, pull-request-main]
 
 jobs:
   job-checkout-and-build:
@@ -38,7 +38,7 @@ jobs:
         run: |
           if [ '${{ github.base_ref }}' = 'develop' ]; then
             yarn run build:staging
-          elif [ '${{ github.base_ref }}' = 'master' ]; then
+          elif [ '${{ github.base_ref }}' = 'main' ]; then
             yarn run build:production
           else
             echo "::error::Pull Request opened on unsupported branch. Exiting."

--- a/.github/workflows/project-stats.yml
+++ b/.github/workflows/project-stats.yml
@@ -39,15 +39,15 @@ jobs:
           git add src/data
           git commit -m "chore(stats): updated project stats files"
 
-          # Push to both develop and master here rather than using github-push-action
+          # Push to both develop and main here rather than using github-push-action
           echo "Pushing to develop"
           git push origin develop
           CHERRYCOMMIT=`git log -n1 | head -n1 | cut -c8-`
 
-          echo "Pushing to master"
-          git checkout master
+          echo "Pushing to main"
+          git checkout main
           git cherry-pick $CHERRYCOMMIT
-          git push origin master
+          git push origin main
 
       # - name: Push Commit
       #   uses: ad-m/github-push-action@v0.6.0
@@ -85,7 +85,7 @@ jobs:
         run: |
           if [ '${{ github.ref }}' = 'refs/heads/develop' ]; then
             yarn run build:staging
-          elif [ '${{ github.ref }}' = 'refs/heads/master' ]; then
+          elif [ '${{ github.ref }}' = 'refs/heads/main' ]; then
             yarn run build:production
           else
             echo "::error::Running on unsupported branch. Exiting."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Contributions are always welcome. Before contributing please read the
-[code of conduct](./CODE_OF_CONDUCT.md) and [search the issue tracker](issues); your issue may have already been discussed or fixed in `master`. To contribute,
+[code of conduct](./CODE_OF_CONDUCT.md) and [search the issue tracker](issues); your issue may have already been discussed or fixed in `main`. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
 Note that our [code of conduct](./CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.

--- a/amplify.yml
+++ b/amplify.yml
@@ -8,7 +8,7 @@ frontend:
     build:
       commands:
         - |
-          if [ "${AWS_BRANCH}" = "master" ]; then
+          if [ "${AWS_BRANCH}" = "main" ]; then
             yarn run build:production;
           else
             yarn run build:production;

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -8,11 +8,11 @@ Every few hours as based on [this configuration](https://github.com/newrelic/ope
 
 1. Retrieve the latest stats from GitHub for each [newrelic](https://github.com/newrelic) and [newrelic-experimental](https://github.com/newrelic-experimental) project registered in the [projects](https://github.com/newrelic/opensource-website/tree/develop/src/data/projects) directory using the GitHub v3 and v4 API's
 2. Write that data to the [staging/develop branch](https://github.com/newrelic/opensource-website/tree/develop/)
-3. Selectively write the [develop](https://github.com/newrelic/opensource-website/tree/develop/) commit to the [production/master branch](https://github.com/newrelic/opensource-website/tree/master)
+3. Selectively write the [develop](https://github.com/newrelic/opensource-website/tree/develop/) commit to the [production/main branch](https://github.com/newrelic/opensource-website/tree/main)
 4. Kick off builds to both the [staging](https://staging-opensource.newrelic.com) and [production](https://opensource.newrelic.com) environments **without** revisioning the sites
 
 This was chosen so that functional changes in the [develop](https://github.com/newrelic/opensource-website/tree/develop/) branch could be tested, reviewed, and merged intentionally while automated content updates would be kept up-to-date in both branches.
 
-The consequence of this choice is that the commit to the [develop](https://github.com/newrelic/opensource-website/tree/develop/) branch is not the same identifier as the commit to the [master](https://github.com/newrelic/opensource-website/tree/master) branch for precisely the same change. In the case of a PR, from [staging](https://github.com/newrelic/opensource-website/tree/develop/) to [production](https://github.com/newrelic/opensource-website/tree/master), the commit histories will appear (in those areas) out of sync, without generating a merge conflict.
+The consequence of this choice is that the commit to the [develop](https://github.com/newrelic/opensource-website/tree/develop/) branch is not the same identifier as the commit to the [main](https://github.com/newrelic/opensource-website/tree/main) branch for precisely the same change. In the case of a PR, from [staging](https://github.com/newrelic/opensource-website/tree/develop/) to [production](https://github.com/newrelic/opensource-website/tree/main), the commit histories will appear (in those areas) out of sync, without generating a merge conflict.
 
 Two commits for the same change isn't optimal, but it's the choice the original maintainers made. Feel free to criticize (and suggest a better solution) in an [issue](https://github.com/newrelic/opensource-website/issues).

--- a/docs/Build-and-Deploy.md
+++ b/docs/Build-and-Deploy.md
@@ -22,19 +22,19 @@ This site is deployed utilizing Github Actions for continuous integration (CI) c
 
 ### Project-Stats Generation
 
-Every 4 hours, the project-stats workflow kicks off. After running this Action, it will commit and push to both the `develop` and `master` branch. Then, this will trigger builds on Amplify.
+Every 4 hours, the project-stats workflow kicks off. After running this Action, it will commit and push to both the `develop` and `main` branch. Then, this will trigger builds on Amplify.
 
 ## Staging/Production Deployment (CD)
 
-Amplify is connected to the `master` and `deploy` branches, and has webhooks set on the repo that listen for pushes to those branches. On push, an atomic deploy is triggered. If the build/deploy fails, the site will continue to run with the existing version.
+Amplify is connected to the `main` and `deploy` branches, and has webhooks set on the repo that listen for pushes to those branches. On push, an atomic deploy is triggered. If the build/deploy fails, the site will continue to run with the existing version.
 
 > Note: Any commit with `[skip-cd]` will bypass the build process in Amplify.
 
 ### Production Deployment
 
-**Production** deployments are exclusively handled through merging a Pull Request into the `master` branch. If an ad-hoc deployment is required, please reach out to a project maintainer.
+**Production** deployments are exclusively handled through merging a Pull Request into the `main` branch. If an ad-hoc deployment is required, please reach out to a project maintainer.
 
-**Opening a Pull Request**: the direction should be `develop` -> `master`. Once all checks have passed, merge via `Merge Pull Request` option (using `Create a merge commit` as the strategy). This will merge the commits in from develop (effectively "catching" `master` up with `develop`), plus issue the merge commit on top.
+**Opening a Pull Request**: the direction should be `develop` -> `main`. Once all checks have passed, merge via `Merge Pull Request` option (using `Create a merge commit` as the strategy). This will merge the commits in from develop (effectively "catching" `main` up with `develop`), plus issue the merge commit on top.
 
 **Merging**: use a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) message indicating this is a release:
 
@@ -48,11 +48,11 @@ The intent is: semantic-release issued a new tag/release on the `develop` branch
 chore(release): content updates but no new site features [vX.X.X]
 ```
 
-> Note: Since semantic-release is only running on the `develop` branch, there won't be a new tag/release cut from the master branch. We might revisit this idea in the future if the tooling evolves.
+> Note: Since semantic-release is only running on the `develop` branch, there won't be a new tag/release cut from the main branch. We might revisit this idea in the future if the tooling evolves.
 
 ### Staging Deployment
 
-**Staging** deployments will happen frequently, and should be used to QA changes prior to opening a Pull Request to `master`.
+**Staging** deployments will happen frequently, and should be used to QA changes prior to opening a Pull Request to `main`.
 
 These deployments happen automagically every time a commit is made to `develop`. This is handled via Amplify's Git-based continuous deployment.
 

--- a/docs/Emergency-Runbook.md
+++ b/docs/Emergency-Runbook.md
@@ -23,7 +23,7 @@ First, determine the desired previous build:
 Steps to redeploy in Amplify:
 
 1. Log into the Amplify Console via nr-prod okta.
-2. Select the `opensource-website` app. Under `Frontend environments`, select `master`.
+2. Select the `opensource-website` app. Under `Frontend environments`, select `main`.
    ![Amplify Console](https://github.com/newrelic/opensource-website/blob/develop/docs/images/screenshot_03.png)
 3. Click the `View build history` button to see all the previous builds that have run.
 4. Find the appropriate build corresponding to the release you located from the repo releases. This is the build to roll back to. Click `Build #xxx` to select that build. In this case, you'd select `Build #10`.
@@ -39,7 +39,7 @@ Note: When building the site, Gatsby coerces anything you've set in `NODE_ENV` t
 
 ### Production
 
-Corresponds to the [`master`](https://github.com/newrelic/opensource-website/master/develop) branch
+Corresponds to the [`main`](https://github.com/newrelic/opensource-website/main/develop) branch
 
 New Relic Domains: [https://opensource.newrelic.com](https://opensource.newrelic.com)
 

--- a/docs/Open-Source-Category-Snippets.md
+++ b/docs/Open-Source-Category-Snippets.md
@@ -15,7 +15,7 @@ Every public repository in the `newrelic` and `newrelic-experimental` GitHub org
 
 ## Category: [New Relic Experimental](#category-new-relic-experimental)
 
-[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
+[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
 
 ### Category Description and Requirements
 
@@ -26,12 +26,12 @@ See [here](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
 **Required:** Copy and paste the following into the **top** of your project's README.
 
 ```markdown
-[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
+[![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
 ```
 
 ## Category: [Community Project](#category-community-project)
 
-[![Community Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
+[![Community Project header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
 
 ### Category Description and Requirements
 
@@ -42,12 +42,12 @@ See [here](https://opensource.newrelic.com/oss-category/#community-project).
 **Required:** Copy and paste the following into the **top** of your project's README.
 
 ```markdown
-[![Community Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
+[![Community Project header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
 ```
 
 ## Category: [Community Plus](#category-community-plus)
 
-[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 ### Category Description and Requirements
 
@@ -58,12 +58,12 @@ See [here](https://opensource.newrelic.com/oss-category/#community-plus).
 **Required:** Copy and paste the following into the **top** of your project's README.
 
 ```markdown
-[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Community Plus header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 ```
 
 ## Category: [New Relic One Catalog Project](#category-new-relic-one-catalog-project)
 
-[![New Relic One Catalog Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/New_Relic_One_Catalog_Project.png)](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-project)
+[![New Relic One Catalog Project header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/New_Relic_One_Catalog_Project.png)](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-project)
 
 ### Category Description and Requirements
 
@@ -74,12 +74,12 @@ See [here](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-p
 **Required:** Copy and paste the following into the **top** of your project's README.
 
 ```markdown
-[![New Relic One Catalog Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/New_Relic_One_Catalog_Project.png)](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-project)
+[![New Relic One Catalog Project header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/New_Relic_One_Catalog_Project.png)](https://opensource.newrelic.com/oss-category/#new-relic-one-catalog-project)
 ```
 
 ## Category: [Example Code](#category-example-code)
 
-[![Example Code header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Example_Code.png)](https://opensource.newrelic.com/oss-category/#example-code)
+[![Example Code header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Example_Code.png)](https://opensource.newrelic.com/oss-category/#example-code)
 
 ### Category Description and Requirements
 
@@ -90,12 +90,12 @@ See [here](https://opensource.newrelic.com/oss-category/#example-code).
 **Required:** Copy and paste the following into the **top** of your project's README.
 
 ```markdown
-[![Example Code header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Example_Code.png)](https://opensource.newrelic.com/oss-category/#example-code)
+[![Example Code header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Example_Code.png)](https://opensource.newrelic.com/oss-category/#example-code)
 ```
 
 ## Category: [Archived](#category-archived)
 
-[![Archived header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Archived.png)](https://opensource.newrelic.com/oss-category/#archived)
+[![Archived header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Archived.png)](https://opensource.newrelic.com/oss-category/#archived)
 
 ### Category Description and Requirements
 
@@ -106,5 +106,5 @@ See [here](https://opensource.newrelic.com/oss-category/#archived).
 **Required:** Copy and paste the following into the **top** of your project's README.
 
 ```markdown
-[![Archived header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Archived.png)](https://opensource.newrelic.com/oss-category/#archived)
+[![Archived header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Archived.png)](https://opensource.newrelic.com/oss-category/#archived)
 ```

--- a/docs/Project-Structure.md
+++ b/docs/Project-Structure.md
@@ -1,7 +1,7 @@
 This project is made up of a few components:
 
 - React code, components, and page templates built primarily in [MDX](https://mdxjs.com/)
-- Static [data](https://github.com/newrelic/opensource-website/tree/master/src/data) for each open source project listed and promoted on the site, including:
+- Static [data](https://github.com/newrelic/opensource-website/tree/main/src/data) for each open source project listed and promoted on the site, including:
   - `project metadata` in the data/projects directory
   - `project stats` in the data/project-stats directory
   - `markdown content` in the data/project-main-content directory

--- a/src/templates/project-page.js
+++ b/src/templates/project-page.js
@@ -351,7 +351,7 @@ const ProjectPage = (props) => {
                   href={
                     project.contributingGuideUrl ||
                     `${project.githubUrl}/blob/${
-                      project.defaultBranch || 'master'
+                      project.defaultBranch || 'main'
                     }/CONTRIBUTING.md`
                   }
                   target="__blank"


### PR DESCRIPTION
Cycled through every reference to the `master` branch and changed them to `main`. Includes several docs pages and workflows to align with the changes already made to Amplify