### PR TITLE
fix: add branch protection handling in workflows

### DIFF
--- a/.github/workflows/project-stats.yml
+++ b/.github/workflows/project-stats.yml
@@ -27,6 +27,24 @@ jobs:
           github-token: ${{ secrets.NEWRELIC_BOT_TOKEN }} # must have push access to repos for stats queries to work
           project-stats: true
 
+      - name: Temporarily disable branch protection
+        id: disable-branch-protection
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'develop',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: null
+            })
+            console.log("Result:", result)
+
       - name: Commit data files
         run: |
           git config --local user.email "${{ env.THIRD_PARTY_GIT_AUTHOR_EMAIL }}"
@@ -49,11 +67,33 @@ jobs:
           git cherry-pick $CHERRYCOMMIT
           git push origin main
 
-      # - name: Push Commit
-      #   uses: ad-m/github-push-action@v0.6.0
-      #   with:
-      #     github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-      #     branch: ${{ github.ref }} #pushes to the branch that kicked off the job
+     - name: Re-enable branch protection
+        id: enable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'develop',
+              required_status_checks: {
+                strict: false,
+                contexts: ['Gatsby Build']
+              },
+              restrictions: {
+                users: [],
+                teams: []
+              },
+              enforce_admins: true,
+              required_pull_request_reviews: {
+                dismiss_stale_reviews: true,
+                required_approving_review_count: 1
+              }
+            })
+            console.log("Result:", result)
 
   job-checkout-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary
A quick PR to add jobs to disable and reenable branch protection during the "Project Stats" workflow.