### PR TITLE
Update gatsby theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
-    "@newrelic/gatsby-theme-newrelic": "2.2.0",
+    "@newrelic/gatsby-theme-newrelic": "2.2.2",
     "@splitsoftware/splitio-react": "^1.2.4",
     "date-fns": "^2.17.0",
     "feather-icons": "^4.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,10 +2049,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.2.0.tgz#9d0719c7084436354f5aab9112986aabd974e79f"
-  integrity sha512-0B3Mzs8KEm/p9aHE4pjyn2/u9tTFvd93X9TkZ5/JYeEKYTiLUvAg3CFPw+JWAP303lpGE7aoUsydFcLF91rAHw==
+"@newrelic/gatsby-theme-newrelic@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.2.2.tgz#342c68a56f94ba7a6c7316a4e75e0402b41d838d"
+  integrity sha512-ig9LC+p0BFDN8IzHc8Ny8QQbRSknCcVU9r/MvgreiEGxWKUp33kD07HohYMsax4eOaCa4SdjUPHWN8R3/OM2fw==
   dependencies:
     "@elastic/react-search-ui" "^1.5.1"
     "@elastic/react-search-ui-views" "^1.5.1"
@@ -2067,7 +2067,7 @@
     gatsby-plugin-react-helmet "^4.3.0"
     gatsby-plugin-robots-txt "^1.5.5"
     gatsby-plugin-sharp "^3.3.0"
-    gatsby-plugin-sitemap "^4.0.0-next.0"
+    gatsby-plugin-sitemap "^4.1.0-next.1"
     gatsby-plugin-use-dark-mode "^1.3.0"
     gatsby-source-filesystem "^3.3.0"
     gatsby-transformer-sharp "^3.3.0"
@@ -7884,10 +7884,10 @@ gatsby-plugin-sharp@^3.3.0:
     svgo "1.3.2"
     uuid "3.4.0"
 
-gatsby-plugin-sitemap@^4.0.0-next.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.0.0.tgz#65f2ef27362796ac145cec1d8dd05c790b50e1fc"
-  integrity sha512-+GxxKhB4Lm1AY+k9LfcnATF/LsUXiRHVwM3YDjzpB25WCGrGZGEgviZXiy4xb2BOZz0EoUkYZ9IDU9eNgAoHBQ==
+gatsby-plugin-sitemap@^4.1.0-next.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.1.0.tgz#13641c92b5b75bdc0d936acc26d99ea81913e341"
+  integrity sha512-ZpBnZLPE5eF+R9Zm0kuak6b+WlErTQfe4iWB0hTZ+1BDMVUg3FWpAg/PWt/o5NRr0ia7qLoY+StaAaJzGg0HeQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     common-tags "^1.8.0"


### PR DESCRIPTION
Updates to 2.2.2 which includes a reduction in console warnings and whitespace wrapping in codeblocks
