### PR TITLE
Add nr1-victory-visualizations listing

### DIFF
--- a/src/data/project-main-content/newrelic-nr1-victory-visualizations.mdx
+++ b/src/data/project-main-content/newrelic-nr1-victory-visualizations.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/projects/newrelic/nr1-victory-visualizations"
 date: "05/21/2021"
-title: "Victory visualizations"
+title: "Victory Visualizations"
 projectConfig: "src/data/projects/newrelic-nr1-victory-visualizations.json"
 ---
 

--- a/src/data/project-main-content/newrelic-nr1-victory-visualizations.mdx
+++ b/src/data/project-main-content/newrelic-nr1-victory-visualizations.mdx
@@ -1,0 +1,10 @@
+---
+path: "/projects/newrelic/nr1-victory-visualizations"
+date: "05/21/2021"
+title: "Victory visualizations"
+projectConfig: "src/data/projects/newrelic-nr1-victory-visualizations.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/nr1-victory-visualizations#readme) for setup and usage details.

--- a/src/data/projects/newrelic-nr1-victory-visualizations.json
+++ b/src/data/projects/newrelic-nr1-victory-visualizations.json
@@ -6,7 +6,7 @@
     "login": "newrelic",
     "type": "Organization"
   },
-  "title": "Victory visualizations",
+  "title": "Victory Visualizations",
   "supportUrl": "https://discuss.newrelic.com/tag/victoryvisualizations",
   "githubUrl": "https://github.com/newrelic/nr1-victory-visualizations",
   "permalink": "https://opensource.newrelic.com/projects/newrelic/nr1-victory-visualizations",
@@ -18,7 +18,7 @@
   "projectTags": ["visualizations"],
   "acceptsContributions": true,
   "website": {
-    "title": "Victory visualizations",
+    "title": "Victory Visualizations",
     "url": "https://github.com/newrelic/nr1-victory-visualizations"
   }
 }

--- a/src/data/projects/newrelic-nr1-victory-visualizations.json
+++ b/src/data/projects/newrelic-nr1-victory-visualizations.json
@@ -1,0 +1,24 @@
+{
+  "name": "nr1-victory-visualizations",
+  "fullName": "newrelic/nr1-victory-visualizations",
+  "slug": "nr1-victory-visualizations",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "Victory visualizations",
+  "supportUrl": "https://discuss.newrelic.com/tag/victoryvisualizations",
+  "githubUrl": "https://github.com/newrelic/nr1-victory-visualizations",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/nr1-victory-visualizations",
+  "iconUrl": "https://github.com/newrelic/nr1-victory-visualizations/blob/main/icon.png?raw=true",
+  "shortDescription": "NRQL-ready Victory charts",
+  "description": "NRQL-ready Victory charts",
+  "ossCategory": "new-relic-one-catalog-project",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["visualizations"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "Victory visualizations",
+    "url": "https://github.com/newrelic/nr1-victory-visualizations"
+  }
+}


### PR DESCRIPTION
Adds the [nr1-victory-visualizations](https://github.com/newrelic/nr1-victory-visualizations) project to the OSS site

