### PR TITLE
chore: Add Prebid Tracker json and metadata

### DIFF
--- a/src/data/project-main-content/newrelic-tracker-prebid-js.mdx
+++ b/src/data/project-main-content/newrelic-tracker-prebid-js.mdx
@@ -1,0 +1,9 @@
+---
+path: "/projects/newrelic/tracker-prebid-js"
+date: "7/8/2021"
+title: "New Relic Prebid Tracker"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/tracker-prebid-js#readme) for setup and usage details.

--- a/src/data/projects/newrelic-tracker-prebid-js.json
+++ b/src/data/projects/newrelic-tracker-prebid-js.json
@@ -1,0 +1,26 @@
+{
+  "name": "tracker-prebid-js",
+  "fullName": "newrelic/tracker-prebid-js",
+  "slug": "newrelic-tracker-prebid-js",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic Prebid Tracker",
+  "supportUrl": null,
+  "githubUrl": "https://github.com/newrelic/tracker-prebid-js",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/tracker-prebid-js",
+  "defaultBranch": "master",
+  "contributingGuideUrl": "https://github.com/newrelic/tracker-prebid-js/blob/master/CONTRIBUTING.md",
+  "iconUrl": null,
+  "shortDescription": "New Relic monitoring for Prebid",
+  "description": "Extend New Relic Browser + SPA Agent to monitor Prebid auctions and slots.",
+  "ossCategory": "new-relic-experimental",
+  "primaryLanguage": "JavaScript",
+  "projectTags": ["browser", "instrumentation"],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Prebid Tracker",
+    "url": "https://github.com/newrelic/tracker-prebid-js"
+  }
+}


### PR DESCRIPTION
Add prebid tracker metadata. As an FYI, the project page may not load for people with adblockers installed, but there's no real way around that without renaming the project beyond reason.