### PR TITLE
chore: add CAF project metadata

### DIFF
--- a/src/data/project-main-content/newrelic-video-caf-js.mdx
+++ b/src/data/project-main-content/newrelic-video-caf-js.mdx
@@ -1,0 +1,10 @@
+---
+path: "/projects/newrelic/video-caf-js"
+date: "07/08/2021"
+title: "New Relic CAF Tracker"
+projectConfig: "src/data/projects/newrelic-video-caf-js.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/video-caf-js#readme) for setup and usage details.

--- a/src/data/projects/newrelic-video-caf-js.json
+++ b/src/data/projects/newrelic-video-caf-js.json
@@ -1,0 +1,27 @@
+{
+	"name": "video-caf-js",
+	"fullName": "newrelic/video-caf-js",
+	"slug": "newrelic-video-caf-js",
+	"owner": {
+	  "login": "newrelic",
+	  "type": "Organization"
+	},
+	"title": "New Relic CAF Tracker",
+	"supportUrl": null,
+	"githubUrl": "https://github.com/newrelic/video-caf-js",
+	"permalink": "https://opensource.newrelic.com/projects/newrelic/video-caf-js",
+  "defaultBranch": "master",
+  "contributingGuideUrl": "https://github.com/newrelic/video-caf-js/blob/master/CONTRIBUTING.md",
+	"iconUrl": null,
+	"shortDescription": "Instrument CAF receivers",
+	"description": "Instrument the CAF receivers to calculate KPIs like Exit Before Video Start and Video Start Time.",
+	"ossCategory": "new-relic-experimental",
+	"projectTags": ["lib", "video"],
+	"primaryLanguage": "JavaScript",
+	"acceptsContributions": true,
+	"website": {
+	  "title": "New Relic CAF Tracker",
+	  "url": "https://github.com/newrelic/video-caf-js"
+	}
+      }
+      


### PR DESCRIPTION
@jpvajda Adding some metadata for an existing open source project, our chromecast tracker. Had to open close duplicate PR as the last one had a check that was hanging.