### PR TITLE
Update project-stats from main

### DIFF
--- a/src/data/project-stats/newrelic-.github.json
+++ b/src/data/project-stats/newrelic-.github.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 78,
-  "lastSixMonthsCommitTotal": 10,
+  "lastSixMonthsCommitTotal": 2,
   "contributors": 7,
   "pullRequests": {
     "open": 0
@@ -14,13 +14,6 @@
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 1
-    },
     {
       "id": 1428400,
       "login": "coreyarnold",
@@ -34,6 +27,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
       "htmlUrl": "https://github.com/jpvajda",
       "contributions": 2
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-absinthe-schema-stitching-example.json
+++ b/src/data/project-stats/newrelic-absinthe-schema-stitching-example.json
@@ -22,11 +22,11 @@
       "contributions": 4
     },
     {
-      "id": 6687220,
-      "login": "emeryotopalik",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6687220?v=4",
-      "htmlUrl": "https://github.com/emeryotopalik",
-      "contributions": 2
+      "id": 39946,
+      "login": "binaryseed",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39946?v=4",
+      "htmlUrl": "https://github.com/binaryseed",
+      "contributions": 4
     },
     {
       "id": 20426676,
@@ -43,11 +43,11 @@
       "contributions": 1
     },
     {
-      "id": 39946,
-      "login": "binaryseed",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39946?v=4",
-      "htmlUrl": "https://github.com/binaryseed",
-      "contributions": 4
+      "id": 6687220,
+      "login": "emeryotopalik",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6687220?v=4",
+      "htmlUrl": "https://github.com/emeryotopalik",
+      "contributions": 2
     },
     {
       "id": 2483839,

--- a/src/data/project-stats/newrelic-aws-log-ingestion.json
+++ b/src/data/project-stats/newrelic-aws-log-ingestion.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/aws-log-ingestion",
   "issues": {
-    "open": 10
+    "open": 11
   },
   "releases": 4,
   "latestRelease": {
@@ -32,18 +32,18 @@
       "contributions": 4
     },
     {
-      "id": 12360736,
-      "login": "prodjito",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12360736?v=4",
-      "htmlUrl": "https://github.com/prodjito",
+      "id": 41185214,
+      "login": "jotanavarro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41185214?v=4",
+      "htmlUrl": "https://github.com/jotanavarro",
       "contributions": 1
     },
     {
-      "id": 6243832,
-      "login": "jsubirat",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6243832?v=4",
-      "htmlUrl": "https://github.com/jsubirat",
-      "contributions": 1
+      "id": 73652669,
+      "login": "arvdias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
+      "htmlUrl": "https://github.com/arvdias",
+      "contributions": 3
     },
     {
       "id": 66844,
@@ -81,10 +81,10 @@
       "contributions": 1
     },
     {
-      "id": 41185214,
-      "login": "jotanavarro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/41185214?v=4",
-      "htmlUrl": "https://github.com/jotanavarro",
+      "id": 12360736,
+      "login": "prodjito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12360736?v=4",
+      "htmlUrl": "https://github.com/prodjito",
       "contributions": 1
     },
     {
@@ -102,11 +102,11 @@
       "contributions": 17
     },
     {
-      "id": 73652669,
-      "login": "arvdias",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
-      "htmlUrl": "https://github.com/arvdias",
-      "contributions": 3
+      "id": 6243832,
+      "login": "jsubirat",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6243832?v=4",
+      "htmlUrl": "https://github.com/jsubirat",
+      "contributions": 1
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-c-sdk.json
+++ b/src/data/project-stats/newrelic-c-sdk.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 53,
-  "lastSixMonthsCommitTotal": 2,
+  "lastSixMonthsCommitTotal": 0,
   "contributors": 7,
   "pullRequests": {
     "open": 3
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 48965776,
-      "login": "jodeev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
-      "htmlUrl": "https://github.com/jodeev",
-      "contributions": 2
+      "id": 229984,
+      "login": "LawnGnome",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/229984?v=4",
+      "htmlUrl": "https://github.com/LawnGnome",
+      "contributions": 5
     },
     {
       "id": 7992384,
@@ -60,11 +60,11 @@
       "contributions": 3
     },
     {
-      "id": 229984,
-      "login": "LawnGnome",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/229984?v=4",
-      "htmlUrl": "https://github.com/LawnGnome",
-      "contributions": 5
+      "id": 48965776,
+      "login": "jodeev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
+      "htmlUrl": "https://github.com/jodeev",
+      "contributions": 2
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-centurion.json
+++ b/src/data/project-stats/newrelic-centurion.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 19076,
-      "login": "kremso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19076?v=4",
-      "htmlUrl": "https://github.com/kremso",
-      "contributions": 5
+      "id": 3062663,
+      "login": "askl56",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3062663?v=4",
+      "htmlUrl": "https://github.com/askl56",
+      "contributions": 1
     },
     {
       "id": 33917,
@@ -32,25 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 176691,
-      "login": "jessedearing",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/176691?v=4",
-      "htmlUrl": "https://github.com/jessedearing",
-      "contributions": 7
-    },
-    {
-      "id": 6953072,
-      "login": "bryannewrelic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6953072?v=4",
-      "htmlUrl": "https://github.com/bryannewrelic",
-      "contributions": 3
-    },
-    {
-      "id": 478564,
-      "login": "zedtux",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/478564?v=4",
-      "htmlUrl": "https://github.com/zedtux",
-      "contributions": 3
+      "id": 723533,
+      "login": "monkeyherder",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/723533?v=4",
+      "htmlUrl": "https://github.com/monkeyherder",
+      "contributions": 1
     },
     {
       "id": 570901,
@@ -60,18 +46,11 @@
       "contributions": 1
     },
     {
-      "id": 661057,
-      "login": "laferrieren",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/661057?v=4",
-      "htmlUrl": "https://github.com/laferrieren",
-      "contributions": 5
-    },
-    {
-      "id": 4865,
-      "login": "gnarg",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4865?v=4",
-      "htmlUrl": "https://github.com/gnarg",
-      "contributions": 1
+      "id": 478564,
+      "login": "zedtux",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/478564?v=4",
+      "htmlUrl": "https://github.com/zedtux",
+      "contributions": 3
     },
     {
       "id": 192135,
@@ -81,11 +60,32 @@
       "contributions": 2
     },
     {
-      "id": 67997,
-      "login": "toffer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/67997?v=4",
-      "htmlUrl": "https://github.com/toffer",
-      "contributions": 4
+      "id": 661057,
+      "login": "laferrieren",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/661057?v=4",
+      "htmlUrl": "https://github.com/laferrieren",
+      "contributions": 5
+    },
+    {
+      "id": 176691,
+      "login": "jessedearing",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/176691?v=4",
+      "htmlUrl": "https://github.com/jessedearing",
+      "contributions": 7
+    },
+    {
+      "id": 129120,
+      "login": "tdooner",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/129120?v=4",
+      "htmlUrl": "https://github.com/tdooner",
+      "contributions": 5
+    },
+    {
+      "id": 196416,
+      "login": "hugochinchilla",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/196416?v=4",
+      "htmlUrl": "https://github.com/hugochinchilla",
+      "contributions": 2
     },
     {
       "id": 2615543,
@@ -93,6 +93,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/2615543?v=4",
       "htmlUrl": "https://github.com/skarap",
       "contributions": 5
+    },
+    {
+      "id": 36873,
+      "login": "davidcelis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36873?v=4",
+      "htmlUrl": "https://github.com/davidcelis",
+      "contributions": 2
     },
     {
       "id": 54611,
@@ -109,13 +116,6 @@
       "contributions": 4
     },
     {
-      "id": 723533,
-      "login": "monkeyherder",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/723533?v=4",
-      "htmlUrl": "https://github.com/monkeyherder",
-      "contributions": 1
-    },
-    {
       "id": 829526,
       "login": "prayagverma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/829526?v=4",
@@ -123,10 +123,10 @@
       "contributions": 1
     },
     {
-      "id": 3062663,
-      "login": "askl56",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3062663?v=4",
-      "htmlUrl": "https://github.com/askl56",
+      "id": 4865,
+      "login": "gnarg",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4865?v=4",
+      "htmlUrl": "https://github.com/gnarg",
       "contributions": 1
     },
     {
@@ -151,11 +151,11 @@
       "contributions": 35
     },
     {
-      "id": 196416,
-      "login": "hugochinchilla",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/196416?v=4",
-      "htmlUrl": "https://github.com/hugochinchilla",
-      "contributions": 2
+      "id": 67997,
+      "login": "toffer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67997?v=4",
+      "htmlUrl": "https://github.com/toffer",
+      "contributions": 4
     },
     {
       "id": 1410846,
@@ -221,18 +221,18 @@
       "contributions": 4
     },
     {
-      "id": 36873,
-      "login": "davidcelis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/36873?v=4",
-      "htmlUrl": "https://github.com/davidcelis",
-      "contributions": 2
+      "id": 19076,
+      "login": "kremso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19076?v=4",
+      "htmlUrl": "https://github.com/kremso",
+      "contributions": 5
     },
     {
-      "id": 129120,
-      "login": "tdooner",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/129120?v=4",
-      "htmlUrl": "https://github.com/tdooner",
-      "contributions": 5
+      "id": 6953072,
+      "login": "bryannewrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6953072?v=4",
+      "htmlUrl": "https://github.com/bryannewrelic",
+      "contributions": 3
     },
     {
       "id": 267761,

--- a/src/data/project-stats/newrelic-demo-catalog.json
+++ b/src/data/project-stats/newrelic-demo-catalog.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 75,
-  "lastSixMonthsCommitTotal": 20,
+  "lastSixMonthsCommitTotal": 18,
   "contributors": 6,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-demo-deployer.json
+++ b/src/data/project-stats/newrelic-demo-deployer.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 409,
-  "lastSixMonthsCommitTotal": 55,
+  "commits": 418,
+  "lastSixMonthsCommitTotal": 53,
   "contributors": 9,
   "pullRequests": {
     "open": 1
@@ -15,11 +15,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 8672090,
-      "login": "alexronquillo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8672090?v=4",
-      "htmlUrl": "https://github.com/alexronquillo",
-      "contributions": 19
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
     },
     {
       "id": 4481921,
@@ -36,13 +36,6 @@
       "contributions": 18
     },
     {
-      "id": 45029322,
-      "login": "polfliet",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45029322?v=4",
-      "htmlUrl": "https://github.com/polfliet",
-      "contributions": 1
-    },
-    {
       "id": 70179303,
       "login": "aswanson-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179303?v=4",
@@ -50,11 +43,18 @@
       "contributions": 25
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
+      "id": 45029322,
+      "login": "polfliet",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45029322?v=4",
+      "htmlUrl": "https://github.com/polfliet",
       "contributions": 1
+    },
+    {
+      "id": 8672090,
+      "login": "alexronquillo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8672090?v=4",
+      "htmlUrl": "https://github.com/alexronquillo",
+      "contributions": 19
     },
     {
       "id": 8731013,
@@ -75,7 +75,7 @@
       "login": "Julien4218",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38018054?v=4",
       "htmlUrl": "https://github.com/Julien4218",
-      "contributions": 195
+      "contributions": 201
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-demo-newrelic-instrumentation.json
+++ b/src/data/project-stats/newrelic-demo-newrelic-instrumentation.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 158,
-  "lastSixMonthsCommitTotal": 8,
+  "lastSixMonthsCommitTotal": 5,
   "contributors": 6,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-demo-nodetron.json
+++ b/src/data/project-stats/newrelic-demo-nodetron.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 168,
-  "lastSixMonthsCommitTotal": 43,
+  "lastSixMonthsCommitTotal": 42,
   "contributors": 6,
   "pullRequests": {
     "open": 3

--- a/src/data/project-stats/newrelic-demo-services.json
+++ b/src/data/project-stats/newrelic-demo-services.json
@@ -9,7 +9,7 @@
     "date": "2021-01-08T22:50:17Z"
   },
   "commits": 14,
-  "lastSixMonthsCommitTotal": 14,
+  "lastSixMonthsCommitTotal": 2,
   "contributors": 4,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-developer-toolkit.json
+++ b/src/data/project-stats/newrelic-developer-toolkit.json
@@ -9,24 +9,24 @@
   "lastSixMonthsCommitTotal": 2,
   "contributors": 5,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 54412777,
+      "login": "carynbaudouxgit",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54412777?v=4",
+      "htmlUrl": "https://github.com/carynbaudouxgit",
+      "contributions": 2
+    },
     {
       "id": 7197435,
       "login": "SowmyaJujjuri",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7197435?v=4",
       "htmlUrl": "https://github.com/SowmyaJujjuri",
       "contributions": 5
-    },
-    {
-      "id": 2590905,
-      "login": "sanderblue",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
-      "htmlUrl": "https://github.com/sanderblue",
-      "contributions": 2
     },
     {
       "id": 455419,
@@ -43,10 +43,10 @@
       "contributions": 4
     },
     {
-      "id": 54412777,
-      "login": "carynbaudouxgit",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54412777?v=4",
-      "htmlUrl": "https://github.com/carynbaudouxgit",
+      "id": 2590905,
+      "login": "sanderblue",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
+      "htmlUrl": "https://github.com/sanderblue",
       "contributions": 2
     }
   ],

--- a/src/data/project-stats/newrelic-developer-website.json
+++ b/src/data/project-stats/newrelic-developer-website.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/developer-website",
   "issues": {
-    "open": 28
+    "open": 30
   },
   "releases": 133,
   "latestRelease": {
     "name": "v1.52.0",
     "date": "2021-06-23T19:28:38Z"
   },
-  "commits": 4479,
-  "lastSixMonthsCommitTotal": 892,
+  "commits": 4497,
+  "lastSixMonthsCommitTotal": 863,
   "contributors": 63,
   "pullRequests": {
-    "open": 3
+    "open": 4
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -56,7 +56,7 @@
       "url": "https://github.com/newrelic/developer-website/issues/1169",
       "createdAt": "2021-03-09T19:42:13Z",
       "comments": {
-        "totalCount": 4
+        "totalCount": 5
       },
       "author": {
         "login": "kaizer113",
@@ -77,25 +77,18 @@
       "contributions": 1
     },
     {
-      "id": 270746,
-      "login": "thejonanshow",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/270746?v=4",
-      "htmlUrl": "https://github.com/thejonanshow",
-      "contributions": 12
-    },
-    {
-      "id": 7992384,
-      "login": "paperclypse",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
-      "htmlUrl": "https://github.com/paperclypse",
-      "contributions": 5
-    },
-    {
       "id": 46462340,
       "login": "abuchanan-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46462340?v=4",
       "htmlUrl": "https://github.com/abuchanan-nr",
       "contributions": 1
+    },
+    {
+      "id": 812989,
+      "login": "danielgolden",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
+      "htmlUrl": "https://github.com/danielgolden",
+      "contributions": 9
     },
     {
       "id": 7365296,
@@ -105,11 +98,11 @@
       "contributions": 3
     },
     {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
-      "contributions": 1
+      "id": 8094310,
+      "login": "pugh-jeremy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8094310?v=4",
+      "htmlUrl": "https://github.com/pugh-jeremy",
+      "contributions": 2
     },
     {
       "id": 929261,
@@ -126,31 +119,24 @@
       "contributions": 1
     },
     {
-      "id": 42678939,
-      "login": "bradleycamacho",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
-      "htmlUrl": "https://github.com/bradleycamacho",
-      "contributions": 3
+      "id": 4978846,
+      "login": "rajatagarwal",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4978846?v=4",
+      "htmlUrl": "https://github.com/rajatagarwal",
+      "contributions": 1
     },
     {
       "id": 39655074,
       "login": "LizBaker",
       "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
       "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 183
+      "contributions": 185
     },
     {
       "id": 8172556,
       "login": "cdanielsen",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8172556?v=4",
       "htmlUrl": "https://github.com/cdanielsen",
-      "contributions": 1
-    },
-    {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
       "contributions": 1
     },
     {
@@ -161,18 +147,18 @@
       "contributions": 1
     },
     {
-      "id": 38860981,
-      "login": "jduarteihm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/38860981?v=4",
-      "htmlUrl": "https://github.com/jduarteihm",
-      "contributions": 2
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 1
     },
     {
-      "id": 45799229,
-      "login": "jkinmonth",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45799229?v=4",
-      "htmlUrl": "https://github.com/jkinmonth",
-      "contributions": 2
+      "id": 1773616,
+      "login": "theletterf",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
+      "htmlUrl": "https://github.com/theletterf",
+      "contributions": 17
     },
     {
       "id": 12112563,
@@ -182,18 +168,18 @@
       "contributions": 44
     },
     {
-      "id": 8672090,
-      "login": "alexronquillo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8672090?v=4",
-      "htmlUrl": "https://github.com/alexronquillo",
-      "contributions": 146
+      "id": 39946,
+      "login": "binaryseed",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39946?v=4",
+      "htmlUrl": "https://github.com/binaryseed",
+      "contributions": 1
     },
     {
-      "id": 97928,
-      "login": "aaronbassett",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/97928?v=4",
-      "htmlUrl": "https://github.com/aaronbassett",
-      "contributions": 8
+      "id": 45799229,
+      "login": "jkinmonth",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45799229?v=4",
+      "htmlUrl": "https://github.com/jkinmonth",
+      "contributions": 2
     },
     {
       "id": 19733683,
@@ -210,25 +196,18 @@
       "contributions": 1
     },
     {
-      "id": 39946,
-      "login": "binaryseed",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39946?v=4",
-      "htmlUrl": "https://github.com/binaryseed",
+      "id": 1273138,
+      "login": "andresroberto",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1273138?v=4",
+      "htmlUrl": "https://github.com/andresroberto",
       "contributions": 1
     },
     {
-      "id": 812989,
-      "login": "danielgolden",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
-      "htmlUrl": "https://github.com/danielgolden",
-      "contributions": 9
-    },
-    {
-      "id": 1663955,
-      "login": "mbazhlekova",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1663955?v=4",
-      "htmlUrl": "https://github.com/mbazhlekova",
-      "contributions": 3
+      "id": 1395158,
+      "login": "jpvajda",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
+      "htmlUrl": "https://github.com/jpvajda",
+      "contributions": 197
     },
     {
       "id": 66321197,
@@ -238,18 +217,46 @@
       "contributions": 307
     },
     {
-      "id": 8094310,
-      "login": "pugh-jeremy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8094310?v=4",
-      "htmlUrl": "https://github.com/pugh-jeremy",
-      "contributions": 2
+      "id": 7992384,
+      "login": "paperclypse",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
+      "htmlUrl": "https://github.com/paperclypse",
+      "contributions": 5
     },
     {
-      "id": 1273138,
-      "login": "andresroberto",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1273138?v=4",
-      "htmlUrl": "https://github.com/andresroberto",
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
       "contributions": 1
+    },
+    {
+      "id": 97928,
+      "login": "aaronbassett",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/97928?v=4",
+      "htmlUrl": "https://github.com/aaronbassett",
+      "contributions": 8
+    },
+    {
+      "id": 38332422,
+      "login": "caylahamann",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38332422?v=4",
+      "htmlUrl": "https://github.com/caylahamann",
+      "contributions": 135
+    },
+    {
+      "id": 44537285,
+      "login": "pachicodes",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/44537285?v=4",
+      "htmlUrl": "https://github.com/pachicodes",
+      "contributions": 28
+    },
+    {
+      "id": 42678939,
+      "login": "bradleycamacho",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
+      "htmlUrl": "https://github.com/bradleycamacho",
+      "contributions": 3
     },
     {
       "id": 9435570,
@@ -259,17 +266,17 @@
       "contributions": 10
     },
     {
-      "id": 1395158,
-      "login": "jpvajda",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
-      "htmlUrl": "https://github.com/jpvajda",
-      "contributions": 194
+      "id": 8672090,
+      "login": "alexronquillo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8672090?v=4",
+      "htmlUrl": "https://github.com/alexronquillo",
+      "contributions": 147
     },
     {
-      "id": 4978846,
-      "login": "rajatagarwal",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4978846?v=4",
-      "htmlUrl": "https://github.com/rajatagarwal",
+      "id": 558327,
+      "login": "maju6406",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/558327?v=4",
+      "htmlUrl": "https://github.com/maju6406",
       "contributions": 1
     },
     {
@@ -287,11 +294,11 @@
       "contributions": 1
     },
     {
-      "id": 43454823,
-      "login": "xomiamoore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43454823?v=4",
-      "htmlUrl": "https://github.com/xomiamoore",
-      "contributions": 2
+      "id": 270746,
+      "login": "thejonanshow",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/270746?v=4",
+      "htmlUrl": "https://github.com/thejonanshow",
+      "contributions": 12
     },
     {
       "id": 2952843,
@@ -315,13 +322,6 @@
       "contributions": 13
     },
     {
-      "id": 186715,
-      "login": "djsauble",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/186715?v=4",
-      "htmlUrl": "https://github.com/djsauble",
-      "contributions": 26
-    },
-    {
       "id": 565661,
       "login": "jerelmiller",
       "avatarUrl": "https://avatars.githubusercontent.com/u/565661?v=4",
@@ -333,7 +333,7 @@
       "login": "rudouglas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
       "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 13
+      "contributions": 17
     },
     {
       "id": 58010132,
@@ -350,11 +350,11 @@
       "contributions": 2
     },
     {
-      "id": 1773616,
-      "login": "theletterf",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
-      "htmlUrl": "https://github.com/theletterf",
-      "contributions": 17
+      "id": 1663955,
+      "login": "mbazhlekova",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1663955?v=4",
+      "htmlUrl": "https://github.com/mbazhlekova",
+      "contributions": 3
     },
     {
       "id": 55004296,
@@ -385,11 +385,11 @@
       "contributions": 48
     },
     {
-      "id": 38332422,
-      "login": "caylahamann",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/38332422?v=4",
-      "htmlUrl": "https://github.com/caylahamann",
-      "contributions": 135
+      "id": 38860981,
+      "login": "jduarteihm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38860981?v=4",
+      "htmlUrl": "https://github.com/jduarteihm",
+      "contributions": 2
     },
     {
       "id": 1987319,
@@ -420,11 +420,11 @@
       "contributions": 3
     },
     {
-      "id": 44537285,
-      "login": "pachicodes",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/44537285?v=4",
-      "htmlUrl": "https://github.com/pachicodes",
-      "contributions": 28
+      "id": 43454823,
+      "login": "xomiamoore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43454823?v=4",
+      "htmlUrl": "https://github.com/xomiamoore",
+      "contributions": 2
     },
     {
       "id": 20293876,
@@ -462,11 +462,11 @@
       "contributions": 304
     },
     {
-      "id": 558327,
-      "login": "maju6406",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/558327?v=4",
-      "htmlUrl": "https://github.com/maju6406",
-      "contributions": 1
+      "id": 186715,
+      "login": "djsauble",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/186715?v=4",
+      "htmlUrl": "https://github.com/djsauble",
+      "contributions": 26
     },
     {
       "id": 6283245,

--- a/src/data/project-stats/newrelic-docs-website.json
+++ b/src/data/project-stats/newrelic-docs-website.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/docs-website",
   "issues": {
-    "open": 105
+    "open": 133
   },
-  "releases": 107,
+  "releases": 128,
   "latestRelease": {
-    "name": "release-206",
-    "date": "2021-06-24T07:37:24Z"
+    "name": "release-07.15.2021-12.35",
+    "date": "2021-07-15T19:15:28Z"
   },
-  "commits": 6224,
-  "lastSixMonthsCommitTotal": 4866,
+  "commits": 6856,
+  "lastSixMonthsCommitTotal": 5244,
   "contributors": 100,
   "pullRequests": {
-    "open": 24
+    "open": 20
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -56,7 +56,7 @@
       "url": "https://github.com/newrelic/docs-website/issues/494",
       "createdAt": "2020-12-29T19:04:11Z",
       "comments": {
-        "totalCount": 9
+        "totalCount": 11
       },
       "author": {
         "login": "jpvajda",
@@ -77,18 +77,11 @@
       "contributions": 55
     },
     {
-      "id": 56379645,
-      "login": "nedl86",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/56379645?v=4",
-      "htmlUrl": "https://github.com/nedl86",
-      "contributions": 3
-    },
-    {
       "id": 3380451,
       "login": "rubenruizdegauna",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
       "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 3
+      "contributions": 6
     },
     {
       "id": 56414817,
@@ -98,32 +91,109 @@
       "contributions": 4
     },
     {
-      "id": 48165025,
-      "login": "linbaker",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48165025?v=4",
-      "htmlUrl": "https://github.com/linbaker",
+      "id": 23203074,
+      "login": "HenryTech",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/23203074?v=4",
+      "htmlUrl": "https://github.com/HenryTech",
+      "contributions": 4
+    },
+    {
+      "id": 467588,
+      "login": "jvanmetre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/467588?v=4",
+      "htmlUrl": "https://github.com/jvanmetre",
+      "contributions": 20
+    },
+    {
+      "id": 69995562,
+      "login": "cthomas-newrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/69995562?v=4",
+      "htmlUrl": "https://github.com/cthomas-newrelic",
+      "contributions": 4
+    },
+    {
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 9
+    },
+    {
+      "id": 654808,
+      "login": "tehbio",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/654808?v=4",
+      "htmlUrl": "https://github.com/tehbio",
       "contributions": 2
     },
     {
-      "id": 4933147,
-      "login": "martinkuba",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4933147?v=4",
-      "htmlUrl": "https://github.com/martinkuba",
-      "contributions": 2
+      "id": 13123145,
+      "login": "RichVanderwal",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13123145?v=4",
+      "htmlUrl": "https://github.com/RichVanderwal",
+      "contributions": 5
     },
     {
-      "id": 43602284,
-      "login": "urbiz-nr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43602284?v=4",
-      "htmlUrl": "https://github.com/urbiz-nr",
-      "contributions": 188
+      "id": 19895951,
+      "login": "umaannamalai",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19895951?v=4",
+      "htmlUrl": "https://github.com/umaannamalai",
+      "contributions": 8
+    },
+    {
+      "id": 3203382,
+      "login": "neilpdx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3203382?v=4",
+      "htmlUrl": "https://github.com/neilpdx",
+      "contributions": 2
     },
     {
       "id": 72516550,
       "login": "cleon-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/72516550?v=4",
       "htmlUrl": "https://github.com/cleon-nr",
-      "contributions": 5
+      "contributions": 6
+    },
+    {
+      "id": 14006450,
+      "login": "Rilsta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14006450?v=4",
+      "htmlUrl": "https://github.com/Rilsta",
+      "contributions": 8
+    },
+    {
+      "id": 65650,
+      "login": "founddrama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65650?v=4",
+      "htmlUrl": "https://github.com/founddrama",
+      "contributions": 7
+    },
+    {
+      "id": 738047,
+      "login": "amhuntsman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/738047?v=4",
+      "htmlUrl": "https://github.com/amhuntsman",
+      "contributions": 2
+    },
+    {
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
+      "contributions": 8
+    },
+    {
+      "id": 84096330,
+      "login": "smalsam-newr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/84096330?v=4",
+      "htmlUrl": "https://github.com/smalsam-newr",
+      "contributions": 6
+    },
+    {
+      "id": 18040274,
+      "login": "rhetoric101",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18040274?v=4",
+      "htmlUrl": "https://github.com/rhetoric101",
+      "contributions": 249
     },
     {
       "id": 81703977,
@@ -133,60 +203,25 @@
       "contributions": 6
     },
     {
-      "id": 55203603,
-      "login": "austin-schaefer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
-      "htmlUrl": "https://github.com/austin-schaefer",
-      "contributions": 140
-    },
-    {
-      "id": 846156,
-      "login": "tanaka-takayoshi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/846156?v=4",
-      "htmlUrl": "https://github.com/tanaka-takayoshi",
-      "contributions": 2
-    },
-    {
-      "id": 80846416,
-      "login": "bdwyer-newrelic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/80846416?v=4",
-      "htmlUrl": "https://github.com/bdwyer-newrelic",
+      "id": 19497993,
+      "login": "rdhar",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19497993?v=4",
+      "htmlUrl": "https://github.com/rdhar",
       "contributions": 3
     },
     {
-      "id": 3496648,
-      "login": "jasonjkeller",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
-      "htmlUrl": "https://github.com/jasonjkeller",
-      "contributions": 15
-    },
-    {
-      "id": 65650,
-      "login": "founddrama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/65650?v=4",
-      "htmlUrl": "https://github.com/founddrama",
-      "contributions": 4
-    },
-    {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 6
-    },
-    {
-      "id": 23203074,
-      "login": "HenryTech",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/23203074?v=4",
-      "htmlUrl": "https://github.com/HenryTech",
-      "contributions": 3
+      "id": 42678939,
+      "login": "bradleycamacho",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
+      "htmlUrl": "https://github.com/bradleycamacho",
+      "contributions": 142
     },
     {
       "id": 55247916,
       "login": "x8a",
       "avatarUrl": "https://avatars.githubusercontent.com/u/55247916?v=4",
       "htmlUrl": "https://github.com/x8a",
-      "contributions": 53
+      "contributions": 76
     },
     {
       "id": 74079252,
@@ -200,21 +235,42 @@
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 22
+      "contributions": 27
+    },
+    {
+      "id": 81393041,
+      "login": "pfraziernr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/81393041?v=4",
+      "htmlUrl": "https://github.com/pfraziernr",
+      "contributions": 3
     },
     {
       "id": 12201539,
       "login": "djaffinito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12201539?v=4",
       "htmlUrl": "https://github.com/djaffinito",
+      "contributions": 5
+    },
+    {
+      "id": 79025418,
+      "login": "nr-jbiggley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/79025418?v=4",
+      "htmlUrl": "https://github.com/nr-jbiggley",
       "contributions": 4
+    },
+    {
+      "id": 56379645,
+      "login": "nedl86",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/56379645?v=4",
+      "htmlUrl": "https://github.com/nedl86",
+      "contributions": 5
     },
     {
       "id": 17018863,
       "login": "jaymcgrath",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17018863?v=4",
       "htmlUrl": "https://github.com/jaymcgrath",
-      "contributions": 3
+      "contributions": 5
     },
     {
       "id": 585473,
@@ -256,7 +312,7 @@
       "login": "LizBaker",
       "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
       "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 50
+      "contributions": 52
     },
     {
       "id": 27844771,
@@ -264,13 +320,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/27844771?v=4",
       "htmlUrl": "https://github.com/robertprast",
       "contributions": 3
-    },
-    {
-      "id": 15843395,
-      "login": "IreneMLC",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15843395?v=4",
-      "htmlUrl": "https://github.com/IreneMLC",
-      "contributions": 2
     },
     {
       "id": 81586764,
@@ -284,7 +333,7 @@
       "login": "hredondo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12070491?v=4",
       "htmlUrl": "https://github.com/hredondo",
-      "contributions": 3
+      "contributions": 7
     },
     {
       "id": 57361211,
@@ -294,11 +343,11 @@
       "contributions": 3
     },
     {
-      "id": 42678939,
-      "login": "bradleycamacho",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
-      "htmlUrl": "https://github.com/bradleycamacho",
-      "contributions": 127
+      "id": 754009,
+      "login": "halocameo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/754009?v=4",
+      "htmlUrl": "https://github.com/halocameo",
+      "contributions": 2
     },
     {
       "id": 3676547,
@@ -308,18 +357,25 @@
       "contributions": 9
     },
     {
-      "id": 13123145,
-      "login": "RichVanderwal",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13123145?v=4",
-      "htmlUrl": "https://github.com/RichVanderwal",
-      "contributions": 5
+      "id": 1874937,
+      "login": "bizob2828",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1874937?v=4",
+      "htmlUrl": "https://github.com/bizob2828",
+      "contributions": 3
     },
     {
-      "id": 18040274,
-      "login": "rhetoric101",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18040274?v=4",
-      "htmlUrl": "https://github.com/rhetoric101",
-      "contributions": 232
+      "id": 43602284,
+      "login": "urbiz-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43602284?v=4",
+      "htmlUrl": "https://github.com/urbiz-nr",
+      "contributions": 216
+    },
+    {
+      "id": 38332422,
+      "login": "caylahamann",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38332422?v=4",
+      "htmlUrl": "https://github.com/caylahamann",
+      "contributions": 276
     },
     {
       "id": 3969485,
@@ -329,11 +385,11 @@
       "contributions": 11
     },
     {
-      "id": 79025418,
-      "login": "nr-jbiggley",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/79025418?v=4",
-      "htmlUrl": "https://github.com/nr-jbiggley",
-      "contributions": 4
+      "id": 80846416,
+      "login": "bdwyer-newrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/80846416?v=4",
+      "htmlUrl": "https://github.com/bdwyer-newrelic",
+      "contributions": 3
     },
     {
       "id": 43335750,
@@ -347,14 +403,14 @@
       "login": "barbnewrelic",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1672581?v=4",
       "htmlUrl": "https://github.com/barbnewrelic",
-      "contributions": 82
+      "contributions": 95
     },
     {
-      "id": 38332422,
-      "login": "caylahamann",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/38332422?v=4",
-      "htmlUrl": "https://github.com/caylahamann",
-      "contributions": 276
+      "id": 48165025,
+      "login": "linbaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48165025?v=4",
+      "htmlUrl": "https://github.com/linbaker",
+      "contributions": 3
     },
     {
       "id": 11223178,
@@ -364,18 +420,11 @@
       "contributions": 10
     },
     {
-      "id": 6243832,
-      "login": "jsubirat",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6243832?v=4",
-      "htmlUrl": "https://github.com/jsubirat",
-      "contributions": 2
-    },
-    {
-      "id": 14006450,
-      "login": "Rilsta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14006450?v=4",
-      "htmlUrl": "https://github.com/Rilsta",
-      "contributions": 7
+      "id": 3496648,
+      "login": "jasonjkeller",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
+      "htmlUrl": "https://github.com/jasonjkeller",
+      "contributions": 15
     },
     {
       "id": 4612272,
@@ -389,21 +438,21 @@
       "login": "CharlieWinters",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10816343?v=4",
       "htmlUrl": "https://github.com/CharlieWinters",
-      "contributions": 3
+      "contributions": 4
     },
     {
       "id": 13966363,
       "login": "carlossscastro",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
       "htmlUrl": "https://github.com/carlossscastro",
-      "contributions": 6
+      "contributions": 8
     },
     {
       "id": 737714,
       "login": "lwegener",
       "avatarUrl": "https://avatars.githubusercontent.com/u/737714?v=4",
       "htmlUrl": "https://github.com/lwegener",
-      "contributions": 9
+      "contributions": 11
     },
     {
       "id": 51135822,
@@ -417,7 +466,7 @@
       "login": "mangulonr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/82898004?v=4",
       "htmlUrl": "https://github.com/mangulonr",
-      "contributions": 4
+      "contributions": 6
     },
     {
       "id": 28364881,
@@ -438,7 +487,7 @@
       "login": "zuluecho9",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9435570?v=4",
       "htmlUrl": "https://github.com/zuluecho9",
-      "contributions": 305
+      "contributions": 339
     },
     {
       "id": 46498444,
@@ -448,25 +497,18 @@
       "contributions": 13
     },
     {
-      "id": 62337995,
-      "login": "jodstrcil",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
-      "htmlUrl": "https://github.com/jodstrcil",
-      "contributions": 3
+      "id": 55203603,
+      "login": "austin-schaefer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
+      "htmlUrl": "https://github.com/austin-schaefer",
+      "contributions": 197
     },
     {
-      "id": 19895951,
-      "login": "umaannamalai",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19895951?v=4",
-      "htmlUrl": "https://github.com/umaannamalai",
-      "contributions": 7
-    },
-    {
-      "id": 1946433,
-      "login": "zstix",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1946433?v=4",
-      "htmlUrl": "https://github.com/zstix",
-      "contributions": 369
+      "id": 2495625,
+      "login": "dbetke",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2495625?v=4",
+      "htmlUrl": "https://github.com/dbetke",
+      "contributions": 5
     },
     {
       "id": 7401258,
@@ -480,7 +522,14 @@
       "login": "aswanson-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179303?v=4",
       "htmlUrl": "https://github.com/aswanson-nr",
-      "contributions": 22
+      "contributions": 28
+    },
+    {
+      "id": 45799229,
+      "login": "jkinmonth",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45799229?v=4",
+      "htmlUrl": "https://github.com/jkinmonth",
+      "contributions": 4
     },
     {
       "id": 19733683,
@@ -488,13 +537,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
       "htmlUrl": "https://github.com/snyk-bot",
       "contributions": 15
-    },
-    {
-      "id": 159474,
-      "login": "ngsw",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/159474?v=4",
-      "htmlUrl": "https://github.com/ngsw",
-      "contributions": 2
     },
     {
       "id": 62625334,
@@ -515,21 +557,7 @@
       "login": "daynaslord",
       "avatarUrl": "https://avatars.githubusercontent.com/u/80060857?v=4",
       "htmlUrl": "https://github.com/daynaslord",
-      "contributions": 45
-    },
-    {
-      "id": 28942544,
-      "login": "katiewest820",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28942544?v=4",
-      "htmlUrl": "https://github.com/katiewest820",
-      "contributions": 2
-    },
-    {
-      "id": 34418638,
-      "login": "jack-berg",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34418638?v=4",
-      "htmlUrl": "https://github.com/jack-berg",
-      "contributions": 2
+      "contributions": 48
     },
     {
       "id": 38245829,
@@ -539,18 +567,11 @@
       "contributions": 6
     },
     {
-      "id": 2769463,
-      "login": "asasha",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2769463?v=4",
-      "htmlUrl": "https://github.com/asasha",
-      "contributions": 2
-    },
-    {
       "id": 67129743,
       "login": "dbarnesbrownNR",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67129743?v=4",
       "htmlUrl": "https://github.com/dbarnesbrownNR",
-      "contributions": 70
+      "contributions": 98
     },
     {
       "id": 2952843,
@@ -564,35 +585,35 @@
       "login": "hroseross",
       "avatarUrl": "https://avatars.githubusercontent.com/u/80003284?v=4",
       "htmlUrl": "https://github.com/hroseross",
-      "contributions": 2
+      "contributions": 4
     },
     {
       "id": 17122543,
       "login": "rudouglas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
       "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 28
+      "contributions": 30
     },
     {
       "id": 61292402,
       "login": "keegoid-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/61292402?v=4",
       "htmlUrl": "https://github.com/keegoid-nr",
-      "contributions": 5
+      "contributions": 6
     },
     {
       "id": 58010132,
       "login": "mmfred",
       "avatarUrl": "https://avatars.githubusercontent.com/u/58010132?v=4",
       "htmlUrl": "https://github.com/mmfred",
-      "contributions": 111
+      "contributions": 142
     },
     {
       "id": 1300852,
       "login": "varas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
       "htmlUrl": "https://github.com/varas",
-      "contributions": 3
+      "contributions": 7
     },
     {
       "id": 82059578,
@@ -602,10 +623,10 @@
       "contributions": 2
     },
     {
-      "id": 54335840,
-      "login": "carlo-808",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
-      "htmlUrl": "https://github.com/carlo-808",
+      "id": 6098021,
+      "login": "jaffinito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6098021?v=4",
+      "htmlUrl": "https://github.com/jaffinito",
       "contributions": 2
     },
     {
@@ -613,7 +634,7 @@
       "login": "paperclypse",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
       "htmlUrl": "https://github.com/paperclypse",
-      "contributions": 243
+      "contributions": 286
     },
     {
       "id": 13590628,
@@ -634,14 +655,7 @@
       "login": "meiao",
       "avatarUrl": "https://avatars.githubusercontent.com/u/292463?v=4",
       "htmlUrl": "https://github.com/meiao",
-      "contributions": 5
-    },
-    {
-      "id": 9002169,
-      "login": "bpschmitt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9002169?v=4",
-      "htmlUrl": "https://github.com/bpschmitt",
-      "contributions": 2
+      "contributions": 8
     },
     {
       "id": 11799492,
@@ -655,14 +669,14 @@
       "login": "nr-kkenney",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
       "htmlUrl": "https://github.com/nr-kkenney",
-      "contributions": 68
+      "contributions": 77
     },
     {
       "id": 24482401,
       "login": "XiXiaPdx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
       "htmlUrl": "https://github.com/XiXiaPdx",
-      "contributions": 7
+      "contributions": 8
     },
     {
       "id": 71277348,
@@ -683,14 +697,7 @@
       "login": "toobagrrl",
       "avatarUrl": "https://avatars.githubusercontent.com/u/64561946?v=4",
       "htmlUrl": "https://github.com/toobagrrl",
-      "contributions": 4
-    },
-    {
-      "id": 15685307,
-      "login": "cristianciutea",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
-      "htmlUrl": "https://github.com/cristianciutea",
-      "contributions": 2
+      "contributions": 6
     },
     {
       "id": 72999039,
@@ -700,11 +707,11 @@
       "contributions": 3
     },
     {
-      "id": 467588,
-      "login": "jvanmetre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/467588?v=4",
-      "htmlUrl": "https://github.com/jvanmetre",
-      "contributions": 19
+      "id": 1946433,
+      "login": "zstix",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1946433?v=4",
+      "htmlUrl": "https://github.com/zstix",
+      "contributions": 369
     },
     {
       "id": 1855259,
@@ -718,21 +725,14 @@
       "login": "TimPansino",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11214426?v=4",
       "htmlUrl": "https://github.com/TimPansino",
-      "contributions": 9
-    },
-    {
-      "id": 32469854,
-      "login": "CherylFrankenfield",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32469854?v=4",
-      "htmlUrl": "https://github.com/CherylFrankenfield",
-      "contributions": 2
+      "contributions": 11
     },
     {
       "id": 1753821,
       "login": "josemore",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1753821?v=4",
       "htmlUrl": "https://github.com/josemore",
-      "contributions": 19
+      "contributions": 24
     },
     {
       "id": 969721,
@@ -753,14 +753,14 @@
       "login": "kaileyhaynes",
       "avatarUrl": "https://avatars.githubusercontent.com/u/84878360?v=4",
       "htmlUrl": "https://github.com/kaileyhaynes",
-      "contributions": 5
+      "contributions": 25
     },
     {
-      "id": 69995562,
-      "login": "cthomas-newrelic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/69995562?v=4",
-      "htmlUrl": "https://github.com/cthomas-newrelic",
-      "contributions": 4
+      "id": 84047247,
+      "login": "ywang-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/84047247?v=4",
+      "htmlUrl": "https://github.com/ywang-nr",
+      "contributions": 10
     },
     {
       "id": 97996,

--- a/src/data/project-stats/newrelic-dropwizard-metrics-newrelic.json
+++ b/src/data/project-stats/newrelic-dropwizard-metrics-newrelic.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/dropwizard-metrics-newrelic",
   "issues": {
-    "open": 7
+    "open": 4
   },
   "releases": 3,
   "latestRelease": {
@@ -53,11 +53,11 @@
   ],
   "cachedContributors": [
     {
-      "id": 858731,
-      "login": "jkwatson",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
-      "htmlUrl": "https://github.com/jkwatson",
-      "contributions": 3
+      "id": 54085190,
+      "login": "breedx-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54085190?v=4",
+      "htmlUrl": "https://github.com/breedx-nr",
+      "contributions": 31
     },
     {
       "id": 43244625,
@@ -74,11 +74,11 @@
       "contributions": 6
     },
     {
-      "id": 54085190,
-      "login": "breedx-nr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54085190?v=4",
-      "htmlUrl": "https://github.com/breedx-nr",
-      "contributions": 31
+      "id": 858731,
+      "login": "jkwatson",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
+      "htmlUrl": "https://github.com/jkwatson",
+      "contributions": 3
     },
     {
       "id": 24482401,

--- a/src/data/project-stats/newrelic-el-dorado-ui.json
+++ b/src/data/project-stats/newrelic-el-dorado-ui.json
@@ -15,18 +15,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 4306527,
-      "login": "bcollinsNR",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4306527?v=4",
-      "htmlUrl": "https://github.com/bcollinsNR",
-      "contributions": 6
-    },
-    {
       "id": 19733683,
       "login": "snyk-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
       "htmlUrl": "https://github.com/snyk-bot",
       "contributions": 2
+    },
+    {
+      "id": 4306527,
+      "login": "bcollinsNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4306527?v=4",
+      "htmlUrl": "https://github.com/bcollinsNR",
+      "contributions": 6
     },
     {
       "id": 130504,

--- a/src/data/project-stats/newrelic-elixir_agent.json
+++ b/src/data/project-stats/newrelic-elixir_agent.json
@@ -3,13 +3,13 @@
   "issues": {
     "open": 5
   },
-  "releases": 107,
+  "releases": 108,
   "latestRelease": {
-    "name": "v1.27.3",
-    "date": "2021-06-23T18:06:21Z"
+    "name": "v1.27.4",
+    "date": "2021-07-13T18:11:55Z"
   },
-  "commits": 682,
-  "lastSixMonthsCommitTotal": 86,
+  "commits": 684,
+  "lastSixMonthsCommitTotal": 88,
   "contributors": 22,
   "pullRequests": {
     "open": 2
@@ -32,24 +32,24 @@
       "contributions": 2
     },
     {
-      "id": 31331498,
-      "login": "benhaney",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/31331498?v=4",
-      "htmlUrl": "https://github.com/benhaney",
-      "contributions": 1
-    },
-    {
-      "id": 101555,
-      "login": "ethangunderson",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/101555?v=4",
-      "htmlUrl": "https://github.com/ethangunderson",
-      "contributions": 1
-    },
-    {
       "id": 6687220,
       "login": "emeryotopalik",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6687220?v=4",
       "htmlUrl": "https://github.com/emeryotopalik",
+      "contributions": 1
+    },
+    {
+      "id": 5297542,
+      "login": "alejandrodnm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
+      "htmlUrl": "https://github.com/alejandrodnm",
+      "contributions": 1
+    },
+    {
+      "id": 31331498,
+      "login": "benhaney",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31331498?v=4",
+      "htmlUrl": "https://github.com/benhaney",
       "contributions": 1
     },
     {
@@ -74,18 +74,18 @@
       "contributions": 1
     },
     {
-      "id": 5297542,
-      "login": "alejandrodnm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
-      "htmlUrl": "https://github.com/alejandrodnm",
+      "id": 101555,
+      "login": "ethangunderson",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/101555?v=4",
+      "htmlUrl": "https://github.com/ethangunderson",
       "contributions": 1
     },
     {
-      "id": 1231659,
-      "login": "sb8244",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1231659?v=4",
-      "htmlUrl": "https://github.com/sb8244",
-      "contributions": 2
+      "id": 151912,
+      "login": "barthez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/151912?v=4",
+      "htmlUrl": "https://github.com/barthez",
+      "contributions": 1
     },
     {
       "id": 17054180,
@@ -116,11 +116,11 @@
       "contributions": 2
     },
     {
-      "id": 151912,
-      "login": "barthez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/151912?v=4",
-      "htmlUrl": "https://github.com/barthez",
-      "contributions": 1
+      "id": 1231659,
+      "login": "sb8244",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1231659?v=4",
+      "htmlUrl": "https://github.com/sb8244",
+      "contributions": 2
     },
     {
       "id": 32940,
@@ -162,7 +162,7 @@
       "login": "binaryseed",
       "avatarUrl": "https://avatars.githubusercontent.com/u/39946?v=4",
       "htmlUrl": "https://github.com/binaryseed",
-      "contributions": 487
+      "contributions": 489
     },
     {
       "id": 45771,

--- a/src/data/project-stats/newrelic-entity-definitions.json
+++ b/src/data/project-stats/newrelic-entity-definitions.json
@@ -1,0 +1,343 @@
+{
+  "projectFullName": "newrelic/entity-definitions",
+  "issues": {
+    "open": 4
+  },
+  "releases": 45,
+  "latestRelease": {
+    "name": "2.29.0",
+    "date": "2021-07-14T13:52:05Z"
+  },
+  "commits": 257,
+  "lastSixMonthsCommitTotal": 224,
+  "contributors": 43,
+  "pullRequests": {
+    "open": 11
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
+      "contributions": 1
+    },
+    {
+      "id": 1735559,
+      "login": "apanosa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1735559?v=4",
+      "htmlUrl": "https://github.com/apanosa",
+      "contributions": 1
+    },
+    {
+      "id": 13734882,
+      "login": "helenapm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13734882?v=4",
+      "htmlUrl": "https://github.com/helenapm",
+      "contributions": 21
+    },
+    {
+      "id": 565661,
+      "login": "jerelmiller",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/565661?v=4",
+      "htmlUrl": "https://github.com/jerelmiller",
+      "contributions": 1
+    },
+    {
+      "id": 1939121,
+      "login": "migruealt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1939121?v=4",
+      "htmlUrl": "https://github.com/migruealt",
+      "contributions": 1
+    },
+    {
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 1
+    },
+    {
+      "id": 36424871,
+      "login": "65pony",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36424871?v=4",
+      "htmlUrl": "https://github.com/65pony",
+      "contributions": 2
+    },
+    {
+      "id": 159076,
+      "login": "douglascamata",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
+      "htmlUrl": "https://github.com/douglascamata",
+      "contributions": 10
+    },
+    {
+      "id": 11946809,
+      "login": "khpeet",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11946809?v=4",
+      "htmlUrl": "https://github.com/khpeet",
+      "contributions": 1
+    },
+    {
+      "id": 8296904,
+      "login": "apoloa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8296904?v=4",
+      "htmlUrl": "https://github.com/apoloa",
+      "contributions": 4
+    },
+    {
+      "id": 8867386,
+      "login": "rcrocker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8867386?v=4",
+      "htmlUrl": "https://github.com/rcrocker",
+      "contributions": 3
+    },
+    {
+      "id": 37779995,
+      "login": "ryanv94",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37779995?v=4",
+      "htmlUrl": "https://github.com/ryanv94",
+      "contributions": 1
+    },
+    {
+      "id": 31922082,
+      "login": "MiriamAparicio",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31922082?v=4",
+      "htmlUrl": "https://github.com/MiriamAparicio",
+      "contributions": 2
+    },
+    {
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 7
+    },
+    {
+      "id": 79025418,
+      "login": "nr-jbiggley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/79025418?v=4",
+      "htmlUrl": "https://github.com/nr-jbiggley",
+      "contributions": 1
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 12560219,
+      "login": "ivancorrales",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12560219?v=4",
+      "htmlUrl": "https://github.com/ivancorrales",
+      "contributions": 2
+    },
+    {
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
+    },
+    {
+      "id": 85335776,
+      "login": "lromer22",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/85335776?v=4",
+      "htmlUrl": "https://github.com/lromer22",
+      "contributions": 1
+    },
+    {
+      "id": 16707638,
+      "login": "AlbertoGoYu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16707638?v=4",
+      "htmlUrl": "https://github.com/AlbertoGoYu",
+      "contributions": 2
+    },
+    {
+      "id": 7732950,
+      "login": "jfjoly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7732950?v=4",
+      "htmlUrl": "https://github.com/jfjoly",
+      "contributions": 3
+    },
+    {
+      "id": 944635,
+      "login": "naxhh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/944635?v=4",
+      "htmlUrl": "https://github.com/naxhh",
+      "contributions": 25
+    },
+    {
+      "id": 30831476,
+      "login": "thezackm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
+      "htmlUrl": "https://github.com/thezackm",
+      "contributions": 23
+    },
+    {
+      "id": 1410846,
+      "login": "javimb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1410846?v=4",
+      "htmlUrl": "https://github.com/javimb",
+      "contributions": 4
+    },
+    {
+      "id": 76217151,
+      "login": "flisflis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76217151?v=4",
+      "htmlUrl": "https://github.com/flisflis",
+      "contributions": 10
+    },
+    {
+      "id": 34025886,
+      "login": "ikavanaghNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34025886?v=4",
+      "htmlUrl": "https://github.com/ikavanaghNR",
+      "contributions": 1
+    },
+    {
+      "id": 1753821,
+      "login": "josemore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1753821?v=4",
+      "htmlUrl": "https://github.com/josemore",
+      "contributions": 2
+    },
+    {
+      "id": 53268450,
+      "login": "jake-codes",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/53268450?v=4",
+      "htmlUrl": "https://github.com/jake-codes",
+      "contributions": 1
+    },
+    {
+      "id": 15843395,
+      "login": "IreneMLC",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15843395?v=4",
+      "htmlUrl": "https://github.com/IreneMLC",
+      "contributions": 55
+    },
+    {
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 1
+    },
+    {
+      "id": 38245829,
+      "login": "mkrichevsky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38245829?v=4",
+      "htmlUrl": "https://github.com/mkrichevsky",
+      "contributions": 2
+    },
+    {
+      "id": 346110,
+      "login": "srvaroa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/346110?v=4",
+      "htmlUrl": "https://github.com/srvaroa",
+      "contributions": 12
+    },
+    {
+      "id": 25227240,
+      "login": "batbore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/25227240?v=4",
+      "htmlUrl": "https://github.com/batbore",
+      "contributions": 1
+    },
+    {
+      "id": 6374032,
+      "login": "a-feld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
+      "htmlUrl": "https://github.com/a-feld",
+      "contributions": 2
+    },
+    {
+      "id": 10852,
+      "login": "areina",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10852?v=4",
+      "htmlUrl": "https://github.com/areina",
+      "contributions": 4
+    },
+    {
+      "id": 78201305,
+      "login": "fprats",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/78201305?v=4",
+      "htmlUrl": "https://github.com/fprats",
+      "contributions": 2
+    },
+    {
+      "id": 30514,
+      "login": "cirne",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
+      "htmlUrl": "https://github.com/cirne",
+      "contributions": 1
+    },
+    {
+      "id": 51135822,
+      "login": "vkasanneni-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/51135822?v=4",
+      "htmlUrl": "https://github.com/vkasanneni-nr",
+      "contributions": 1
+    },
+    {
+      "id": 1479942,
+      "login": "dfernandeza",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1479942?v=4",
+      "htmlUrl": "https://github.com/dfernandeza",
+      "contributions": 2
+    },
+    {
+      "id": 80925470,
+      "login": "AustinNester",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/80925470?v=4",
+      "htmlUrl": "https://github.com/AustinNester",
+      "contributions": 2
+    },
+    {
+      "id": 976883,
+      "login": "jlegoff",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/976883?v=4",
+      "htmlUrl": "https://github.com/jlegoff",
+      "contributions": 22
+    },
+    {
+      "id": 8439728,
+      "login": "OscarDCorbalan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8439728?v=4",
+      "htmlUrl": "https://github.com/OscarDCorbalan",
+      "contributions": 2
+    },
+    {
+      "id": 15201509,
+      "login": "aschmid13",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15201509?v=4",
+      "htmlUrl": "https://github.com/aschmid13",
+      "contributions": 1
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxNDA=",
+      "name": "JavaScript",
+      "color": "#f1e05a"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2U1MzU=",
+      "name": "Dockerfile",
+      "color": "#384d54"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-experimental-deploy-repolinter-action.json
+++ b/src/data/project-stats/newrelic-experimental-deploy-repolinter-action.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 9,
-  "lastSixMonthsCommitTotal": 9,
+  "lastSixMonthsCommitTotal": 0,
   "contributors": 2,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-entity-synthesis-definitions.json
+++ b/src/data/project-stats/newrelic-experimental-entity-synthesis-definitions.json
@@ -1,42 +1,49 @@
 {
   "projectFullName": "newrelic-experimental/entity-synthesis-definitions",
   "issues": {
-    "open": 3
+    "open": 4
   },
   "releases": 42,
   "latestRelease": {
     "name": "2.26.0",
     "date": "2021-06-18T15:37:24Z"
   },
-  "commits": 243,
-  "lastSixMonthsCommitTotal": 214,
-  "contributors": 42,
+  "commits": 249,
+  "lastSixMonthsCommitTotal": 220,
+  "contributors": 43,
   "pullRequests": {
-    "open": 9
+    "open": 11
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 565661,
-      "login": "jerelmiller",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/565661?v=4",
-      "htmlUrl": "https://github.com/jerelmiller",
+      "id": 37779995,
+      "login": "ryanv94",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37779995?v=4",
+      "htmlUrl": "https://github.com/ryanv94",
       "contributions": 1
     },
     {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
+      "id": 12560219,
+      "login": "ivancorrales",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12560219?v=4",
+      "htmlUrl": "https://github.com/ivancorrales",
+      "contributions": 2
+    },
+    {
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
       "contributions": 1
     },
     {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
-      "contributions": 1
+      "id": 8296904,
+      "login": "apoloa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8296904?v=4",
+      "htmlUrl": "https://github.com/apoloa",
+      "contributions": 2
     },
     {
       "id": 1939121,
@@ -44,13 +51,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/1939121?v=4",
       "htmlUrl": "https://github.com/migruealt",
       "contributions": 1
-    },
-    {
-      "id": 976883,
-      "login": "jlegoff",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/976883?v=4",
-      "htmlUrl": "https://github.com/jlegoff",
-      "contributions": 22
     },
     {
       "id": 36424871,
@@ -74,25 +74,25 @@
       "contributions": 1
     },
     {
-      "id": 8296904,
-      "login": "apoloa",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8296904?v=4",
-      "htmlUrl": "https://github.com/apoloa",
+      "id": 565661,
+      "login": "jerelmiller",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/565661?v=4",
+      "htmlUrl": "https://github.com/jerelmiller",
       "contributions": 1
     },
     {
-      "id": 7732950,
-      "login": "jfjoly",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7732950?v=4",
-      "htmlUrl": "https://github.com/jfjoly",
-      "contributions": 3
+      "id": 15843395,
+      "login": "IreneMLC",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15843395?v=4",
+      "htmlUrl": "https://github.com/IreneMLC",
+      "contributions": 54
     },
     {
-      "id": 37779995,
-      "login": "ryanv94",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37779995?v=4",
-      "htmlUrl": "https://github.com/ryanv94",
-      "contributions": 1
+      "id": 13734882,
+      "login": "helenapm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13734882?v=4",
+      "htmlUrl": "https://github.com/helenapm",
+      "contributions": 21
     },
     {
       "id": 31922082,
@@ -123,25 +123,18 @@
       "contributions": 1
     },
     {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 7
+      "id": 76217151,
+      "login": "flisflis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76217151?v=4",
+      "htmlUrl": "https://github.com/flisflis",
+      "contributions": 10
     },
     {
-      "id": 17122543,
-      "login": "rudouglas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
-      "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 1
-    },
-    {
-      "id": 13734882,
-      "login": "helenapm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13734882?v=4",
-      "htmlUrl": "https://github.com/helenapm",
-      "contributions": 21
+      "id": 7732950,
+      "login": "jfjoly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7732950?v=4",
+      "htmlUrl": "https://github.com/jfjoly",
+      "contributions": 3
     },
     {
       "id": 85335776,
@@ -165,18 +158,11 @@
       "contributions": 1
     },
     {
-      "id": 944635,
-      "login": "naxhh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/944635?v=4",
-      "htmlUrl": "https://github.com/naxhh",
-      "contributions": 25
-    },
-    {
-      "id": 30831476,
-      "login": "thezackm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
-      "htmlUrl": "https://github.com/thezackm",
-      "contributions": 16
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 1
     },
     {
       "id": 1753821,
@@ -186,18 +172,25 @@
       "contributions": 2
     },
     {
+      "id": 30831476,
+      "login": "thezackm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
+      "htmlUrl": "https://github.com/thezackm",
+      "contributions": 19
+    },
+    {
+      "id": 944635,
+      "login": "naxhh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/944635?v=4",
+      "htmlUrl": "https://github.com/naxhh",
+      "contributions": 25
+    },
+    {
       "id": 1410846,
       "login": "javimb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1410846?v=4",
       "htmlUrl": "https://github.com/javimb",
       "contributions": 4
-    },
-    {
-      "id": 76217151,
-      "login": "flisflis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76217151?v=4",
-      "htmlUrl": "https://github.com/flisflis",
-      "contributions": 10
     },
     {
       "id": 8867386,
@@ -207,11 +200,25 @@
       "contributions": 3
     },
     {
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 7
+    },
+    {
       "id": 53268450,
       "login": "jake-codes",
       "avatarUrl": "https://avatars.githubusercontent.com/u/53268450?v=4",
       "htmlUrl": "https://github.com/jake-codes",
       "contributions": 1
+    },
+    {
+      "id": 78201305,
+      "login": "fprats",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/78201305?v=4",
+      "htmlUrl": "https://github.com/fprats",
+      "contributions": 2
     },
     {
       "id": 5143130,
@@ -256,11 +263,11 @@
       "contributions": 4
     },
     {
-      "id": 78201305,
-      "login": "fprats",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/78201305?v=4",
-      "htmlUrl": "https://github.com/fprats",
-      "contributions": 2
+      "id": 877369,
+      "login": "ramonguiu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
+      "htmlUrl": "https://github.com/ramonguiu",
+      "contributions": 1
     },
     {
       "id": 30514,
@@ -291,11 +298,11 @@
       "contributions": 2
     },
     {
-      "id": 15843395,
-      "login": "IreneMLC",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15843395?v=4",
-      "htmlUrl": "https://github.com/IreneMLC",
-      "contributions": 54
+      "id": 976883,
+      "login": "jlegoff",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/976883?v=4",
+      "htmlUrl": "https://github.com/jlegoff",
+      "contributions": 22
     },
     {
       "id": 8439728,

--- a/src/data/project-stats/newrelic-experimental-gatsby-plugin-newrelic.json
+++ b/src/data/project-stats/newrelic-experimental-gatsby-plugin-newrelic.json
@@ -1,0 +1,48 @@
+{
+  "projectFullName": "newrelic-experimental/gatsby-plugin-newrelic",
+  "issues": {
+    "open": 0
+  },
+  "releases": 0,
+  "latestRelease": null,
+  "commits": 5,
+  "lastSixMonthsCommitTotal": 5,
+  "contributors": 2,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
+      "contributions": 4
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxNDA=",
+      "name": "JavaScript",
+      "color": "#f1e05a"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-experimental-java-instrumentation-template.json
+++ b/src/data/project-stats/newrelic-experimental-java-instrumentation-template.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 12,
-  "lastSixMonthsCommitTotal": 0,
+  "commits": 20,
+  "lastSixMonthsCommitTotal": 8,
   "contributors": 3,
   "pullRequests": {
     "open": 0
@@ -19,7 +19,7 @@
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 3
+      "contributions": 9
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-kubernetes-demo-apps.json
+++ b/src/data/project-stats/newrelic-experimental-kubernetes-demo-apps.json
@@ -15,11 +15,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 812989,
-      "login": "danielgolden",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
-      "htmlUrl": "https://github.com/danielgolden",
-      "contributions": 2
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 16
     },
     {
       "id": 43244625,
@@ -36,11 +36,11 @@
       "contributions": 29
     },
     {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
-      "contributions": 16
+      "id": 812989,
+      "login": "danielgolden",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
+      "htmlUrl": "https://github.com/danielgolden",
+      "contributions": 2
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-aws-servicecatalog-appregistry.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-aws-servicecatalog-appregistry.json
@@ -1,0 +1,35 @@
+{
+  "projectFullName": "newrelic-experimental/newrelic-aws-servicecatalog-appregistry",
+  "issues": {
+    "open": 0
+  },
+  "releases": 0,
+  "latestRelease": null,
+  "commits": 1,
+  "lastSixMonthsCommitTotal": 1,
+  "contributors": 1,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
+    }
+  ],
+  "languages": [],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-experimental-newrelic-entity-cmdb-ci-sync.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-entity-cmdb-ci-sync.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 26,
-  "lastSixMonthsCommitTotal": 23,
+  "lastSixMonthsCommitTotal": 17,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelic-gcp-log-forwarder.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-gcp-log-forwarder.json
@@ -1,0 +1,35 @@
+{
+  "projectFullName": "newrelic-experimental/newrelic-gcp-log-forwarder",
+  "issues": {
+    "open": 0
+  },
+  "releases": 0,
+  "latestRelease": null,
+  "commits": 1,
+  "lastSixMonthsCommitTotal": 1,
+  "contributors": 1,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 4061375,
+      "login": "ricegi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4061375?v=4",
+      "htmlUrl": "https://github.com/ricegi",
+      "contributions": 1
+    }
+  ],
+  "languages": [],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-aerospike.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-aerospike.json
@@ -8,22 +8,15 @@
     "name": "1.0",
     "date": "2020-10-06T14:38:19Z"
   },
-  "commits": 7,
-  "lastSixMonthsCommitTotal": 1,
+  "commits": 20,
+  "lastSixMonthsCommitTotal": 13,
   "contributors": 3,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 3
-    },
     {
       "id": 41585091,
       "login": "hsinghkalsi",
@@ -32,11 +25,18 @@
       "contributions": 1
     },
     {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 11
+    },
+    {
       "id": 43244625,
       "login": "melissaklein24",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 3
+      "contributions": 4
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-atomikos.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-atomikos.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 7,
-  "lastSixMonthsCommitTotal": 5,
+  "commits": 13,
+  "lastSixMonthsCommitTotal": 6,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -19,7 +19,7 @@
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 4
+      "contributions": 10
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-camel.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-camel.json
@@ -8,8 +8,8 @@
     "name": "1.1",
     "date": "2021-02-09T19:39:17Z"
   },
-  "commits": 9,
-  "lastSixMonthsCommitTotal": 8,
+  "commits": 15,
+  "lastSixMonthsCommitTotal": 11,
   "contributors": 3,
   "pullRequests": {
     "open": 0
@@ -18,24 +18,24 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
+    },
+    {
       "id": 8822859,
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 6
+      "contributions": 10
     },
     {
       "id": 3536684,
       "login": "sschwartzman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 1
-    },
-    {
-      "id": 41585091,
-      "login": "hsinghkalsi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
-      "htmlUrl": "https://github.com/hsinghkalsi",
       "contributions": 1
     }
   ],

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-couchbase.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-couchbase.json
@@ -8,8 +8,8 @@
     "name": "1.0",
     "date": "2020-10-14T21:54:09Z"
   },
-  "commits": 5,
-  "lastSixMonthsCommitTotal": 2,
+  "commits": 13,
+  "lastSixMonthsCommitTotal": 10,
   "contributors": 3,
   "pullRequests": {
     "open": 0
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 1
-    },
-    {
       "id": 41585091,
       "login": "hsinghkalsi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
       "htmlUrl": "https://github.com/hsinghkalsi",
       "contributions": 1
+    },
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 8
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-elasticsearch.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-elasticsearch.json
@@ -8,8 +8,8 @@
     "name": "1.0",
     "date": "2020-12-31T23:27:55Z"
   },
-  "commits": 8,
-  "lastSixMonthsCommitTotal": 7,
+  "commits": 11,
+  "lastSixMonthsCommitTotal": 6,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -22,7 +22,7 @@
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 5
+      "contributions": 8
     },
     {
       "id": 3536684,

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-executors.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-executors.json
@@ -8,8 +8,8 @@
     "name": "1.0",
     "date": "2021-03-30T21:06:32Z"
   },
-  "commits": 5,
-  "lastSixMonthsCommitTotal": 4,
+  "commits": 7,
+  "lastSixMonthsCommitTotal": 6,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -29,7 +29,7 @@
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 4
+      "contributions": 5
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-gcp-pubsub.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-gcp-pubsub.json
@@ -5,28 +5,28 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 3,
-  "lastSixMonthsCommitTotal": 3,
+  "commits": 13,
+  "lastSixMonthsCommitTotal": 13,
   "contributors": 2,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 2
-    },
     {
       "id": 3536684,
       "login": "sschwartzman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
       "contributions": 1
+    },
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 11
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-http4s.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-http4s.json
@@ -8,7 +8,7 @@
     "name": "1.0",
     "date": "2021-01-29T14:52:58Z"
   },
-  "commits": 6,
+  "commits": 10,
   "lastSixMonthsCommitTotal": 5,
   "contributors": 3,
   "pullRequests": {
@@ -18,24 +18,24 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
+    },
+    {
       "id": 8822859,
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 4
+      "contributions": 7
     },
     {
       "id": 3536684,
       "login": "sschwartzman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 1
-    },
-    {
-      "id": 41585091,
-      "login": "hsinghkalsi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
-      "htmlUrl": "https://github.com/hsinghkalsi",
       "contributions": 1
     }
   ],

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-kotlin-coroutines.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-kotlin-coroutines.json
@@ -8,8 +8,8 @@
     "name": "1.3",
     "date": "2021-03-17T16:01:56Z"
   },
-  "commits": 23,
-  "lastSixMonthsCommitTotal": 15,
+  "commits": 27,
+  "lastSixMonthsCommitTotal": 18,
   "contributors": 3,
   "pullRequests": {
     "open": 0
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 18
-    },
-    {
       "id": 41585091,
       "login": "hsinghkalsi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
       "htmlUrl": "https://github.com/hsinghkalsi",
       "contributions": 1
+    },
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 20
     },
     {
       "id": 3536684,

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-mongo-async.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-mongo-async.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 7,
-  "lastSixMonthsCommitTotal": 6,
+  "commits": 10,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 3,
   "pullRequests": {
     "open": 0
@@ -19,20 +19,20 @@
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 5
-    },
-    {
-      "id": 3536684,
-      "login": "sschwartzman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
-      "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 1
+      "contributions": 7
     },
     {
       "id": 41585091,
       "login": "hsinghkalsi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
       "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
+    },
+    {
+      "id": 3536684,
+      "login": "sschwartzman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
+      "htmlUrl": "https://github.com/sschwartzman",
       "contributions": 1
     }
   ],

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-mqtt-eclipse-paho.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-mqtt-eclipse-paho.json
@@ -8,8 +8,8 @@
     "name": "1.0",
     "date": "2021-02-22T17:17:36Z"
   },
-  "commits": 3,
-  "lastSixMonthsCommitTotal": 3,
+  "commits": 5,
+  "lastSixMonthsCommitTotal": 5,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 2
-    },
-    {
       "id": 3536684,
       "login": "sschwartzman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
       "contributions": 1
+    },
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 4
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-mqtt-hivemq.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-mqtt-hivemq.json
@@ -8,8 +8,8 @@
     "name": "1.0",
     "date": "2021-02-22T18:36:06Z"
   },
-  "commits": 5,
-  "lastSixMonthsCommitTotal": 5,
+  "commits": 7,
+  "lastSixMonthsCommitTotal": 7,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -29,7 +29,7 @@
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 4
+      "contributions": 5
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-mule-4.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-mule-4.json
@@ -8,8 +8,8 @@
     "name": "4.3",
     "date": "2021-04-12T17:07:51Z"
   },
-  "commits": 13,
-  "lastSixMonthsCommitTotal": 12,
+  "commits": 29,
+  "lastSixMonthsCommitTotal": 28,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 10
-    },
-    {
       "id": 3536684,
       "login": "sschwartzman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
       "contributions": 1
+    },
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 21
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-osb-11g.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-osb-11g.json
@@ -5,15 +5,22 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 17,
-  "lastSixMonthsCommitTotal": 15,
+  "commits": 25,
+  "lastSixMonthsCommitTotal": 22,
   "contributors": 3,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 19
+    },
     {
       "id": 41585091,
       "login": "hsinghkalsi",
@@ -22,18 +29,11 @@
       "contributions": 1
     },
     {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 14
-    },
-    {
       "id": 43244625,
       "login": "melissaklein24",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 1
+      "contributions": 2
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-reactor.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-reactor.json
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 3536684,
-      "login": "sschwartzman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
-      "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 1
-    },
-    {
       "id": 8822859,
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
       "contributions": 10
+    },
+    {
+      "id": 3536684,
+      "login": "sschwartzman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
+      "htmlUrl": "https://github.com/sschwartzman",
+      "contributions": 1
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-redisson.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-redisson.json
@@ -1,0 +1,56 @@
+{
+  "projectFullName": "newrelic-experimental/newrelic-java-redisson",
+  "issues": {
+    "open": 0
+  },
+  "releases": 1,
+  "latestRelease": {
+    "name": "1.0",
+    "date": "2021-07-02T15:26:50Z"
+  },
+  "commits": 29,
+  "lastSixMonthsCommitTotal": 29,
+  "contributors": 2,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
+    },
+    {
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 24
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxMzk=",
+      "name": "Shell",
+      "color": "#89e051"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2UxNTg=",
+      "name": "Java",
+      "color": "#b07219"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-rxjava.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-rxjava.json
@@ -9,7 +9,7 @@
     "date": "2021-03-30T19:52:04Z"
   },
   "commits": 25,
-  "lastSixMonthsCommitTotal": 24,
+  "lastSixMonthsCommitTotal": 20,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-tibco-businessconnect.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-tibco-businessconnect.json
@@ -15,18 +15,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 41585091,
-      "login": "hsinghkalsi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
-      "htmlUrl": "https://github.com/hsinghkalsi",
-      "contributions": 1
-    },
-    {
       "id": 8822859,
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
       "contributions": 8
+    },
+    {
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-tibco-bw6.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-tibco-bw6.json
@@ -15,18 +15,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 41585091,
-      "login": "hsinghkalsi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
-      "htmlUrl": "https://github.com/hsinghkalsi",
-      "contributions": 1
-    },
-    {
       "id": 8822859,
       "login": "dhilpipre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
       "htmlUrl": "https://github.com/dhilpipre",
       "contributions": 10
+    },
+    {
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-tibco-core.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-tibco-core.json
@@ -9,7 +9,7 @@
     "date": "2021-01-29T14:58:09Z"
   },
   "commits": 9,
-  "lastSixMonthsCommitTotal": 2,
+  "lastSixMonthsCommitTotal": 1,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-undertow.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-undertow.json
@@ -9,7 +9,7 @@
     "date": "2020-12-30T13:43:28Z"
   },
   "commits": 3,
-  "lastSixMonthsCommitTotal": 2,
+  "lastSixMonthsCommitTotal": 1,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelic-java-vertx-extensions.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-java-vertx-extensions.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 41585091,
-      "login": "hsinghkalsi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
-      "htmlUrl": "https://github.com/hsinghkalsi",
-      "contributions": 1
+      "id": 8822859,
+      "login": "dhilpipre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
+      "htmlUrl": "https://github.com/dhilpipre",
+      "contributions": 8
     },
     {
       "id": 3536684,
@@ -32,11 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 8822859,
-      "login": "dhilpipre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8822859?v=4",
-      "htmlUrl": "https://github.com/dhilpipre",
-      "contributions": 8
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-newrelic-kafka-playground.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-kafka-playground.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 11,
-  "lastSixMonthsCommitTotal": 3,
+  "commits": 14,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 3,
   "pullRequests": {
     "open": 0
@@ -26,7 +26,7 @@
       "login": "ericmittelhammer",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1082112?v=4",
       "htmlUrl": "https://github.com/ericmittelhammer",
-      "contributions": 7
+      "contributions": 9
     },
     {
       "id": 43244625,
@@ -37,11 +37,6 @@
     }
   ],
   "languages": [
-    {
-      "id": "MDg6TGFuZ3VhZ2U0MTc=",
-      "name": "HTML",
-      "color": "#e34c26"
-    },
     {
       "id": "MDg6TGFuZ3VhZ2UxNTg=",
       "name": "Java",
@@ -66,6 +61,11 @@
       "id": "MDg6TGFuZ3VhZ2U0MzE=",
       "name": "Smarty",
       "color": null
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2U3ODY=",
+      "name": "Jinja",
+      "color": "#a52a22"
     }
   ],
   "screenshots": [],

--- a/src/data/project-stats/newrelic-experimental-newrelic-mparticle-integration.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-mparticle-integration.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 12,
-  "lastSixMonthsCommitTotal": 2,
+  "lastSixMonthsCommitTotal": 1,
   "contributors": 2,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelic-social-listening-service-nodejs.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-social-listening-service-nodejs.json
@@ -25,17 +25,17 @@
       "contributions": 30
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
-    },
-    {
       "id": 43244625,
       "login": "melissaklein24",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
     }
   ],

--- a/src/data/project-stats/newrelic-experimental-newrelic-tsak.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-tsak.json
@@ -9,7 +9,7 @@
     "date": "2021-03-02T19:52:09Z"
   },
   "commits": 181,
-  "lastSixMonthsCommitTotal": 54,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 2,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelic-xamarin-binding.json
+++ b/src/data/project-stats/newrelic-experimental-newrelic-xamarin-binding.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 13,
-  "lastSixMonthsCommitTotal": 5,
+  "lastSixMonthsCommitTotal": 1,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-newrelicreactnativemodule.json
+++ b/src/data/project-stats/newrelic-experimental-newrelicreactnativemodule.json
@@ -9,7 +9,7 @@
   "lastSixMonthsCommitTotal": 0,
   "contributors": 3,
   "pullRequests": {
-    "open": 1
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],

--- a/src/data/project-stats/newrelic-experimental-nr-account-migration.json
+++ b/src/data/project-stats/newrelic-experimental-nr-account-migration.json
@@ -1,15 +1,15 @@
 {
   "projectFullName": "newrelic-experimental/nr-account-migration",
   "issues": {
-    "open": 2
+    "open": 3
   },
-  "releases": 5,
+  "releases": 6,
   "latestRelease": {
-    "name": "2.2.0",
-    "date": "2021-06-09T20:40:40Z"
+    "name": "2.2.1",
+    "date": "2021-07-07T22:31:18Z"
   },
-  "commits": 29,
-  "lastSixMonthsCommitTotal": 19,
+  "commits": 30,
+  "lastSixMonthsCommitTotal": 20,
   "contributors": 6,
   "pullRequests": {
     "open": 0
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 2
+      "id": 45947764,
+      "login": "bpeckNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
+      "htmlUrl": "https://github.com/bpeckNR",
+      "contributions": 5
     },
     {
       "id": 43244625,
@@ -32,11 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 45947764,
-      "login": "bpeckNR",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
-      "htmlUrl": "https://github.com/bpeckNR",
-      "contributions": 5
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 2
     },
     {
       "id": 8333200,
@@ -57,7 +57,7 @@
       "login": "adiosspandit",
       "avatarUrl": "https://avatars.githubusercontent.com/u/39402771?v=4",
       "htmlUrl": "https://github.com/adiosspandit",
-      "contributions": 13
+      "contributions": 14
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-nr-grafana-migration.json
+++ b/src/data/project-stats/newrelic-experimental-nr-grafana-migration.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 29,
-  "lastSixMonthsCommitTotal": 22,
+  "lastSixMonthsCommitTotal": 21,
   "contributors": 1,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-experimental-nr-students-edition.json
+++ b/src/data/project-stats/newrelic-experimental-nr-students-edition.json
@@ -3,13 +3,13 @@
   "issues": {
     "open": 0
   },
-  "releases": 7,
+  "releases": 10,
   "latestRelease": {
-    "name": "v1.3.0",
+    "name": "v1.5.0",
     "date": null
   },
-  "commits": 125,
-  "lastSixMonthsCommitTotal": 125,
+  "commits": 158,
+  "lastSixMonthsCommitTotal": 158,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -22,7 +22,7 @@
       "login": "DominikMarciniszyn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/59443662?v=4",
       "htmlUrl": "https://github.com/DominikMarciniszyn",
-      "contributions": 125
+      "contributions": 148
     },
     {
       "id": 13562672,

--- a/src/data/project-stats/newrelic-experimental-nr1-account-maturity-products.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-account-maturity-products.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 112,
-  "lastSixMonthsCommitTotal": 13,
+  "lastSixMonthsCommitTotal": 12,
   "contributors": 6,
   "pullRequests": {
     "open": 6

--- a/src/data/project-stats/newrelic-experimental-nr1-alerts-board.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-alerts-board.json
@@ -8,11 +8,11 @@
     "name": "v2.2.1",
     "date": "2020-06-08T16:39:34Z"
   },
-  "commits": 28,
-  "lastSixMonthsCommitTotal": 0,
+  "commits": 37,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 5,
   "pullRequests": {
-    "open": 4
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -29,7 +29,7 @@
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 2
+      "contributions": 3
     },
     {
       "id": 4061375,
@@ -60,9 +60,9 @@
       "color": "#f1e05a"
     },
     {
-      "id": "MDg6TGFuZ3VhZ2UzMDg=",
-      "name": "CSS",
-      "color": "#563d7c"
+      "id": "MDg6TGFuZ3VhZ2U2MDU=",
+      "name": "SCSS",
+      "color": "#c6538c"
     }
   ],
   "screenshots": [

--- a/src/data/project-stats/newrelic-experimental-nr1-cards-for-observability.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-cards-for-observability.json
@@ -9,7 +9,7 @@
     "date": "2021-02-25T02:25:16Z"
   },
   "commits": 46,
-  "lastSixMonthsCommitTotal": 13,
+  "lastSixMonthsCommitTotal": 12,
   "contributors": 3,
   "pullRequests": {
     "open": 6

--- a/src/data/project-stats/newrelic-experimental-nr1-facinator.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-facinator.json
@@ -9,7 +9,7 @@
     "date": "2020-11-20T15:12:49Z"
   },
   "commits": 21,
-  "lastSixMonthsCommitTotal": 3,
+  "lastSixMonthsCommitTotal": 0,
   "contributors": 5,
   "pullRequests": {
     "open": 4
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 2
+      "id": 55132258,
+      "login": "jsbnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
+      "htmlUrl": "https://github.com/jsbnr",
+      "contributions": 9
     },
     {
       "id": 66321197,
@@ -32,11 +32,11 @@
       "contributions": 3
     },
     {
-      "id": 55132258,
-      "login": "jsbnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
-      "htmlUrl": "https://github.com/jsbnr",
-      "contributions": 9
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 2
     },
     {
       "id": 32174276,

--- a/src/data/project-stats/newrelic-experimental-nr1-igor.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-igor.json
@@ -25,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 1
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 9
     },
     {
       "id": 58010132,
@@ -39,11 +39,11 @@
       "contributions": 1
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 9
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 1
     },
     {
       "id": 929261,

--- a/src/data/project-stats/newrelic-experimental-nr1-mountpointutilization.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-mountpointutilization.json
@@ -15,11 +15,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
+      "id": 47863580,
+      "login": "cah-zack-mutchler",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47863580?v=4",
+      "htmlUrl": "https://github.com/cah-zack-mutchler",
+      "contributions": 18
     },
     {
       "id": 812989,
@@ -29,11 +29,11 @@
       "contributions": 1
     },
     {
-      "id": 47863580,
-      "login": "cah-zack-mutchler",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47863580?v=4",
-      "htmlUrl": "https://github.com/cah-zack-mutchler",
-      "contributions": 18
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-nr1-multi-account-query.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-multi-account-query.json
@@ -9,7 +9,7 @@
     "date": "2021-01-14T15:28:06Z"
   },
   "commits": 36,
-  "lastSixMonthsCommitTotal": 13,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 6,
   "pullRequests": {
     "open": 3
@@ -17,6 +17,13 @@
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 2
+    },
     {
       "id": 66321197,
       "login": "nr-opensource-bot",
@@ -30,13 +37,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
-    },
-    {
-      "id": 55132258,
-      "login": "jsbnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
-      "htmlUrl": "https://github.com/jsbnr",
-      "contributions": 14
     },
     {
       "id": 32174276,
@@ -53,11 +53,11 @@
       "contributions": 1
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 2
+      "id": 55132258,
+      "login": "jsbnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
+      "htmlUrl": "https://github.com/jsbnr",
+      "contributions": 14
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-nr1-open-boards.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-open-boards.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 139,
-  "lastSixMonthsCommitTotal": 12,
+  "lastSixMonthsCommitTotal": 11,
   "contributors": 5,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-experimental-nr1-openstack.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-openstack.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 24,
-  "lastSixMonthsCommitTotal": 2,
+  "lastSixMonthsCommitTotal": 1,
   "contributors": 4,
   "pullRequests": {
     "open": 4
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 1
-    },
-    {
       "id": 7143309,
       "login": "ddarwin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7143309?v=4",
       "htmlUrl": "https://github.com/ddarwin",
       "contributions": 4
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-nr1-session-timeline.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-session-timeline.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic-experimental/nr1-session-timeline",
   "issues": {
-    "open": 7
+    "open": 8
   },
   "releases": 3,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2020-09-21T18:08:04Z"
   },
   "commits": 53,
-  "lastSixMonthsCommitTotal": 10,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 5,
   "pullRequests": {
     "open": 0
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 1786630,
-      "login": "aso1124",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1786630?v=4",
-      "htmlUrl": "https://github.com/aso1124",
-      "contributions": 32
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 2
     },
     {
       "id": 66321197,
@@ -32,11 +32,11 @@
       "contributions": 8
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 2
+      "id": 1786630,
+      "login": "aso1124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1786630?v=4",
+      "htmlUrl": "https://github.com/aso1124",
+      "contributions": 32
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-experimental-nr1-synthetics-alerts.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-synthetics-alerts.json
@@ -9,7 +9,7 @@
     "date": "2020-09-10T16:27:55Z"
   },
   "commits": 32,
-  "lastSixMonthsCommitTotal": 3,
+  "lastSixMonthsCommitTotal": 2,
   "contributors": 5,
   "pullRequests": {
     "open": 0
@@ -18,10 +18,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
+      "id": 4061375,
+      "login": "ricegi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4061375?v=4",
+      "htmlUrl": "https://github.com/ricegi",
       "contributions": 1
     },
     {
@@ -46,10 +46,10 @@
       "contributions": 1
     },
     {
-      "id": 4061375,
-      "login": "ricegi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4061375?v=4",
-      "htmlUrl": "https://github.com/ricegi",
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
       "contributions": 1
     }
   ],

--- a/src/data/project-stats/newrelic-experimental-nr1-wall-status-board.json
+++ b/src/data/project-stats/newrelic-experimental-nr1-wall-status-board.json
@@ -9,7 +9,7 @@
     "date": "2020-11-27T09:24:39Z"
   },
   "commits": 69,
-  "lastSixMonthsCommitTotal": 8,
+  "lastSixMonthsCommitTotal": 5,
   "contributors": 8,
   "pullRequests": {
     "open": 1
@@ -32,11 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 10984551,
-      "login": "icpenguins",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10984551?v=4",
-      "htmlUrl": "https://github.com/icpenguins",
-      "contributions": 8
+      "id": 55132258,
+      "login": "jsbnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
+      "htmlUrl": "https://github.com/jsbnr",
+      "contributions": 23
     },
     {
       "id": 32174276,
@@ -46,11 +46,11 @@
       "contributions": 3
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 4
+      "id": 10984551,
+      "login": "icpenguins",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10984551?v=4",
+      "htmlUrl": "https://github.com/icpenguins",
+      "contributions": 8
     },
     {
       "id": 929261,
@@ -60,11 +60,11 @@
       "contributions": 1
     },
     {
-      "id": 55132258,
-      "login": "jsbnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
-      "htmlUrl": "https://github.com/jsbnr",
-      "contributions": 23
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 4
     },
     {
       "id": 44571906,

--- a/src/data/project-stats/newrelic-experimental-nri-datapower.json
+++ b/src/data/project-stats/newrelic-experimental-nri-datapower.json
@@ -1,0 +1,61 @@
+{
+  "projectFullName": "newrelic-experimental/nri-datapower",
+  "issues": {
+    "open": 0
+  },
+  "releases": 1,
+  "latestRelease": {
+    "name": "1.0.0",
+    "date": "2021-06-25T19:18:06Z"
+  },
+  "commits": 4,
+  "lastSixMonthsCommitTotal": 4,
+  "contributors": 2,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 41585091,
+      "login": "hsinghkalsi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
+      "htmlUrl": "https://github.com/hsinghkalsi",
+      "contributions": 1
+    },
+    {
+      "id": 17014899,
+      "login": "psomareddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17014899?v=4",
+      "htmlUrl": "https://github.com/psomareddy",
+      "contributions": 3
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxMzk=",
+      "name": "Shell",
+      "color": "#89e051"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2U0NjM=",
+      "name": "Batchfile",
+      "color": "#C1F12E"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2UxNTg=",
+      "name": "Java",
+      "color": "#b07219"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-experimental-nri-dirwatcher.json
+++ b/src/data/project-stats/newrelic-experimental-nri-dirwatcher.json
@@ -9,7 +9,7 @@
     "date": "2021-01-05T15:53:56Z"
   },
   "commits": 23,
-  "lastSixMonthsCommitTotal": 3,
+  "lastSixMonthsCommitTotal": 2,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 33189156,
-      "login": "a-james-faria",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33189156?v=4",
-      "htmlUrl": "https://github.com/a-james-faria",
-      "contributions": 2
-    },
-    {
       "id": 3536684,
       "login": "sschwartzman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
       "contributions": 9
+    },
+    {
+      "id": 33189156,
+      "login": "a-james-faria",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33189156?v=4",
+      "htmlUrl": "https://github.com/a-james-faria",
+      "contributions": 2
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-experimental-nri-iib.json
+++ b/src/data/project-stats/newrelic-experimental-nri-iib.json
@@ -1,0 +1,34 @@
+{
+  "projectFullName": "newrelic-experimental/nri-iib",
+  "issues": {
+    "open": 0
+  },
+  "releases": 0,
+  "latestRelease": null,
+  "commits": 2,
+  "lastSixMonthsCommitTotal": 2,
+  "contributors": 1,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 17014899,
+      "login": "psomareddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17014899?v=4",
+      "htmlUrl": "https://github.com/psomareddy",
+      "contributions": 2
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxNTg=",
+      "name": "Java",
+      "color": "#b07219"
+    }
+  ],
+  "screenshots": [],
+  "license": null
+}

--- a/src/data/project-stats/newrelic-experimental-nri-snmp-trapd.json
+++ b/src/data/project-stats/newrelic-experimental-nri-snmp-trapd.json
@@ -9,7 +9,7 @@
     "date": "2021-01-20T18:02:48Z"
   },
   "commits": 13,
-  "lastSixMonthsCommitTotal": 11,
+  "lastSixMonthsCommitTotal": 10,
   "contributors": 3,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-experimental-nri-snmpdb.json
+++ b/src/data/project-stats/newrelic-experimental-nri-snmpdb.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 12,
-  "lastSixMonthsCommitTotal": 12,
+  "lastSixMonthsCommitTotal": 10,
   "contributors": 2,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-experimental-nri-spark.json
+++ b/src/data/project-stats/newrelic-experimental-nri-spark.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic-experimental/nri-spark",
   "issues": {
-    "open": 1
+    "open": 2
   },
-  "releases": 3,
+  "releases": 4,
   "latestRelease": {
-    "name": "1.1.0",
-    "date": "2021-05-03T19:05:57Z"
+    "name": "1.1.1",
+    "date": "2021-06-25T16:54:39Z"
   },
-  "commits": 9,
-  "lastSixMonthsCommitTotal": 4,
+  "commits": 19,
+  "lastSixMonthsCommitTotal": 14,
   "contributors": 4,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -22,14 +22,7 @@
       "login": "hsinghkalsi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/41585091?v=4",
       "htmlUrl": "https://github.com/hsinghkalsi",
-      "contributions": 3
-    },
-    {
-      "id": 28544519,
-      "login": "goldenplec",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28544519?v=4",
-      "htmlUrl": "https://github.com/goldenplec",
-      "contributions": 1
+      "contributions": 9
     },
     {
       "id": 43244625,
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
+    },
+    {
+      "id": 28544519,
+      "login": "goldenplec",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28544519?v=4",
+      "htmlUrl": "https://github.com/goldenplec",
+      "contributions": 3
     },
     {
       "id": 3536684,

--- a/src/data/project-stats/newrelic-experimental-nrpy.json
+++ b/src/data/project-stats/newrelic-experimental-nrpy.json
@@ -15,17 +15,17 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 39402771,
-      "login": "adiosspandit",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39402771?v=4",
-      "htmlUrl": "https://github.com/adiosspandit",
-      "contributions": 1
-    },
-    {
       "id": 43244625,
       "login": "melissaklein24",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 39402771,
+      "login": "adiosspandit",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39402771?v=4",
+      "htmlUrl": "https://github.com/adiosspandit",
       "contributions": 1
     }
   ],

--- a/src/data/project-stats/newrelic-experimental-programmability-in-a-box.json
+++ b/src/data/project-stats/newrelic-experimental-programmability-in-a-box.json
@@ -15,18 +15,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 5
-    },
-    {
       "id": 6426523,
       "login": "veextee",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6426523?v=4",
       "htmlUrl": "https://github.com/veextee",
       "contributions": 1
+    },
+    {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 5
     }
   ],
   "languages": [],

--- a/src/data/project-stats/newrelic-experimental-talisker.json
+++ b/src/data/project-stats/newrelic-experimental-talisker.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 4,
-  "lastSixMonthsCommitTotal": 4,
+  "commits": 5,
+  "lastSixMonthsCommitTotal": 5,
   "contributors": 2,
   "pullRequests": {
     "open": 0
@@ -19,7 +19,7 @@
       "login": "jsbnr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
       "htmlUrl": "https://github.com/jsbnr",
-      "contributions": 3
+      "contributions": 4
     },
     {
       "id": 6722433,

--- a/src/data/project-stats/newrelic-experimental-video-documentation.json
+++ b/src/data/project-stats/newrelic-experimental-video-documentation.json
@@ -1,0 +1,48 @@
+{
+  "projectFullName": "newrelic-experimental/video-documentation",
+  "issues": {
+    "open": 2
+  },
+  "releases": 0,
+  "latestRelease": null,
+  "commits": 4,
+  "lastSixMonthsCommitTotal": 4,
+  "contributors": 2,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 4061375,
+      "login": "ricegi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4061375?v=4",
+      "htmlUrl": "https://github.com/ricegi",
+      "contributions": 1
+    },
+    {
+      "id": 3828366,
+      "login": "cjmccarthy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3828366?v=4",
+      "htmlUrl": "https://github.com/cjmccarthy",
+      "contributions": 3
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxMzk=",
+      "name": "Shell",
+      "color": "#89e051"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-fluent-bit-package.json
+++ b/src/data/project-stats/newrelic-fluent-bit-package.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/fluent-bit-package",
   "issues": {
-    "open": 0
+    "open": 1
   },
-  "releases": 10,
+  "releases": 13,
   "latestRelease": {
-    "name": "1.7.4",
-    "date": "2021-06-22T08:45:04Z"
+    "name": "1.8.1",
+    "date": "2021-07-13T10:38:30Z"
   },
-  "commits": 33,
-  "lastSixMonthsCommitTotal": 28,
-  "contributors": 4,
+  "commits": 44,
+  "lastSixMonthsCommitTotal": 39,
+  "contributors": 5,
   "pullRequests": {
     "open": 0
   },
@@ -22,7 +22,7 @@
       "login": "tejunior",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7537725?v=4",
       "htmlUrl": "https://github.com/tejunior",
-      "contributions": 13
+      "contributions": 14
     },
     {
       "id": 15685307,
@@ -32,21 +32,34 @@
       "contributions": 2
     },
     {
-      "id": 62337995,
-      "login": "jodstrcil",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
-      "htmlUrl": "https://github.com/jodstrcil",
-      "contributions": 10
-    },
-    {
       "id": 812989,
       "login": "danielgolden",
       "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
       "htmlUrl": "https://github.com/danielgolden",
       "contributions": 2
+    },
+    {
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
+      "contributions": 11
+    },
+    {
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 8
     }
   ],
-  "languages": [],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxMzk=",
+      "name": "Shell",
+      "color": "#89e051"
+    }
+  ],
   "screenshots": [],
   "license": {
     "id": "MDc6TGljZW5zZTI=",

--- a/src/data/project-stats/newrelic-fluentd-examples.json
+++ b/src/data/project-stats/newrelic-fluentd-examples.json
@@ -15,10 +15,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 62337995,
-      "login": "jodstrcil",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
-      "htmlUrl": "https://github.com/jodstrcil",
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
     },
     {
@@ -29,10 +29,10 @@
       "contributions": 1
     },
     {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-gatsby-plugin-newrelic.json
+++ b/src/data/project-stats/newrelic-gatsby-plugin-newrelic.json
@@ -9,7 +9,7 @@
     "date": "2021-04-20T17:51:17Z"
   },
   "commits": 53,
-  "lastSixMonthsCommitTotal": 11,
+  "lastSixMonthsCommitTotal": 8,
   "contributors": 7,
   "pullRequests": {
     "open": 2
@@ -25,18 +25,18 @@
       "contributions": 31
     },
     {
-      "id": 2952843,
-      "login": "roadlittledawn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2952843?v=4",
-      "htmlUrl": "https://github.com/roadlittledawn",
-      "contributions": 3
-    },
-    {
       "id": 66321197,
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
       "contributions": 5
+    },
+    {
+      "id": 2952843,
+      "login": "roadlittledawn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2952843?v=4",
+      "htmlUrl": "https://github.com/roadlittledawn",
+      "contributions": 3
     },
     {
       "id": 929261,

--- a/src/data/project-stats/newrelic-gatsby-theme-newrelic.json
+++ b/src/data/project-stats/newrelic-gatsby-theme-newrelic.json
@@ -1,21 +1,56 @@
 {
   "projectFullName": "newrelic/gatsby-theme-newrelic",
   "issues": {
-    "open": 8
+    "open": 10
   },
-  "releases": 123,
+  "releases": 124,
   "latestRelease": {
-    "name": "v2.4.4",
+    "name": "v2.4.5",
     "date": null
   },
-  "commits": 1679,
-  "lastSixMonthsCommitTotal": 911,
+  "commits": 1692,
+  "lastSixMonthsCommitTotal": 766,
   "contributors": 15,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
-  "cachedIssues": [],
+  "cachedIssues": [
+    {
+      "id": "MDU6SXNzdWU4MzkyMjYyNDY=",
+      "title": "Header improvements: Bigger search",
+      "url": "https://github.com/newrelic/gatsby-theme-newrelic/issues/333",
+      "createdAt": "2021-03-24T00:19:36Z",
+      "comments": {
+        "totalCount": 3
+      },
+      "author": {
+        "login": "austin-schaefer",
+        "id": "MDQ6VXNlcjU1MjAzNjAz",
+        "email": "",
+        "name": "Austin Schaefer"
+      },
+      "number": 333,
+      "createdBy": "Austin Schaefer"
+    },
+    {
+      "id": "MDU6SXNzdWU5NDQ2MjQ0MDU=",
+      "title": "Don't copy line numbers from codeblocks",
+      "url": "https://github.com/newrelic/gatsby-theme-newrelic/issues/426",
+      "createdAt": "2021-03-24T14:49:13Z",
+      "comments": {
+        "totalCount": 4
+      },
+      "author": {
+        "login": "alexronquillo",
+        "id": "MDQ6VXNlcjg2NzIwOTA=",
+        "email": "",
+        "name": null
+      },
+      "number": 426,
+      "createdBy": "alexronquillo"
+    }
+  ],
   "cachedContributors": [
     {
       "id": 1395158,
@@ -39,6 +74,20 @@
       "contributions": 2
     },
     {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
+    },
+    {
+      "id": 19733683,
+      "login": "snyk-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
+      "htmlUrl": "https://github.com/snyk-bot",
+      "contributions": 2
+    },
+    {
       "id": 70179303,
       "login": "aswanson-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179303?v=4",
@@ -50,7 +99,7 @@
       "login": "rudouglas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
       "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 3
+      "contributions": 9
     },
     {
       "id": 55203603,
@@ -58,20 +107,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
       "htmlUrl": "https://github.com/austin-schaefer",
       "contributions": 2
-    },
-    {
-      "id": 39655074,
-      "login": "LizBaker",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
-      "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 38
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 1
     },
     {
       "id": 1946433,
@@ -85,7 +120,7 @@
       "login": "roadlittledawn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2952843?v=4",
       "htmlUrl": "https://github.com/roadlittledawn",
-      "contributions": 74
+      "contributions": 77
     },
     {
       "id": 2069584,
@@ -109,11 +144,11 @@
       "contributions": 916
     },
     {
-      "id": 19733683,
-      "login": "snyk-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
-      "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 2
+      "id": 39655074,
+      "login": "LizBaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
+      "htmlUrl": "https://github.com/LizBaker",
+      "contributions": 38
     },
     {
       "id": 38332422,

--- a/src/data/project-stats/newrelic-go-agent.json
+++ b/src/data/project-stats/newrelic-go-agent.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/go-agent",
   "issues": {
-    "open": 51
+    "open": 46
   },
-  "releases": 131,
+  "releases": 134,
   "latestRelease": {
-    "name": "v3/integrations/nrstan/v1.1.1",
-    "date": "2021-06-07T22:23:40Z"
+    "name": "v3.14.0",
+    "date": "2021-07-12T20:22:00Z"
   },
-  "commits": 2099,
-  "lastSixMonthsCommitTotal": 72,
-  "contributors": 36,
+  "commits": 2128,
+  "lastSixMonthsCommitTotal": 85,
+  "contributors": 37,
   "pullRequests": {
-    "open": 9
+    "open": 10
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -43,11 +43,11 @@
       "contributions": 1
     },
     {
-      "id": 48965776,
-      "login": "jodeev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
-      "htmlUrl": "https://github.com/jodeev",
-      "contributions": 9
+      "id": 590773,
+      "login": "flaviotruzzi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/590773?v=4",
+      "htmlUrl": "https://github.com/flaviotruzzi",
+      "contributions": 1
     },
     {
       "id": 4304849,
@@ -64,11 +64,11 @@
       "contributions": 147
     },
     {
-      "id": 590773,
-      "login": "flaviotruzzi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/590773?v=4",
-      "htmlUrl": "https://github.com/flaviotruzzi",
-      "contributions": 1
+      "id": 982820,
+      "login": "benweint",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/982820?v=4",
+      "htmlUrl": "https://github.com/benweint",
+      "contributions": 2
     },
     {
       "id": 5743678,
@@ -85,18 +85,18 @@
       "contributions": 1
     },
     {
-      "id": 52978576,
-      "login": "Miriam-R",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/52978576?v=4",
-      "htmlUrl": "https://github.com/Miriam-R",
+      "id": 704945,
+      "login": "alfred-landrum",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/704945?v=4",
+      "htmlUrl": "https://github.com/alfred-landrum",
       "contributions": 1
     },
     {
-      "id": 76975199,
-      "login": "nr-swilloughby",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76975199?v=4",
-      "htmlUrl": "https://github.com/nr-swilloughby",
-      "contributions": 11
+      "id": 1667247,
+      "login": "bearcherian",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1667247?v=4",
+      "htmlUrl": "https://github.com/bearcherian",
+      "contributions": 2
     },
     {
       "id": 15305011,
@@ -120,25 +120,25 @@
       "contributions": 1
     },
     {
-      "id": 704945,
-      "login": "alfred-landrum",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/704945?v=4",
-      "htmlUrl": "https://github.com/alfred-landrum",
-      "contributions": 1
+      "id": 76975199,
+      "login": "nr-swilloughby",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76975199?v=4",
+      "htmlUrl": "https://github.com/nr-swilloughby",
+      "contributions": 29
     },
     {
-      "id": 1667247,
-      "login": "bearcherian",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1667247?v=4",
-      "htmlUrl": "https://github.com/bearcherian",
-      "contributions": 2
+      "id": 52978576,
+      "login": "Miriam-R",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/52978576?v=4",
+      "htmlUrl": "https://github.com/Miriam-R",
+      "contributions": 1
     },
     {
       "id": 13123145,
       "login": "RichVanderwal",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13123145?v=4",
       "htmlUrl": "https://github.com/RichVanderwal",
-      "contributions": 22
+      "contributions": 23
     },
     {
       "id": 3920286,
@@ -190,11 +190,11 @@
       "contributions": 1
     },
     {
-      "id": 982820,
-      "login": "benweint",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/982820?v=4",
-      "htmlUrl": "https://github.com/benweint",
-      "contributions": 2
+      "id": 48965776,
+      "login": "jodeev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
+      "htmlUrl": "https://github.com/jodeev",
+      "contributions": 9
     },
     {
       "id": 12864641,
@@ -257,6 +257,13 @@
       "login": "lvxv",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5800970?v=4",
       "htmlUrl": "https://github.com/lvxv",
+      "contributions": 1
+    },
+    {
+      "id": 28936242,
+      "login": "nc-wittj",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28936242?v=4",
+      "htmlUrl": "https://github.com/nc-wittj",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-helm-charts.json
+++ b/src/data/project-stats/newrelic-helm-charts.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/helm-charts",
   "issues": {
-    "open": 47
+    "open": 42
   },
-  "releases": 230,
+  "releases": 242,
   "latestRelease": {
-    "name": "nri-statsd-1.0.2",
-    "date": "2021-06-18T10:31:50Z"
+    "name": "newrelic-logging-1.5.0",
+    "date": "2021-07-15T13:00:12Z"
   },
-  "commits": 278,
-  "lastSixMonthsCommitTotal": 93,
-  "contributors": 45,
+  "commits": 294,
+  "lastSixMonthsCommitTotal": 101,
+  "contributors": 47,
   "pullRequests": {
-    "open": 15
+    "open": 14
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -53,46 +53,18 @@
   ],
   "cachedContributors": [
     {
+      "id": 7537725,
+      "login": "tejunior",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7537725?v=4",
+      "htmlUrl": "https://github.com/tejunior",
+      "contributions": 2
+    },
+    {
       "id": 16539896,
       "login": "invidian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16539896?v=4",
       "htmlUrl": "https://github.com/invidian",
       "contributions": 3
-    },
-    {
-      "id": 11544146,
-      "login": "jeenx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11544146?v=4",
-      "htmlUrl": "https://github.com/jeenx",
-      "contributions": 1
-    },
-    {
-      "id": 159076,
-      "login": "douglascamata",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
-      "htmlUrl": "https://github.com/douglascamata",
-      "contributions": 25
-    },
-    {
-      "id": 33644,
-      "login": "velothump",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33644?v=4",
-      "htmlUrl": "https://github.com/velothump",
-      "contributions": 2
-    },
-    {
-      "id": 13766937,
-      "login": "gonzalobarbitta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13766937?v=4",
-      "htmlUrl": "https://github.com/gonzalobarbitta",
-      "contributions": 3
-    },
-    {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 1
     },
     {
       "id": 6243832,
@@ -102,6 +74,34 @@
       "contributions": 6
     },
     {
+      "id": 22605483,
+      "login": "quentinplessis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22605483?v=4",
+      "htmlUrl": "https://github.com/quentinplessis",
+      "contributions": 1
+    },
+    {
+      "id": 33644,
+      "login": "velothump",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33644?v=4",
+      "htmlUrl": "https://github.com/velothump",
+      "contributions": 2
+    },
+    {
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 13
+    },
+    {
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 1
+    },
+    {
       "id": 1773616,
       "login": "theletterf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
@@ -109,10 +109,10 @@
       "contributions": 1
     },
     {
-      "id": 347547,
-      "login": "goody44",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/347547?v=4",
-      "htmlUrl": "https://github.com/goody44",
+      "id": 317362,
+      "login": "danybmx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/317362?v=4",
+      "htmlUrl": "https://github.com/danybmx",
       "contributions": 1
     },
     {
@@ -123,25 +123,25 @@
       "contributions": 1
     },
     {
-      "id": 12255612,
-      "login": "gopisaba",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12255612?v=4",
-      "htmlUrl": "https://github.com/gopisaba",
+      "id": 11544146,
+      "login": "jeenx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11544146?v=4",
+      "htmlUrl": "https://github.com/jeenx",
       "contributions": 1
     },
     {
-      "id": 45029322,
-      "login": "polfliet",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45029322?v=4",
-      "htmlUrl": "https://github.com/polfliet",
-      "contributions": 2
+      "id": 13733349,
+      "login": "duncaan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13733349?v=4",
+      "htmlUrl": "https://github.com/duncaan",
+      "contributions": 1
     },
     {
-      "id": 503802,
-      "login": "jorik",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/503802?v=4",
-      "htmlUrl": "https://github.com/jorik",
-      "contributions": 13
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
+      "contributions": 25
     },
     {
       "id": 184273,
@@ -165,11 +165,11 @@
       "contributions": 14
     },
     {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
-      "contributions": 25
+      "id": 45029322,
+      "login": "polfliet",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45029322?v=4",
+      "htmlUrl": "https://github.com/polfliet",
+      "contributions": 2
     },
     {
       "id": 43244625,
@@ -186,25 +186,25 @@
       "contributions": 2
     },
     {
-      "id": 5163675,
-      "login": "lenfree",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5163675?v=4",
-      "htmlUrl": "https://github.com/lenfree",
-      "contributions": 1
-    },
-    {
-      "id": 7001514,
-      "login": "bmcfeely",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7001514?v=4",
-      "htmlUrl": "https://github.com/bmcfeely",
-      "contributions": 1
-    },
-    {
       "id": 11836452,
       "login": "edmocosta",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11836452?v=4",
       "htmlUrl": "https://github.com/edmocosta",
       "contributions": 2
+    },
+    {
+      "id": 503802,
+      "login": "jorik",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/503802?v=4",
+      "htmlUrl": "https://github.com/jorik",
+      "contributions": 13
+    },
+    {
+      "id": 13766937,
+      "login": "gonzalobarbitta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13766937?v=4",
+      "htmlUrl": "https://github.com/gonzalobarbitta",
+      "contributions": 3
     },
     {
       "id": 9218272,
@@ -228,18 +228,18 @@
       "contributions": 4
     },
     {
-      "id": 7537725,
-      "login": "tejunior",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7537725?v=4",
-      "htmlUrl": "https://github.com/tejunior",
-      "contributions": 2
+      "id": 7001514,
+      "login": "bmcfeely",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7001514?v=4",
+      "htmlUrl": "https://github.com/bmcfeely",
+      "contributions": 1
     },
     {
-      "id": 2459231,
-      "login": "AdrienKuhn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2459231?v=4",
-      "htmlUrl": "https://github.com/AdrienKuhn",
-      "contributions": 5
+      "id": 73652669,
+      "login": "arvdias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
+      "htmlUrl": "https://github.com/arvdias",
+      "contributions": 12
     },
     {
       "id": 630550,
@@ -249,17 +249,24 @@
       "contributions": 4
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 25
+      "id": 5163675,
+      "login": "lenfree",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5163675?v=4",
+      "htmlUrl": "https://github.com/lenfree",
+      "contributions": 1
     },
     {
-      "id": 13733349,
-      "login": "duncaan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13733349?v=4",
-      "htmlUrl": "https://github.com/duncaan",
+      "id": 347547,
+      "login": "goody44",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/347547?v=4",
+      "htmlUrl": "https://github.com/goody44",
+      "contributions": 1
+    },
+    {
+      "id": 12255612,
+      "login": "gopisaba",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12255612?v=4",
+      "htmlUrl": "https://github.com/gopisaba",
       "contributions": 1
     },
     {
@@ -284,11 +291,11 @@
       "contributions": 9
     },
     {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 12
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 31
     },
     {
       "id": 18450816,
@@ -319,6 +326,13 @@
       "contributions": 30
     },
     {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 2
+    },
+    {
       "id": 72516550,
       "login": "cleon-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/72516550?v=4",
@@ -333,11 +347,11 @@
       "contributions": 1
     },
     {
-      "id": 22605483,
-      "login": "quentinplessis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/22605483?v=4",
-      "htmlUrl": "https://github.com/quentinplessis",
-      "contributions": 1
+      "id": 2459231,
+      "login": "AdrienKuhn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2459231?v=4",
+      "htmlUrl": "https://github.com/AdrienKuhn",
+      "contributions": 5
     },
     {
       "id": 10218908,
@@ -361,11 +375,11 @@
       "contributions": 1
     },
     {
-      "id": 73652669,
-      "login": "arvdias",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
-      "htmlUrl": "https://github.com/arvdias",
-      "contributions": 12
+      "id": 159076,
+      "login": "douglascamata",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
+      "htmlUrl": "https://github.com/douglascamata",
+      "contributions": 27
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-infra-identity-client-go.json
+++ b/src/data/project-stats/newrelic-infra-identity-client-go.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 1
-    },
-    {
       "id": 7992384,
       "login": "paperclypse",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
       "htmlUrl": "https://github.com/brushknight",
       "contributions": 10
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
     },
     {
       "id": 7040181,

--- a/src/data/project-stats/newrelic-infra-integrations-sdk.json
+++ b/src/data/project-stats/newrelic-infra-integrations-sdk.json
@@ -9,20 +9,20 @@
     "date": "2021-06-01T09:39:42Z"
   },
   "commits": 720,
-  "lastSixMonthsCommitTotal": 15,
+  "lastSixMonthsCommitTotal": 7,
   "contributors": 22,
   "pullRequests": {
-    "open": 1
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 1
+      "id": 717815,
+      "login": "carlosroman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
+      "htmlUrl": "https://github.com/carlosroman",
+      "contributions": 4
     },
     {
       "id": 9912,
@@ -32,60 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 717815,
-      "login": "carlosroman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
-      "htmlUrl": "https://github.com/carlosroman",
-      "contributions": 4
-    },
-    {
-      "id": 466745,
-      "login": "vvydier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/466745?v=4",
-      "htmlUrl": "https://github.com/vvydier",
-      "contributions": 3
-    },
-    {
-      "id": 2054195,
-      "login": "ardias",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2054195?v=4",
-      "htmlUrl": "https://github.com/ardias",
-      "contributions": 11
-    },
-    {
-      "id": 4612272,
-      "login": "Noly",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
-      "htmlUrl": "https://github.com/Noly",
-      "contributions": 6
-    },
-    {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 25
-    },
-    {
-      "id": 15685307,
-      "login": "cristianciutea",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
-      "htmlUrl": "https://github.com/cristianciutea",
-      "contributions": 15
-    },
-    {
-      "id": 3622298,
-      "login": "heaje",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3622298?v=4",
-      "htmlUrl": "https://github.com/heaje",
+      "id": 29264964,
+      "login": "zlesnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
+      "htmlUrl": "https://github.com/zlesnr",
       "contributions": 1
-    },
-    {
-      "id": 5297542,
-      "login": "alejandrodnm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
-      "htmlUrl": "https://github.com/alejandrodnm",
-      "contributions": 15
     },
     {
       "id": 13438133,
@@ -95,11 +46,60 @@
       "contributions": 1
     },
     {
+      "id": 2054195,
+      "login": "ardias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2054195?v=4",
+      "htmlUrl": "https://github.com/ardias",
+      "contributions": 11
+    },
+    {
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 1
+    },
+    {
+      "id": 3622298,
+      "login": "heaje",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3622298?v=4",
+      "htmlUrl": "https://github.com/heaje",
+      "contributions": 1
+    },
+    {
+      "id": 15685307,
+      "login": "cristianciutea",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
+      "htmlUrl": "https://github.com/cristianciutea",
+      "contributions": 15
+    },
+    {
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 25
+    },
+    {
+      "id": 5297542,
+      "login": "alejandrodnm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
+      "htmlUrl": "https://github.com/alejandrodnm",
+      "contributions": 15
+    },
+    {
       "id": 10852,
       "login": "areina",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10852?v=4",
       "htmlUrl": "https://github.com/areina",
       "contributions": 27
+    },
+    {
+      "id": 34025886,
+      "login": "ikavanaghNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34025886?v=4",
+      "htmlUrl": "https://github.com/ikavanaghNR",
+      "contributions": 20
     },
     {
       "id": 939550,
@@ -109,25 +109,25 @@
       "contributions": 4
     },
     {
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 6
+    },
+    {
+      "id": 466745,
+      "login": "vvydier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/466745?v=4",
+      "htmlUrl": "https://github.com/vvydier",
+      "contributions": 3
+    },
+    {
       "id": 3969485,
       "login": "brushknight",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
       "htmlUrl": "https://github.com/brushknight",
       "contributions": 5
-    },
-    {
-      "id": 29264964,
-      "login": "zlesnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
-      "htmlUrl": "https://github.com/zlesnr",
-      "contributions": 1
-    },
-    {
-      "id": 34025886,
-      "login": "ikavanaghNR",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34025886?v=4",
-      "htmlUrl": "https://github.com/ikavanaghNR",
-      "contributions": 20
     },
     {
       "id": 1083296,

--- a/src/data/project-stats/newrelic-infrastructure-agent-ansible.json
+++ b/src/data/project-stats/newrelic-infrastructure-agent-ansible.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/infrastructure-agent-ansible",
   "issues": {
-    "open": 10
+    "open": 6
   },
   "releases": 15,
   "latestRelease": {
     "name": "0.8.2",
     "date": "2019-07-10T08:26:26Z"
   },
-  "commits": 114,
-  "lastSixMonthsCommitTotal": 2,
-  "contributors": 21,
+  "commits": 159,
+  "lastSixMonthsCommitTotal": 42,
+  "contributors": 26,
   "pullRequests": {
-    "open": 8
+    "open": 3
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -23,13 +23,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/48232?v=4",
       "htmlUrl": "https://github.com/davetapley",
       "contributions": 1
-    },
-    {
-      "id": 39911991,
-      "login": "davidbrota",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39911991?v=4",
-      "htmlUrl": "https://github.com/davidbrota",
-      "contributions": 2
     },
     {
       "id": 351038,
@@ -46,11 +39,11 @@
       "contributions": 1
     },
     {
-      "id": 20031994,
-      "login": "ripclawffb",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/20031994?v=4",
-      "htmlUrl": "https://github.com/ripclawffb",
-      "contributions": 1
+      "id": 18057391,
+      "login": "bartier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18057391?v=4",
+      "htmlUrl": "https://github.com/bartier",
+      "contributions": 14
     },
     {
       "id": 2077281,
@@ -60,11 +53,11 @@
       "contributions": 1
     },
     {
-      "id": 9837641,
-      "login": "abedk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9837641?v=4",
-      "htmlUrl": "https://github.com/abedk",
-      "contributions": 1
+      "id": 715538,
+      "login": "rdeknijf",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/715538?v=4",
+      "htmlUrl": "https://github.com/rdeknijf",
+      "contributions": 2
     },
     {
       "id": 401819,
@@ -74,11 +67,11 @@
       "contributions": 1
     },
     {
-      "id": 2896066,
-      "login": "ryanpineo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2896066?v=4",
-      "htmlUrl": "https://github.com/ryanpineo",
-      "contributions": 2
+      "id": 763439,
+      "login": "nicofff",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/763439?v=4",
+      "htmlUrl": "https://github.com/nicofff",
+      "contributions": 1
     },
     {
       "id": 15685307,
@@ -88,11 +81,11 @@
       "contributions": 11
     },
     {
-      "id": 1876430,
-      "login": "xino12",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1876430?v=4",
-      "htmlUrl": "https://github.com/xino12",
-      "contributions": 1
+      "id": 2896066,
+      "login": "ryanpineo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2896066?v=4",
+      "htmlUrl": "https://github.com/ryanpineo",
+      "contributions": 2
     },
     {
       "id": 5297542,
@@ -100,6 +93,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
       "htmlUrl": "https://github.com/alejandrodnm",
       "contributions": 8
+    },
+    {
+      "id": 1876430,
+      "login": "xino12",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1876430?v=4",
+      "htmlUrl": "https://github.com/xino12",
+      "contributions": 1
     },
     {
       "id": 12295310,
@@ -116,6 +116,13 @@
       "contributions": 2
     },
     {
+      "id": 32712520,
+      "login": "dannybrody",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32712520?v=4",
+      "htmlUrl": "https://github.com/dannybrody",
+      "contributions": 1
+    },
+    {
       "id": 717815,
       "login": "carlosroman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
@@ -123,18 +130,46 @@
       "contributions": 1
     },
     {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
+      "id": 20031994,
+      "login": "ripclawffb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20031994?v=4",
+      "htmlUrl": "https://github.com/ripclawffb",
       "contributions": 1
     },
     {
-      "id": 715538,
-      "login": "rdeknijf",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/715538?v=4",
-      "htmlUrl": "https://github.com/rdeknijf",
+      "id": 7643439,
+      "login": "jacobsnapp",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7643439?v=4",
+      "htmlUrl": "https://github.com/jacobsnapp",
+      "contributions": 1
+    },
+    {
+      "id": 9837641,
+      "login": "abedk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9837641?v=4",
+      "htmlUrl": "https://github.com/abedk",
+      "contributions": 1
+    },
+    {
+      "id": 39911991,
+      "login": "davidbrota",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39911991?v=4",
+      "htmlUrl": "https://github.com/davidbrota",
       "contributions": 2
+    },
+    {
+      "id": 11629311,
+      "login": "blofeldthefish",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11629311?v=4",
+      "htmlUrl": "https://github.com/blofeldthefish",
+      "contributions": 5
+    },
+    {
+      "id": 52407257,
+      "login": "JakubKotkowiak",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/52407257?v=4",
+      "htmlUrl": "https://github.com/JakubKotkowiak",
+      "contributions": 11
     },
     {
       "id": 18354,

--- a/src/data/project-stats/newrelic-infrastructure-agent-chef.json
+++ b/src/data/project-stats/newrelic-infrastructure-agent-chef.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/infrastructure-agent-chef",
   "issues": {
-    "open": 13
+    "open": 11
   },
   "releases": 18,
   "latestRelease": {
     "name": "0.11.0",
     "date": "2019-07-04T07:39:12Z"
   },
-  "commits": 131,
-  "lastSixMonthsCommitTotal": 2,
+  "commits": 136,
+  "lastSixMonthsCommitTotal": 7,
   "contributors": 13,
   "pullRequests": {
-    "open": 1
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,59 +25,10 @@
       "contributions": 2
     },
     {
-      "id": 2497895,
-      "login": "dlanner",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2497895?v=4",
-      "htmlUrl": "https://github.com/dlanner",
-      "contributions": 4
-    },
-    {
       "id": 640347,
       "login": "angusiguess",
       "avatarUrl": "https://avatars.githubusercontent.com/u/640347?v=4",
       "htmlUrl": "https://github.com/angusiguess",
-      "contributions": 1
-    },
-    {
-      "id": 12255612,
-      "login": "gopisaba",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12255612?v=4",
-      "htmlUrl": "https://github.com/gopisaba",
-      "contributions": 2
-    },
-    {
-      "id": 39911991,
-      "login": "davidbrota",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39911991?v=4",
-      "htmlUrl": "https://github.com/davidbrota",
-      "contributions": 2
-    },
-    {
-      "id": 7150978,
-      "login": "rsluzhynskyy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7150978?v=4",
-      "htmlUrl": "https://github.com/rsluzhynskyy",
-      "contributions": 3
-    },
-    {
-      "id": 5297542,
-      "login": "alejandrodnm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
-      "htmlUrl": "https://github.com/alejandrodnm",
-      "contributions": 20
-    },
-    {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
-      "contributions": 1
-    },
-    {
-      "id": 63525134,
-      "login": "mbwhelan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/63525134?v=4",
-      "htmlUrl": "https://github.com/mbwhelan",
       "contributions": 1
     },
     {
@@ -88,11 +39,60 @@
       "contributions": 1
     },
     {
+      "id": 7150978,
+      "login": "rsluzhynskyy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7150978?v=4",
+      "htmlUrl": "https://github.com/rsluzhynskyy",
+      "contributions": 3
+    },
+    {
+      "id": 39911991,
+      "login": "davidbrota",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39911991?v=4",
+      "htmlUrl": "https://github.com/davidbrota",
+      "contributions": 2
+    },
+    {
+      "id": 2497895,
+      "login": "dlanner",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2497895?v=4",
+      "htmlUrl": "https://github.com/dlanner",
+      "contributions": 4
+    },
+    {
+      "id": 5297542,
+      "login": "alejandrodnm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
+      "htmlUrl": "https://github.com/alejandrodnm",
+      "contributions": 20
+    },
+    {
+      "id": 63525134,
+      "login": "mbwhelan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/63525134?v=4",
+      "htmlUrl": "https://github.com/mbwhelan",
+      "contributions": 1
+    },
+    {
+      "id": 12255612,
+      "login": "gopisaba",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12255612?v=4",
+      "htmlUrl": "https://github.com/gopisaba",
+      "contributions": 2
+    },
+    {
       "id": 16387219,
       "login": "chrisminton",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16387219?v=4",
       "htmlUrl": "https://github.com/chrisminton",
       "contributions": 2
+    },
+    {
+      "id": 46314449,
+      "login": "zelaskov",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46314449?v=4",
+      "htmlUrl": "https://github.com/zelaskov",
+      "contributions": 3
     },
     {
       "id": 5935,

--- a/src/data/project-stats/newrelic-infrastructure-agent-puppet.json
+++ b/src/data/project-stats/newrelic-infrastructure-agent-puppet.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/infrastructure-agent-puppet",
   "issues": {
-    "open": 3
+    "open": 2
   },
-  "releases": 21,
+  "releases": 22,
   "latestRelease": {
-    "name": "0.10.2",
-    "date": "2021-05-05T16:28:50Z"
+    "name": "0.11.0",
+    "date": "2021-07-05T13:45:53Z"
   },
-  "commits": 155,
-  "lastSixMonthsCommitTotal": 31,
+  "commits": 172,
+  "lastSixMonthsCommitTotal": 46,
   "contributors": 27,
   "pullRequests": {
-    "open": 2
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,6 +25,13 @@
       "contributions": 1
     },
     {
+      "id": 42580929,
+      "login": "zeljkostjepanovic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42580929?v=4",
+      "htmlUrl": "https://github.com/zeljkostjepanovic",
+      "contributions": 2
+    },
+    {
       "id": 2957750,
       "login": "mstathers",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2957750?v=4",
@@ -32,11 +39,11 @@
       "contributions": 2
     },
     {
-      "id": 105565,
-      "login": "amiryal",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/105565?v=4",
-      "htmlUrl": "https://github.com/amiryal",
-      "contributions": 1
+      "id": 5935,
+      "login": "chaupt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5935?v=4",
+      "htmlUrl": "https://github.com/chaupt",
+      "contributions": 3
     },
     {
       "id": 22596,
@@ -60,13 +67,6 @@
       "contributions": 3
     },
     {
-      "id": 2538971,
-      "login": "imehdihosseini",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2538971?v=4",
-      "htmlUrl": "https://github.com/imehdihosseini",
-      "contributions": 4
-    },
-    {
       "id": 6640829,
       "login": "hjfbynara",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6640829?v=4",
@@ -74,18 +74,11 @@
       "contributions": 1
     },
     {
-      "id": 5935,
-      "login": "chaupt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5935?v=4",
-      "htmlUrl": "https://github.com/chaupt",
-      "contributions": 3
-    },
-    {
-      "id": 42580929,
-      "login": "zeljkostjepanovic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42580929?v=4",
-      "htmlUrl": "https://github.com/zeljkostjepanovic",
-      "contributions": 2
+      "id": 52407257,
+      "login": "JakubKotkowiak",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/52407257?v=4",
+      "htmlUrl": "https://github.com/JakubKotkowiak",
+      "contributions": 11
     },
     {
       "id": 1796577,
@@ -158,10 +151,10 @@
       "contributions": 1
     },
     {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
+      "id": 105565,
+      "login": "amiryal",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/105565?v=4",
+      "htmlUrl": "https://github.com/amiryal",
       "contributions": 1
     },
     {
@@ -179,11 +172,11 @@
       "contributions": 1
     },
     {
-      "id": 52407257,
-      "login": "JakubKotkowiak",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/52407257?v=4",
-      "htmlUrl": "https://github.com/JakubKotkowiak",
-      "contributions": 6
+      "id": 2538971,
+      "login": "imehdihosseini",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2538971?v=4",
+      "htmlUrl": "https://github.com/imehdihosseini",
+      "contributions": 4
     },
     {
       "id": 19955251,
@@ -191,6 +184,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/19955251?v=4",
       "htmlUrl": "https://github.com/kwstone14",
       "contributions": 1
+    },
+    {
+      "id": 46314449,
+      "login": "zelaskov",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46314449?v=4",
+      "htmlUrl": "https://github.com/zelaskov",
+      "contributions": 8
     },
     {
       "id": 1876430,

--- a/src/data/project-stats/newrelic-infrastructure-agent.json
+++ b/src/data/project-stats/newrelic-infrastructure-agent.json
@@ -3,40 +3,40 @@
   "issues": {
     "open": 72
   },
-  "releases": 34,
+  "releases": 31,
   "latestRelease": {
-    "name": "1.19.4",
-    "date": "2021-06-17T15:38:29Z"
+    "name": "1.19.2",
+    "date": "2021-07-07T11:18:27Z"
   },
-  "commits": 281,
-  "lastSixMonthsCommitTotal": 103,
-  "contributors": 27,
+  "commits": 302,
+  "lastSixMonthsCommitTotal": 121,
+  "contributors": 28,
   "pullRequests": {
-    "open": 4
+    "open": 9
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 13966363,
-      "login": "carlossscastro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
-      "htmlUrl": "https://github.com/carlossscastro",
-      "contributions": 1
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 22
     },
     {
-      "id": 6243832,
-      "login": "jsubirat",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6243832?v=4",
-      "htmlUrl": "https://github.com/jsubirat",
-      "contributions": 4
+      "id": 15685307,
+      "login": "cristianciutea",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
+      "htmlUrl": "https://github.com/cristianciutea",
+      "contributions": 19
     },
     {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 7
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 129
     },
     {
       "id": 20245790,
@@ -46,18 +46,18 @@
       "contributions": 1
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
+      "id": 13966363,
+      "login": "carlossscastro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
+      "htmlUrl": "https://github.com/carlossscastro",
       "contributions": 1
     },
     {
-      "id": 4612272,
-      "login": "Noly",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
-      "htmlUrl": "https://github.com/Noly",
-      "contributions": 22
+      "id": 46498444,
+      "login": "lchapman4",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46498444?v=4",
+      "htmlUrl": "https://github.com/lchapman4",
+      "contributions": 1
     },
     {
       "id": 976883,
@@ -67,10 +67,10 @@
       "contributions": 1
     },
     {
-      "id": 46498444,
-      "login": "lchapman4",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46498444?v=4",
-      "htmlUrl": "https://github.com/lchapman4",
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
     },
     {
@@ -88,25 +88,25 @@
       "contributions": 2
     },
     {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 112
+      "id": 6243832,
+      "login": "jsubirat",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6243832?v=4",
+      "htmlUrl": "https://github.com/jsubirat",
+      "contributions": 4
     },
     {
-      "id": 15685307,
-      "login": "cristianciutea",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
-      "htmlUrl": "https://github.com/cristianciutea",
-      "contributions": 19
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 7
     },
     {
       "id": 3969485,
       "login": "brushknight",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
       "htmlUrl": "https://github.com/brushknight",
-      "contributions": 32
+      "contributions": 33
     },
     {
       "id": 43244625,
@@ -120,6 +120,13 @@
       "login": "ivancorrales",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12560219?v=4",
       "htmlUrl": "https://github.com/ivancorrales",
+      "contributions": 1
+    },
+    {
+      "id": 7537725,
+      "login": "tejunior",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7537725?v=4",
+      "htmlUrl": "https://github.com/tejunior",
       "contributions": 1
     },
     {
@@ -169,7 +176,7 @@
       "login": "rubenruizdegauna",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
       "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 12
+      "contributions": 14
     },
     {
       "id": 717815,

--- a/src/data/project-stats/newrelic-infrastructure-bundle.json
+++ b/src/data/project-stats/newrelic-infrastructure-bundle.json
@@ -3,26 +3,33 @@
   "issues": {
     "open": 5
   },
-  "releases": 36,
+  "releases": 37,
   "latestRelease": {
-    "name": "2.6.1",
-    "date": "2021-06-21T12:41:30Z"
+    "name": "2.6.2",
+    "date": "2021-07-08T15:54:57Z"
   },
-  "commits": 145,
-  "lastSixMonthsCommitTotal": 45,
-  "contributors": 13,
+  "commits": 168,
+  "lastSixMonthsCommitTotal": 66,
+  "contributors": 14,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 4612272,
-      "login": "Noly",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
-      "htmlUrl": "https://github.com/Noly",
-      "contributions": 2
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 22
+    },
+    {
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 1
     },
     {
       "id": 5143130,
@@ -39,11 +46,11 @@
       "contributions": 1
     },
     {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 20
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 2
     },
     {
       "id": 929261,
@@ -67,13 +74,6 @@
       "contributions": 1
     },
     {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 1
-    },
-    {
       "id": 717815,
       "login": "carlosroman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
@@ -92,7 +92,7 @@
       "login": "roobre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
       "htmlUrl": "https://github.com/roobre",
-      "contributions": 20
+      "contributions": 35
     },
     {
       "id": 12560219,
@@ -100,6 +100,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/12560219?v=4",
       "htmlUrl": "https://github.com/ivancorrales",
       "contributions": 6
+    },
+    {
+      "id": 16539896,
+      "login": "invidian",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16539896?v=4",
+      "htmlUrl": "https://github.com/invidian",
+      "contributions": 4
     },
     {
       "id": 73652669,

--- a/src/data/project-stats/newrelic-infrastructure-publish-action.json
+++ b/src/data/project-stats/newrelic-infrastructure-publish-action.json
@@ -3,20 +3,27 @@
   "issues": {
     "open": 2
   },
-  "releases": 18,
+  "releases": 19,
   "latestRelease": {
-    "name": "v1.0.16",
-    "date": "2021-06-22T07:19:39Z"
+    "name": "v1.0.17",
+    "date": "2021-07-01T14:58:32Z"
   },
-  "commits": 194,
-  "lastSixMonthsCommitTotal": 194,
+  "commits": 195,
+  "lastSixMonthsCommitTotal": 195,
   "contributors": 10,
   "pullRequests": {
-    "open": 3
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 81
+    },
     {
       "id": 3969485,
       "login": "brushknight",
@@ -25,17 +32,10 @@
       "contributions": 16
     },
     {
-      "id": 4612272,
-      "login": "Noly",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
-      "htmlUrl": "https://github.com/Noly",
-      "contributions": 6
-    },
-    {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
     },
     {
@@ -46,25 +46,25 @@
       "contributions": 2
     },
     {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
       "contributions": 1
     },
     {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 81
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 6
     },
     {
       "id": 5143130,
       "login": "gsanchezgavier",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
       "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 1
+      "contributions": 2
     },
     {
       "id": 43335750,

--- a/src/data/project-stats/newrelic-integrations-pkg-test-action.json
+++ b/src/data/project-stats/newrelic-integrations-pkg-test-action.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/integrations-pkg-test-action",
   "issues": {
-    "open": 3
+    "open": 4
   },
   "releases": 15,
   "latestRelease": {

--- a/src/data/project-stats/newrelic-java-agent-api.json
+++ b/src/data/project-stats/newrelic-java-agent-api.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 35,
-  "lastSixMonthsCommitTotal": 5,
+  "commits": 36,
+  "lastSixMonthsCommitTotal": 6,
   "contributors": 9,
   "pullRequests": {
     "open": 0
@@ -15,24 +15,17 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 211186,
-      "login": "toddwest",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/211186?v=4",
-      "htmlUrl": "https://github.com/toddwest",
-      "contributions": 2
-    },
-    {
-      "id": 842717,
-      "login": "tspring",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/842717?v=4",
-      "htmlUrl": "https://github.com/tspring",
-      "contributions": 10
-    },
-    {
       "id": 1572019,
       "login": "sebastianrmirz",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1572019?v=4",
       "htmlUrl": "https://github.com/sebastianrmirz",
+      "contributions": 2
+    },
+    {
+      "id": 211186,
+      "login": "toddwest",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/211186?v=4",
+      "htmlUrl": "https://github.com/toddwest",
       "contributions": 2
     },
     {
@@ -41,6 +34,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
       "htmlUrl": "https://github.com/jasonjkeller",
       "contributions": 7
+    },
+    {
+      "id": 842717,
+      "login": "tspring",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/842717?v=4",
+      "htmlUrl": "https://github.com/tspring",
+      "contributions": 10
     },
     {
       "id": 34418638,
@@ -61,7 +61,7 @@
       "login": "meiao",
       "avatarUrl": "https://avatars.githubusercontent.com/u/292463?v=4",
       "htmlUrl": "https://github.com/meiao",
-      "contributions": 2
+      "contributions": 3
     },
     {
       "id": 24482401,

--- a/src/data/project-stats/newrelic-java-aws-lambda.json
+++ b/src/data/project-stats/newrelic-java-aws-lambda.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/java-aws-lambda",
   "issues": {
-    "open": 1
+    "open": 0
   },
   "releases": 3,
   "latestRelease": {
@@ -46,11 +46,11 @@
       "contributions": 16
     },
     {
-      "id": 734757,
-      "login": "agarbutt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/734757?v=4",
-      "htmlUrl": "https://github.com/agarbutt",
-      "contributions": 5
+      "id": 211186,
+      "login": "toddwest",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/211186?v=4",
+      "htmlUrl": "https://github.com/toddwest",
+      "contributions": 1
     },
     {
       "id": 585473,
@@ -60,18 +60,18 @@
       "contributions": 3
     },
     {
-      "id": 211186,
-      "login": "toddwest",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/211186?v=4",
-      "htmlUrl": "https://github.com/toddwest",
-      "contributions": 1
-    },
-    {
       "id": 24482401,
       "login": "XiXiaPdx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
       "htmlUrl": "https://github.com/XiXiaPdx",
       "contributions": 1
+    },
+    {
+      "id": 734757,
+      "login": "agarbutt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/734757?v=4",
+      "htmlUrl": "https://github.com/agarbutt",
+      "contributions": 5
     },
     {
       "id": 46032291,

--- a/src/data/project-stats/newrelic-java-log-extensions.json
+++ b/src/data/project-stats/newrelic-java-log-extensions.json
@@ -9,7 +9,7 @@
     "date": "2021-05-18T20:39:48Z"
   },
   "commits": 98,
-  "lastSixMonthsCommitTotal": 12,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 9,
   "pullRequests": {
     "open": 0
@@ -18,6 +18,13 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
+    },
+    {
       "id": 49817386,
       "login": "jeffalder",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
@@ -25,18 +32,11 @@
       "contributions": 48
     },
     {
-      "id": 24482401,
-      "login": "XiXiaPdx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
-      "htmlUrl": "https://github.com/XiXiaPdx",
-      "contributions": 2
-    },
-    {
-      "id": 54085190,
-      "login": "breedx-nr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54085190?v=4",
-      "htmlUrl": "https://github.com/breedx-nr",
-      "contributions": 3
+      "id": 9247809,
+      "login": "gstoupis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9247809?v=4",
+      "htmlUrl": "https://github.com/gstoupis",
+      "contributions": 4
     },
     {
       "id": 3496648,
@@ -46,18 +46,18 @@
       "contributions": 4
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
+      "id": 54085190,
+      "login": "breedx-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54085190?v=4",
+      "htmlUrl": "https://github.com/breedx-nr",
+      "contributions": 3
     },
     {
-      "id": 9247809,
-      "login": "gstoupis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9247809?v=4",
-      "htmlUrl": "https://github.com/gstoupis",
-      "contributions": 4
+      "id": 24482401,
+      "login": "XiXiaPdx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
+      "htmlUrl": "https://github.com/XiXiaPdx",
+      "contributions": 2
     },
     {
       "id": 3536684,

--- a/src/data/project-stats/newrelic-k8s-metadata-injection.json
+++ b/src/data/project-stats/newrelic-k8s-metadata-injection.json
@@ -9,10 +9,10 @@
     "date": "2021-06-01T10:40:05Z"
   },
   "commits": 103,
-  "lastSixMonthsCommitTotal": 10,
+  "lastSixMonthsCommitTotal": 8,
   "contributors": 16,
   "pullRequests": {
-    "open": 4
+    "open": 5
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -32,31 +32,17 @@
       "contributions": 1
     },
     {
-      "id": 503802,
-      "login": "jorik",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/503802?v=4",
-      "htmlUrl": "https://github.com/jorik",
-      "contributions": 1
-    },
-    {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 1
+      "id": 1083296,
+      "login": "smoya",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1083296?v=4",
+      "htmlUrl": "https://github.com/smoya",
+      "contributions": 19
     },
     {
       "id": 1684801,
       "login": "cvpinhe",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1684801?v=4",
       "htmlUrl": "https://github.com/cvpinhe",
-      "contributions": 1
-    },
-    {
-      "id": 73652669,
-      "login": "arvdias",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
-      "htmlUrl": "https://github.com/arvdias",
       "contributions": 1
     },
     {
@@ -74,11 +60,25 @@
       "contributions": 1
     },
     {
+      "id": 159076,
+      "login": "douglascamata",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
+      "htmlUrl": "https://github.com/douglascamata",
+      "contributions": 16
+    },
+    {
       "id": 5297542,
       "login": "alejandrodnm",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
       "htmlUrl": "https://github.com/alejandrodnm",
       "contributions": 12
+    },
+    {
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
+      "contributions": 6
     },
     {
       "id": 488391,
@@ -95,11 +95,11 @@
       "contributions": 4
     },
     {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
-      "contributions": 6
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
     },
     {
       "id": 33835,
@@ -109,11 +109,11 @@
       "contributions": 1
     },
     {
-      "id": 1083296,
-      "login": "smoya",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1083296?v=4",
-      "htmlUrl": "https://github.com/smoya",
-      "contributions": 19
+      "id": 503802,
+      "login": "jorik",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/503802?v=4",
+      "htmlUrl": "https://github.com/jorik",
+      "contributions": 1
     },
     {
       "id": 10852,
@@ -123,11 +123,11 @@
       "contributions": 14
     },
     {
-      "id": 159076,
-      "login": "douglascamata",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
-      "htmlUrl": "https://github.com/douglascamata",
-      "contributions": 16
+      "id": 73652669,
+      "login": "arvdias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
+      "htmlUrl": "https://github.com/arvdias",
+      "contributions": 1
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-kafka-connect-newrelic.json
+++ b/src/data/project-stats/newrelic-kafka-connect-newrelic.json
@@ -8,21 +8,35 @@
     "name": "v1.1",
     "date": "2021-04-21T18:24:47Z"
   },
-  "commits": 43,
-  "lastSixMonthsCommitTotal": 3,
-  "contributors": 5,
+  "commits": 48,
+  "lastSixMonthsCommitTotal": 6,
+  "contributors": 7,
   "pullRequests": {
-    "open": 5
+    "open": 4
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 8333200,
-      "login": "JimHagan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8333200?v=4",
-      "htmlUrl": "https://github.com/JimHagan",
-      "contributions": 2
+      "id": 558327,
+      "login": "maju6406",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/558327?v=4",
+      "htmlUrl": "https://github.com/maju6406",
+      "contributions": 3
+    },
+    {
+      "id": 30939429,
+      "login": "hanischandrew",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30939429?v=4",
+      "htmlUrl": "https://github.com/hanischandrew",
+      "contributions": 1
+    },
+    {
+      "id": 22718932,
+      "login": "benzhang94",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22718932?v=4",
+      "htmlUrl": "https://github.com/benzhang94",
+      "contributions": 1
     },
     {
       "id": 43244625,
@@ -32,18 +46,18 @@
       "contributions": 3
     },
     {
-      "id": 558327,
-      "login": "maju6406",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/558327?v=4",
-      "htmlUrl": "https://github.com/maju6406",
-      "contributions": 3
-    },
-    {
       "id": 156743,
       "login": "defconx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/156743?v=4",
       "htmlUrl": "https://github.com/defconx",
       "contributions": 4
+    },
+    {
+      "id": 8333200,
+      "login": "JimHagan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8333200?v=4",
+      "htmlUrl": "https://github.com/JimHagan",
+      "contributions": 2
     },
     {
       "id": 627905,

--- a/src/data/project-stats/newrelic-logstash-examples.json
+++ b/src/data/project-stats/newrelic-logstash-examples.json
@@ -15,10 +15,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
       "contributions": 1
     },
     {
@@ -29,10 +29,10 @@
       "contributions": 1
     },
     {
-      "id": 62337995,
-      "login": "jodstrcil",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
-      "htmlUrl": "https://github.com/jodstrcil",
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-logstash-output-plugin.json
+++ b/src/data/project-stats/newrelic-logstash-output-plugin.json
@@ -1,13 +1,13 @@
 {
   "projectFullName": "newrelic/logstash-output-plugin",
   "issues": {
-    "open": 1
+    "open": 0
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 21,
-  "lastSixMonthsCommitTotal": 4,
-  "contributors": 6,
+  "commits": 22,
+  "lastSixMonthsCommitTotal": 5,
+  "contributors": 7,
   "pullRequests": {
     "open": 0
   },
@@ -19,6 +19,13 @@
       "login": "bmcfeely",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7001514?v=4",
       "htmlUrl": "https://github.com/bmcfeely",
+      "contributions": 1
+    },
+    {
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-micrometer-registry-newrelic.json
+++ b/src/data/project-stats/newrelic-micrometer-registry-newrelic.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/micrometer-registry-newrelic",
   "issues": {
-    "open": 15
+    "open": 14
   },
   "releases": 8,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-06-10T00:31:51Z"
   },
   "commits": 187,
-  "lastSixMonthsCommitTotal": 18,
+  "lastSixMonthsCommitTotal": 15,
   "contributors": 15,
   "pullRequests": {
     "open": 0
@@ -32,18 +32,18 @@
       "contributions": 1
     },
     {
-      "id": 23264568,
-      "login": "juholgado",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/23264568?v=4",
-      "htmlUrl": "https://github.com/juholgado",
-      "contributions": 13
+      "id": 808713,
+      "login": "ebullient",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/808713?v=4",
+      "htmlUrl": "https://github.com/ebullient",
+      "contributions": 1
     },
     {
-      "id": 858731,
-      "login": "jkwatson",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
-      "htmlUrl": "https://github.com/jkwatson",
-      "contributions": 4
+      "id": 46032291,
+      "login": "grahamfuller1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46032291?v=4",
+      "htmlUrl": "https://github.com/grahamfuller1",
+      "contributions": 1
     },
     {
       "id": 210691,
@@ -53,11 +53,11 @@
       "contributions": 1
     },
     {
-      "id": 808713,
-      "login": "ebullient",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/808713?v=4",
-      "htmlUrl": "https://github.com/ebullient",
-      "contributions": 1
+      "id": 858731,
+      "login": "jkwatson",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
+      "htmlUrl": "https://github.com/jkwatson",
+      "contributions": 4
     },
     {
       "id": 165260,
@@ -116,11 +116,11 @@
       "contributions": 1
     },
     {
-      "id": 46032291,
-      "login": "grahamfuller1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46032291?v=4",
-      "htmlUrl": "https://github.com/grahamfuller1",
-      "contributions": 1
+      "id": 23264568,
+      "login": "juholgado",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/23264568?v=4",
+      "htmlUrl": "https://github.com/juholgado",
+      "contributions": 13
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-airflow-plugin.json
+++ b/src/data/project-stats/newrelic-newrelic-airflow-plugin.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/newrelic-airflow-plugin",
   "issues": {
-    "open": 6
+    "open": 7
   },
   "releases": 5,
   "latestRelease": {

--- a/src/data/project-stats/newrelic-newrelic-azure-log-ingestion.json
+++ b/src/data/project-stats/newrelic-newrelic-azure-log-ingestion.json
@@ -12,7 +12,7 @@
   "lastSixMonthsCommitTotal": 98,
   "contributors": 5,
   "pullRequests": {
-    "open": 0
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],

--- a/src/data/project-stats/newrelic-newrelic-browser-agent.json
+++ b/src/data/project-stats/newrelic-newrelic-browser-agent.json
@@ -8,11 +8,11 @@
     "name": "v1210",
     "date": "2021-06-22T22:36:48Z"
   },
-  "commits": 54,
-  "lastSixMonthsCommitTotal": 54,
+  "commits": 57,
+  "lastSixMonthsCommitTotal": 57,
   "contributors": 5,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -22,7 +22,7 @@
       "login": "aubreymasten",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4779220?v=4",
       "htmlUrl": "https://github.com/aubreymasten",
-      "contributions": 14
+      "contributions": 15
     },
     {
       "id": 43244625,
@@ -36,14 +36,14 @@
       "login": "martinkuba",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4933147?v=4",
       "htmlUrl": "https://github.com/martinkuba",
-      "contributions": 20
+      "contributions": 21
     },
     {
       "id": 24296585,
       "login": "metal-messiah",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24296585?v=4",
       "htmlUrl": "https://github.com/metal-messiah",
-      "contributions": 10
+      "contributions": 11
     },
     {
       "id": 18040274,

--- a/src/data/project-stats/newrelic-newrelic-cli.json
+++ b/src/data/project-stats/newrelic-newrelic-cli.json
@@ -3,16 +3,16 @@
   "issues": {
     "open": 15
   },
-  "releases": 111,
+  "releases": 125,
   "latestRelease": {
-    "name": "v0.28.12",
-    "date": "2021-06-23T22:28:59Z"
+    "name": "v0.30.5",
+    "date": "2021-07-14T22:33:40Z"
   },
-  "commits": 2163,
-  "lastSixMonthsCommitTotal": 1061,
-  "contributors": 22,
+  "commits": 2374,
+  "lastSixMonthsCommitTotal": 1090,
+  "contributors": 24,
   "pullRequests": {
-    "open": 13
+    "open": 4
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -32,39 +32,25 @@
       "contributions": 1
     },
     {
-      "id": 1183070,
-      "login": "GlenOFoghlu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1183070?v=4",
-      "htmlUrl": "https://github.com/GlenOFoghlu",
-      "contributions": 4
+      "id": 19716792,
+      "login": "njvrzm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19716792?v=4",
+      "htmlUrl": "https://github.com/njvrzm",
+      "contributions": 2
     },
     {
-      "id": 25180681,
-      "login": "renovate-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/25180681?v=4",
-      "htmlUrl": "https://github.com/renovate-bot",
-      "contributions": 196
+      "id": 1987319,
+      "login": "idirouhab",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1987319?v=4",
+      "htmlUrl": "https://github.com/idirouhab",
+      "contributions": 1
     },
     {
-      "id": 2590905,
-      "login": "sanderblue",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
-      "htmlUrl": "https://github.com/sanderblue",
-      "contributions": 84
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 32
-    },
-    {
-      "id": 455419,
-      "login": "jthurman42",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
-      "htmlUrl": "https://github.com/jthurman42",
-      "contributions": 174
+      "id": 11640472,
+      "login": "nicolasjhampton",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11640472?v=4",
+      "htmlUrl": "https://github.com/nicolasjhampton",
+      "contributions": 1
     },
     {
       "id": 7244569,
@@ -74,17 +60,31 @@
       "contributions": 3
     },
     {
-      "id": 19716792,
-      "login": "njvrzm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19716792?v=4",
-      "htmlUrl": "https://github.com/njvrzm",
-      "contributions": 2
+      "id": 25180681,
+      "login": "renovate-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/25180681?v=4",
+      "htmlUrl": "https://github.com/renovate-bot",
+      "contributions": 207
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
+      "id": 3522458,
+      "login": "jifeingo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3522458?v=4",
+      "htmlUrl": "https://github.com/jifeingo",
+      "contributions": 9
+    },
+    {
+      "id": 455419,
+      "login": "jthurman42",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
+      "htmlUrl": "https://github.com/jthurman42",
+      "contributions": 174
+    },
+    {
+      "id": 7197435,
+      "login": "SowmyaJujjuri",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7197435?v=4",
+      "htmlUrl": "https://github.com/SowmyaJujjuri",
       "contributions": 3
     },
     {
@@ -99,7 +99,21 @@
       "login": "nr-developer-toolkit",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62031461?v=4",
       "htmlUrl": "https://github.com/nr-developer-toolkit",
-      "contributions": 90
+      "contributions": 102
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 68
+    },
+    {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 3
     },
     {
       "id": 4481921,
@@ -109,32 +123,25 @@
       "contributions": 2
     },
     {
-      "id": 1987319,
-      "login": "idirouhab",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1987319?v=4",
-      "htmlUrl": "https://github.com/idirouhab",
+      "id": 47485486,
+      "login": "noahmmcgivern",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47485486?v=4",
+      "htmlUrl": "https://github.com/noahmmcgivern",
+      "contributions": 5
+    },
+    {
+      "id": 344634,
+      "login": "ruffy91",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/344634?v=4",
+      "htmlUrl": "https://github.com/ruffy91",
       "contributions": 1
     },
     {
-      "id": 3522458,
-      "login": "jifeingo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3522458?v=4",
-      "htmlUrl": "https://github.com/jifeingo",
-      "contributions": 9
-    },
-    {
-      "id": 11640472,
-      "login": "nicolasjhampton",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11640472?v=4",
-      "htmlUrl": "https://github.com/nicolasjhampton",
-      "contributions": 1
-    },
-    {
-      "id": 7197435,
-      "login": "SowmyaJujjuri",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7197435?v=4",
-      "htmlUrl": "https://github.com/SowmyaJujjuri",
-      "contributions": 3
+      "id": 413389,
+      "login": "ctrombley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
+      "htmlUrl": "https://github.com/ctrombley",
+      "contributions": 402
     },
     {
       "id": 29264964,
@@ -144,11 +151,18 @@
       "contributions": 228
     },
     {
-      "id": 344634,
-      "login": "ruffy91",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/344634?v=4",
-      "htmlUrl": "https://github.com/ruffy91",
-      "contributions": 1
+      "id": 1183070,
+      "login": "GlenOFoghlu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1183070?v=4",
+      "htmlUrl": "https://github.com/GlenOFoghlu",
+      "contributions": 4
+    },
+    {
+      "id": 2590905,
+      "login": "sanderblue",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
+      "htmlUrl": "https://github.com/sanderblue",
+      "contributions": 87
     },
     {
       "id": 61292402,
@@ -162,14 +176,14 @@
       "login": "Julien4218",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38018054?v=4",
       "htmlUrl": "https://github.com/Julien4218",
-      "contributions": 155
+      "contributions": 193
     },
     {
-      "id": 413389,
-      "login": "ctrombley",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
-      "htmlUrl": "https://github.com/ctrombley",
-      "contributions": 366
+      "id": 1580956,
+      "login": "chenrui333",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1580956?v=4",
+      "htmlUrl": "https://github.com/chenrui333",
+      "contributions": 3
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-client-go.json
+++ b/src/data/project-stats/newrelic-newrelic-client-go.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/newrelic-client-go",
   "issues": {
-    "open": 14
+    "open": 15
   },
-  "releases": 113,
+  "releases": 116,
   "latestRelease": {
-    "name": "v0.60.0",
-    "date": "2021-06-11T23:37:27Z"
+    "name": "v0.61.0",
+    "date": "2021-07-13T18:58:08Z"
   },
-  "commits": 1569,
-  "lastSixMonthsCommitTotal": 320,
-  "contributors": 23,
+  "commits": 1608,
+  "lastSixMonthsCommitTotal": 263,
+  "contributors": 25,
   "pullRequests": {
     "open": 5
   },
@@ -32,18 +32,18 @@
       "contributions": 4
     },
     {
-      "id": 25180681,
-      "login": "renovate-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/25180681?v=4",
-      "htmlUrl": "https://github.com/renovate-bot",
-      "contributions": 103
-    },
-    {
       "id": 7197435,
       "login": "SowmyaJujjuri",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7197435?v=4",
       "htmlUrl": "https://github.com/SowmyaJujjuri",
       "contributions": 8
+    },
+    {
+      "id": 1663955,
+      "login": "mbazhlekova",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1663955?v=4",
+      "htmlUrl": "https://github.com/mbazhlekova",
+      "contributions": 5
     },
     {
       "id": 3596655,
@@ -53,74 +53,11 @@
       "contributions": 2
     },
     {
-      "id": 245435,
-      "login": "caarlos0",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/245435?v=4",
-      "htmlUrl": "https://github.com/caarlos0",
-      "contributions": 2
-    },
-    {
-      "id": 62031461,
-      "login": "nr-developer-toolkit",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62031461?v=4",
-      "htmlUrl": "https://github.com/nr-developer-toolkit",
-      "contributions": 9
-    },
-    {
-      "id": 32712520,
-      "login": "dannybrody",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32712520?v=4",
-      "htmlUrl": "https://github.com/dannybrody",
-      "contributions": 1
-    },
-    {
-      "id": 455419,
-      "login": "jthurman42",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
-      "htmlUrl": "https://github.com/jthurman42",
-      "contributions": 296
-    },
-    {
-      "id": 3991975,
-      "login": "davidji99",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3991975?v=4",
-      "htmlUrl": "https://github.com/davidji99",
-      "contributions": 1
-    },
-    {
-      "id": 413389,
-      "login": "ctrombley",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
-      "htmlUrl": "https://github.com/ctrombley",
-      "contributions": 299
-    },
-    {
-      "id": 7471617,
-      "login": "Tarliton",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7471617?v=4",
-      "htmlUrl": "https://github.com/Tarliton",
-      "contributions": 3
-    },
-    {
-      "id": 5140827,
-      "login": "kminehart",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5140827?v=4",
-      "htmlUrl": "https://github.com/kminehart",
-      "contributions": 3
-    },
-    {
-      "id": 753159,
-      "login": "paul91",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/753159?v=4",
-      "htmlUrl": "https://github.com/paul91",
-      "contributions": 2
-    },
-    {
-      "id": 17018863,
-      "login": "jaymcgrath",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17018863?v=4",
-      "htmlUrl": "https://github.com/jaymcgrath",
-      "contributions": 3
+      "id": 25180681,
+      "login": "renovate-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/25180681?v=4",
+      "htmlUrl": "https://github.com/renovate-bot",
+      "contributions": 103
     },
     {
       "id": 20245790,
@@ -130,10 +67,24 @@
       "contributions": 4
     },
     {
-      "id": 12853539,
-      "login": "jhutchings1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12853539?v=4",
-      "htmlUrl": "https://github.com/jhutchings1",
+      "id": 32712520,
+      "login": "dannybrody",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32712520?v=4",
+      "htmlUrl": "https://github.com/dannybrody",
+      "contributions": 1
+    },
+    {
+      "id": 7471617,
+      "login": "Tarliton",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7471617?v=4",
+      "htmlUrl": "https://github.com/Tarliton",
+      "contributions": 3
+    },
+    {
+      "id": 3991975,
+      "login": "davidji99",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3991975?v=4",
+      "htmlUrl": "https://github.com/davidji99",
       "contributions": 1
     },
     {
@@ -144,6 +95,20 @@
       "contributions": 1
     },
     {
+      "id": 455419,
+      "login": "jthurman42",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
+      "htmlUrl": "https://github.com/jthurman42",
+      "contributions": 299
+    },
+    {
+      "id": 5140827,
+      "login": "kminehart",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5140827?v=4",
+      "htmlUrl": "https://github.com/kminehart",
+      "contributions": 3
+    },
+    {
       "id": 723533,
       "login": "monkeyherder",
       "avatarUrl": "https://avatars.githubusercontent.com/u/723533?v=4",
@@ -151,10 +116,59 @@
       "contributions": 3
     },
     {
+      "id": 143818,
+      "login": "colesnodgrass",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/143818?v=4",
+      "htmlUrl": "https://github.com/colesnodgrass",
+      "contributions": 1
+    },
+    {
+      "id": 413389,
+      "login": "ctrombley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
+      "htmlUrl": "https://github.com/ctrombley",
+      "contributions": 306
+    },
+    {
       "id": 45947764,
       "login": "bpeckNR",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
       "htmlUrl": "https://github.com/bpeckNR",
+      "contributions": 1
+    },
+    {
+      "id": 245435,
+      "login": "caarlos0",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/245435?v=4",
+      "htmlUrl": "https://github.com/caarlos0",
+      "contributions": 2
+    },
+    {
+      "id": 20836690,
+      "login": "abrunner94",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20836690?v=4",
+      "htmlUrl": "https://github.com/abrunner94",
+      "contributions": 1
+    },
+    {
+      "id": 17018863,
+      "login": "jaymcgrath",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17018863?v=4",
+      "htmlUrl": "https://github.com/jaymcgrath",
+      "contributions": 3
+    },
+    {
+      "id": 753159,
+      "login": "paul91",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/753159?v=4",
+      "htmlUrl": "https://github.com/paul91",
+      "contributions": 2
+    },
+    {
+      "id": 12853539,
+      "login": "jhutchings1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12853539?v=4",
+      "htmlUrl": "https://github.com/jhutchings1",
       "contributions": 1
     },
     {
@@ -165,18 +179,18 @@
       "contributions": 204
     },
     {
-      "id": 143818,
-      "login": "colesnodgrass",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/143818?v=4",
-      "htmlUrl": "https://github.com/colesnodgrass",
-      "contributions": 1
+      "id": 62031461,
+      "login": "nr-developer-toolkit",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62031461?v=4",
+      "htmlUrl": "https://github.com/nr-developer-toolkit",
+      "contributions": 9
     },
     {
       "id": 29264964,
       "login": "zlesnr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
       "htmlUrl": "https://github.com/zlesnr",
-      "contributions": 103
+      "contributions": 113
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-cordova-plugin.json
+++ b/src/data/project-stats/newrelic-newrelic-cordova-plugin.json
@@ -5,8 +5,8 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 68,
-  "lastSixMonthsCommitTotal": 5,
+  "commits": 69,
+  "lastSixMonthsCommitTotal": 6,
   "contributors": 5,
   "pullRequests": {
     "open": 4

--- a/src/data/project-stats/newrelic-newrelic-coreint.json
+++ b/src/data/project-stats/newrelic-newrelic-coreint.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/newrelic-coreint",
   "issues": {
-    "open": 46
+    "open": 38
   },
   "releases": 0,
   "latestRelease": null,

--- a/src/data/project-stats/newrelic-newrelic-diagnostics-cli.json
+++ b/src/data/project-stats/newrelic-newrelic-diagnostics-cli.json
@@ -9,7 +9,7 @@
     "date": "2021-04-01T21:18:37Z"
   },
   "commits": 387,
-  "lastSixMonthsCommitTotal": 161,
+  "lastSixMonthsCommitTotal": 144,
   "contributors": 10,
   "pullRequests": {
     "open": 2
@@ -36,10 +36,10 @@
   ],
   "cachedContributors": [
     {
-      "id": 77851771,
-      "login": "brianyangNR",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/77851771?v=4",
-      "htmlUrl": "https://github.com/brianyangNR",
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
     },
     {
@@ -64,11 +64,11 @@
       "contributions": 11
     },
     {
-      "id": 19716792,
-      "login": "njvrzm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19716792?v=4",
-      "htmlUrl": "https://github.com/njvrzm",
-      "contributions": 2
+      "id": 77851771,
+      "login": "brianyangNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/77851771?v=4",
+      "htmlUrl": "https://github.com/brianyangNR",
+      "contributions": 1
     },
     {
       "id": 32469854,
@@ -85,11 +85,11 @@
       "contributions": 9
     },
     {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 1
+      "id": 19716792,
+      "login": "njvrzm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19716792?v=4",
+      "htmlUrl": "https://github.com/njvrzm",
+      "contributions": 2
     },
     {
       "id": 34964885,

--- a/src/data/project-stats/newrelic-newrelic-dotnet-agent.json
+++ b/src/data/project-stats/newrelic-newrelic-dotnet-agent.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/newrelic-dotnet-agent",
   "issues": {
-    "open": 84
+    "open": 81
   },
-  "releases": 61,
+  "releases": 62,
   "latestRelease": {
-    "name": "v8.40.0",
-    "date": "2021-06-08T01:32:41Z"
+    "name": "v8.40.1",
+    "date": "2021-07-08T01:13:57Z"
   },
-  "commits": 336,
-  "lastSixMonthsCommitTotal": 90,
+  "commits": 358,
+  "lastSixMonthsCommitTotal": 99,
   "contributors": 16,
   "pullRequests": {
-    "open": 3
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -70,11 +70,18 @@
   ],
   "cachedContributors": [
     {
-      "id": 69914680,
-      "login": "angelatan2",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/69914680?v=4",
-      "htmlUrl": "https://github.com/angelatan2",
-      "contributions": 12
+      "id": 654808,
+      "login": "tehbio",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/654808?v=4",
+      "htmlUrl": "https://github.com/tehbio",
+      "contributions": 14
+    },
+    {
+      "id": 3522458,
+      "login": "jifeingo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3522458?v=4",
+      "htmlUrl": "https://github.com/jifeingo",
+      "contributions": 38
     },
     {
       "id": 4761745,
@@ -84,18 +91,11 @@
       "contributions": 4
     },
     {
-      "id": 654808,
-      "login": "tehbio",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/654808?v=4",
-      "htmlUrl": "https://github.com/tehbio",
-      "contributions": 9
-    },
-    {
-      "id": 3522458,
-      "login": "jifeingo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3522458?v=4",
-      "htmlUrl": "https://github.com/jifeingo",
-      "contributions": 38
+      "id": 3676547,
+      "login": "alanwest",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3676547?v=4",
+      "htmlUrl": "https://github.com/alanwest",
+      "contributions": 5
     },
     {
       "id": 20267975,
@@ -109,7 +109,7 @@
       "login": "JcolemanNR",
       "avatarUrl": "https://avatars.githubusercontent.com/u/83677148?v=4",
       "htmlUrl": "https://github.com/JcolemanNR",
-      "contributions": 6
+      "contributions": 9
     },
     {
       "id": 929261,
@@ -133,18 +133,18 @@
       "contributions": 2
     },
     {
-      "id": 3676547,
-      "login": "alanwest",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3676547?v=4",
-      "htmlUrl": "https://github.com/alanwest",
-      "contributions": 5
+      "id": 69914680,
+      "login": "angelatan2",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/69914680?v=4",
+      "htmlUrl": "https://github.com/angelatan2",
+      "contributions": 12
     },
     {
       "id": 6098021,
       "login": "jaffinito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6098021?v=4",
       "htmlUrl": "https://github.com/jaffinito",
-      "contributions": 40
+      "contributions": 43
     },
     {
       "id": 30146,
@@ -158,14 +158,14 @@
       "login": "nr-ahemsath",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
       "htmlUrl": "https://github.com/nr-ahemsath",
-      "contributions": 67
+      "contributions": 74
     },
     {
       "id": 56414817,
       "login": "vuqtran88",
       "avatarUrl": "https://avatars.githubusercontent.com/u/56414817?v=4",
       "htmlUrl": "https://github.com/vuqtran88",
-      "contributions": 52
+      "contributions": 55
     },
     {
       "id": 28942544,

--- a/src/data/project-stats/newrelic-newrelic-exporter-specs.json
+++ b/src/data/project-stats/newrelic-newrelic-exporter-specs.json
@@ -22,13 +22,6 @@
       "contributions": 4
     },
     {
-      "id": 858731,
-      "login": "jkwatson",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
-      "htmlUrl": "https://github.com/jkwatson",
-      "contributions": 1
-    },
-    {
       "id": 3170392,
       "login": "justinfoote",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3170392?v=4",
@@ -36,11 +29,18 @@
       "contributions": 1
     },
     {
-      "id": 306384,
-      "login": "joshuabenuck",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/306384?v=4",
-      "htmlUrl": "https://github.com/joshuabenuck",
-      "contributions": 2
+      "id": 858731,
+      "login": "jkwatson",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
+      "htmlUrl": "https://github.com/jkwatson",
+      "contributions": 1
+    },
+    {
+      "id": 48965776,
+      "login": "jodeev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
+      "htmlUrl": "https://github.com/jodeev",
+      "contributions": 3
     },
     {
       "id": 9435570,
@@ -57,11 +57,11 @@
       "contributions": 4
     },
     {
-      "id": 48965776,
-      "login": "jodeev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
-      "htmlUrl": "https://github.com/jodeev",
-      "contributions": 3
+      "id": 306384,
+      "login": "joshuabenuck",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/306384?v=4",
+      "htmlUrl": "https://github.com/joshuabenuck",
+      "contributions": 2
     },
     {
       "id": 1342804,

--- a/src/data/project-stats/newrelic-newrelic-fluent-bit-output.json
+++ b/src/data/project-stats/newrelic-newrelic-fluent-bit-output.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/newrelic-fluent-bit-output",
   "issues": {
-    "open": 6
+    "open": 5
   },
-  "releases": 16,
+  "releases": 20,
   "latestRelease": {
-    "name": "v1.5.0",
-    "date": "2021-04-30T15:55:19Z"
+    "name": "v1.6.1",
+    "date": "2021-07-13T11:51:21Z"
   },
-  "commits": 84,
-  "lastSixMonthsCommitTotal": 6,
-  "contributors": 9,
+  "commits": 90,
+  "lastSixMonthsCommitTotal": 10,
+  "contributors": 11,
   "pullRequests": {
     "open": 3
   },
@@ -18,25 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
+      "id": 7537725,
+      "login": "tejunior",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7537725?v=4",
+      "htmlUrl": "https://github.com/tejunior",
+      "contributions": 3
+    },
+    {
+      "id": 317362,
+      "login": "danybmx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/317362?v=4",
+      "htmlUrl": "https://github.com/danybmx",
       "contributions": 1
-    },
-    {
-      "id": 59101374,
-      "login": "mshamota-nr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/59101374?v=4",
-      "htmlUrl": "https://github.com/mshamota-nr",
-      "contributions": 5
-    },
-    {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 2
     },
     {
       "id": 2571329,
@@ -46,11 +39,39 @@
       "contributions": 2
     },
     {
-      "id": 13105375,
-      "login": "matildasmeds",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13105375?v=4",
-      "htmlUrl": "https://github.com/matildasmeds",
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 2
+    },
+    {
+      "id": 59101374,
+      "login": "mshamota-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59101374?v=4",
+      "htmlUrl": "https://github.com/mshamota-nr",
+      "contributions": 5
+    },
+    {
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
+      "contributions": 4
+    },
+    {
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
       "contributions": 1
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 2
     },
     {
       "id": 7001514,
@@ -60,17 +81,10 @@
       "contributions": 6
     },
     {
-      "id": 7537725,
-      "login": "tejunior",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7537725?v=4",
-      "htmlUrl": "https://github.com/tejunior",
-      "contributions": 3
-    },
-    {
-      "id": 62337995,
-      "login": "jodstrcil",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
-      "htmlUrl": "https://github.com/jodstrcil",
+      "id": 13105375,
+      "login": "matildasmeds",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13105375?v=4",
+      "htmlUrl": "https://github.com/matildasmeds",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-newrelic-fluentd-output.json
+++ b/src/data/project-stats/newrelic-newrelic-fluentd-output.json
@@ -1,12 +1,12 @@
 {
   "projectFullName": "newrelic/newrelic-fluentd-output",
   "issues": {
-    "open": 4
+    "open": 3
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 38,
-  "lastSixMonthsCommitTotal": 3,
+  "commits": 39,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 11,
   "pullRequests": {
     "open": 0
@@ -22,13 +22,6 @@
       "contributions": 1
     },
     {
-      "id": 2571329,
-      "login": "ngotim",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2571329?v=4",
-      "htmlUrl": "https://github.com/ngotim",
-      "contributions": 1
-    },
-    {
       "id": 40015725,
       "login": "bangle-98",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40015725?v=4",
@@ -36,11 +29,18 @@
       "contributions": 1
     },
     {
-      "id": 536332,
-      "login": "danielsig727",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/536332?v=4",
-      "htmlUrl": "https://github.com/danielsig727",
+      "id": 2571329,
+      "login": "ngotim",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2571329?v=4",
+      "htmlUrl": "https://github.com/ngotim",
       "contributions": 1
+    },
+    {
+      "id": 62337995,
+      "login": "jodstrcil",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
+      "htmlUrl": "https://github.com/jodstrcil",
+      "contributions": 5
     },
     {
       "id": 6243832,
@@ -50,11 +50,11 @@
       "contributions": 1
     },
     {
-      "id": 62337995,
-      "login": "jodstrcil",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62337995?v=4",
-      "htmlUrl": "https://github.com/jodstrcil",
-      "contributions": 4
+      "id": 536332,
+      "login": "danielsig727",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/536332?v=4",
+      "htmlUrl": "https://github.com/danielsig727",
+      "contributions": 1
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-newrelic-gradle-verify-instrumentation.json
+++ b/src/data/project-stats/newrelic-newrelic-gradle-verify-instrumentation.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/newrelic-gradle-verify-instrumentation",
   "issues": {
-    "open": 1
+    "open": 0
   },
   "releases": 2,
   "latestRelease": {
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 49817386,
-      "login": "jeffalder",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
-      "htmlUrl": "https://github.com/jeffalder",
-      "contributions": 6
+      "id": 842717,
+      "login": "tspring",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/842717?v=4",
+      "htmlUrl": "https://github.com/tspring",
+      "contributions": 1
     },
     {
       "id": 43244625,
@@ -32,11 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 842717,
-      "login": "tspring",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/842717?v=4",
-      "htmlUrl": "https://github.com/tspring",
-      "contributions": 1
+      "id": 49817386,
+      "login": "jeffalder",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
+      "htmlUrl": "https://github.com/jeffalder",
+      "contributions": 6
     },
     {
       "id": 54085190,

--- a/src/data/project-stats/newrelic-newrelic-graphql-java-core.json
+++ b/src/data/project-stats/newrelic-newrelic-graphql-java-core.json
@@ -18,10 +18,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
+      "id": 13240719,
+      "login": "leifan89",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13240719?v=4",
+      "htmlUrl": "https://github.com/leifan89",
       "contributions": 2
     },
     {
@@ -39,10 +39,10 @@
       "contributions": 29
     },
     {
-      "id": 13240719,
-      "login": "leifan89",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13240719?v=4",
-      "htmlUrl": "https://github.com/leifan89",
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
       "contributions": 2
     }
   ],

--- a/src/data/project-stats/newrelic-newrelic-infinite-tracing-protobuf-java.json
+++ b/src/data/project-stats/newrelic-newrelic-infinite-tracing-protobuf-java.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 3496648,
-      "login": "jasonjkeller",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
-      "htmlUrl": "https://github.com/jasonjkeller",
-      "contributions": 3
+      "id": 49817386,
+      "login": "jeffalder",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
+      "htmlUrl": "https://github.com/jeffalder",
+      "contributions": 2
     },
     {
       "id": 7992384,
@@ -39,11 +39,11 @@
       "contributions": 2
     },
     {
-      "id": 49817386,
-      "login": "jeffalder",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
-      "htmlUrl": "https://github.com/jeffalder",
-      "contributions": 2
+      "id": 3496648,
+      "login": "jasonjkeller",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
+      "htmlUrl": "https://github.com/jasonjkeller",
+      "contributions": 3
     },
     {
       "id": 42678939,

--- a/src/data/project-stats/newrelic-newrelic-infra-operator.json
+++ b/src/data/project-stats/newrelic-newrelic-infra-operator.json
@@ -8,8 +8,8 @@
     "name": "v0.4.0",
     "date": "2021-05-19T12:47:16Z"
   },
-  "commits": 58,
-  "lastSixMonthsCommitTotal": 58,
+  "commits": 60,
+  "lastSixMonthsCommitTotal": 60,
   "contributors": 4,
   "pullRequests": {
     "open": 4
@@ -22,7 +22,7 @@
       "login": "invidian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16539896?v=4",
       "htmlUrl": "https://github.com/invidian",
-      "contributions": 42
+      "contributions": 43
     },
     {
       "id": 969721,
@@ -43,7 +43,7 @@
       "login": "paologallinaharbur",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
       "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 19
+      "contributions": 20
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-ios-agent-spm.json
+++ b/src/data/project-stats/newrelic-newrelic-ios-agent-spm.json
@@ -1,0 +1,58 @@
+{
+  "projectFullName": "newrelic/newrelic-ios-agent-spm",
+  "issues": {
+    "open": 2
+  },
+  "releases": 6,
+  "latestRelease": {
+    "name": "7.3.2",
+    "date": "2021-06-30T17:23:45Z"
+  },
+  "commits": 13,
+  "lastSixMonthsCommitTotal": 13,
+  "contributors": 3,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 84096330,
+      "login": "smalsam-newr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/84096330?v=4",
+      "htmlUrl": "https://github.com/smalsam-newr",
+      "contributions": 10
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UzNzE=",
+      "name": "Swift",
+      "color": "#ffac45"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-newrelic-ios-sdk.json
+++ b/src/data/project-stats/newrelic-newrelic-ios-sdk.json
@@ -1,0 +1,58 @@
+{
+  "projectFullName": "newrelic/newrelic-ios-sdk",
+  "issues": {
+    "open": 1
+  },
+  "releases": 5,
+  "latestRelease": {
+    "name": "7.3.1",
+    "date": "2021-05-26T21:30:13Z"
+  },
+  "commits": 12,
+  "lastSixMonthsCommitTotal": 12,
+  "contributors": 3,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 84096330,
+      "login": "smalsam-newr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/84096330?v=4",
+      "htmlUrl": "https://github.com/smalsam-newr",
+      "contributions": 9
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UzNzE=",
+      "name": "Swift",
+      "color": "#ffac45"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-newrelic-istio-adapter.json
+++ b/src/data/project-stats/newrelic-newrelic-istio-adapter.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/newrelic-istio-adapter",
   "issues": {
-    "open": 6
+    "open": 7
   },
   "releases": 5,
   "latestRelease": {
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 22605483,
-      "login": "quentinplessis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/22605483?v=4",
-      "htmlUrl": "https://github.com/quentinplessis",
-      "contributions": 1
-    },
-    {
       "id": 16081795,
       "login": "sskilbred",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16081795?v=4",
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/54864571?v=4",
       "htmlUrl": "https://github.com/kdef-nr",
       "contributions": 3
+    },
+    {
+      "id": 22605483,
+      "login": "quentinplessis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22605483?v=4",
+      "htmlUrl": "https://github.com/quentinplessis",
+      "contributions": 1
     },
     {
       "id": 3810702,

--- a/src/data/project-stats/newrelic-newrelic-java-agent-ansible-role.json
+++ b/src/data/project-stats/newrelic-newrelic-java-agent-ansible-role.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 1773616,
-      "login": "theletterf",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
-      "htmlUrl": "https://github.com/theletterf",
-      "contributions": 2
+      "id": 63664197,
+      "login": "rishimukhop1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/63664197?v=4",
+      "htmlUrl": "https://github.com/rishimukhop1",
+      "contributions": 1
     },
     {
       "id": 19716792,
@@ -32,11 +32,11 @@
       "contributions": 20
     },
     {
-      "id": 63664197,
-      "login": "rishimukhop1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/63664197?v=4",
-      "htmlUrl": "https://github.com/rishimukhop1",
-      "contributions": 1
+      "id": 1773616,
+      "login": "theletterf",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
+      "htmlUrl": "https://github.com/theletterf",
+      "contributions": 2
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-newrelic-java-agent.json
+++ b/src/data/project-stats/newrelic-newrelic-java-agent.json
@@ -1,28 +1,28 @@
 {
   "projectFullName": "newrelic/newrelic-java-agent",
   "issues": {
-    "open": 59
+    "open": 57
   },
-  "releases": 11,
+  "releases": 13,
   "latestRelease": {
-    "name": "v7.0.1",
-    "date": "2021-06-15T20:29:49Z"
+    "name": "v7.1.1",
+    "date": "2021-07-15T16:56:49Z"
   },
-  "commits": 465,
-  "lastSixMonthsCommitTotal": 181,
+  "commits": 472,
+  "lastSixMonthsCommitTotal": 172,
   "contributors": 24,
   "pullRequests": {
-    "open": 8
+    "open": 9
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 1627067,
-      "login": "sdaubin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1627067?v=4",
-      "htmlUrl": "https://github.com/sdaubin",
-      "contributions": 5
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
     },
     {
       "id": 513280,
@@ -39,13 +39,6 @@
       "contributions": 1
     },
     {
-      "id": 34418638,
-      "login": "jack-berg",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34418638?v=4",
-      "htmlUrl": "https://github.com/jack-berg",
-      "contributions": 20
-    },
-    {
       "id": 842717,
       "login": "tspring",
       "avatarUrl": "https://avatars.githubusercontent.com/u/842717?v=4",
@@ -53,11 +46,18 @@
       "contributions": 65
     },
     {
-      "id": 25208879,
-      "login": "veklov",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/25208879?v=4",
-      "htmlUrl": "https://github.com/veklov",
-      "contributions": 7
+      "id": 3496648,
+      "login": "jasonjkeller",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
+      "htmlUrl": "https://github.com/jasonjkeller",
+      "contributions": 63
+    },
+    {
+      "id": 7401258,
+      "login": "tbradellis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7401258?v=4",
+      "htmlUrl": "https://github.com/tbradellis",
+      "contributions": 4
     },
     {
       "id": 81539,
@@ -78,35 +78,7 @@
       "login": "richard-gibson",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2817215?v=4",
       "htmlUrl": "https://github.com/richard-gibson",
-      "contributions": 1
-    },
-    {
-      "id": 3496648,
-      "login": "jasonjkeller",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
-      "htmlUrl": "https://github.com/jasonjkeller",
-      "contributions": 63
-    },
-    {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 1
-    },
-    {
-      "id": 7401258,
-      "login": "tbradellis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7401258?v=4",
-      "htmlUrl": "https://github.com/tbradellis",
-      "contributions": 4
-    },
-    {
-      "id": 48965776,
-      "login": "jodeev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
-      "htmlUrl": "https://github.com/jodeev",
-      "contributions": 1
+      "contributions": 2
     },
     {
       "id": 42678939,
@@ -116,11 +88,39 @@
       "contributions": 2
     },
     {
+      "id": 34418638,
+      "login": "jack-berg",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34418638?v=4",
+      "htmlUrl": "https://github.com/jack-berg",
+      "contributions": 20
+    },
+    {
+      "id": 48965776,
+      "login": "jodeev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
+      "htmlUrl": "https://github.com/jodeev",
+      "contributions": 1
+    },
+    {
+      "id": 25208879,
+      "login": "veklov",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/25208879?v=4",
+      "htmlUrl": "https://github.com/veklov",
+      "contributions": 7
+    },
+    {
       "id": 7905841,
       "login": "junder31",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7905841?v=4",
       "htmlUrl": "https://github.com/junder31",
       "contributions": 3
+    },
+    {
+      "id": 1627067,
+      "login": "sdaubin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1627067?v=4",
+      "htmlUrl": "https://github.com/sdaubin",
+      "contributions": 5
     },
     {
       "id": 7992384,
@@ -162,14 +162,14 @@
       "login": "meiao",
       "avatarUrl": "https://avatars.githubusercontent.com/u/292463?v=4",
       "htmlUrl": "https://github.com/meiao",
-      "contributions": 5
+      "contributions": 9
     },
     {
       "id": 24482401,
       "login": "XiXiaPdx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
       "htmlUrl": "https://github.com/XiXiaPdx",
-      "contributions": 43
+      "contributions": 44
     },
     {
       "id": 58712431,

--- a/src/data/project-stats/newrelic-newrelic-jfr-core.json
+++ b/src/data/project-stats/newrelic-newrelic-jfr-core.json
@@ -3,27 +3,20 @@
   "issues": {
     "open": 12
   },
-  "releases": 8,
+  "releases": 9,
   "latestRelease": {
-    "name": "v1.3.0",
-    "date": "2021-06-01T14:42:03Z"
+    "name": "v1.4.0",
+    "date": "2021-07-02T00:19:03Z"
   },
-  "commits": 383,
-  "lastSixMonthsCommitTotal": 135,
+  "commits": 385,
+  "lastSixMonthsCommitTotal": 121,
   "contributors": 16,
   "pullRequests": {
-    "open": 1
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 42678939,
-      "login": "bradleycamacho",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
-      "htmlUrl": "https://github.com/bradleycamacho",
-      "contributions": 4
-    },
     {
       "id": 34418638,
       "login": "jack-berg",
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
       "htmlUrl": "https://github.com/jasonjkeller",
       "contributions": 44
+    },
+    {
+      "id": 42678939,
+      "login": "bradleycamacho",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
+      "htmlUrl": "https://github.com/bradleycamacho",
+      "contributions": 4
     },
     {
       "id": 842717,
@@ -106,7 +106,7 @@
       "login": "meiao",
       "avatarUrl": "https://avatars.githubusercontent.com/u/292463?v=4",
       "htmlUrl": "https://github.com/meiao",
-      "contributions": 1
+      "contributions": 2
     },
     {
       "id": 24482401,
@@ -127,7 +127,7 @@
       "login": "kittylyst",
       "avatarUrl": "https://avatars.githubusercontent.com/u/81539?v=4",
       "htmlUrl": "https://github.com/kittylyst",
-      "contributions": 44
+      "contributions": 45
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-kubernetes-operator.json
+++ b/src/data/project-stats/newrelic-newrelic-kubernetes-operator.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/newrelic-kubernetes-operator",
   "issues": {
-    "open": 23
+    "open": 22
   },
-  "releases": 7,
+  "releases": 8,
   "latestRelease": {
-    "name": "v0.0.7",
-    "date": "2020-10-15T18:28:03Z"
+    "name": "v0.0.8",
+    "date": "2021-07-10T01:03:26Z"
   },
-  "commits": 377,
-  "lastSixMonthsCommitTotal": 5,
-  "contributors": 16,
+  "commits": 397,
+  "lastSixMonthsCommitTotal": 17,
+  "contributors": 18,
   "pullRequests": {
-    "open": 6
+    "open": 4
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -36,18 +36,11 @@
   ],
   "cachedContributors": [
     {
-      "id": 29264964,
-      "login": "zlesnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
-      "htmlUrl": "https://github.com/zlesnr",
-      "contributions": 21
-    },
-    {
-      "id": 2590905,
-      "login": "sanderblue",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
-      "htmlUrl": "https://github.com/sanderblue",
-      "contributions": 22
+      "id": 695967,
+      "login": "danielpanzella",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/695967?v=4",
+      "htmlUrl": "https://github.com/danielpanzella",
+      "contributions": 2
     },
     {
       "id": 1902623,
@@ -62,6 +55,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
       "htmlUrl": "https://github.com/ctrombley",
       "contributions": 24
+    },
+    {
+      "id": 29264964,
+      "login": "zlesnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
+      "htmlUrl": "https://github.com/zlesnr",
+      "contributions": 21
     },
     {
       "id": 25180681,
@@ -103,7 +103,14 @@
       "login": "monkeyherder",
       "avatarUrl": "https://avatars.githubusercontent.com/u/723533?v=4",
       "htmlUrl": "https://github.com/monkeyherder",
-      "contributions": 9
+      "contributions": 10
+    },
+    {
+      "id": 2590905,
+      "login": "sanderblue",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
+      "htmlUrl": "https://github.com/sanderblue",
+      "contributions": 22
     },
     {
       "id": 27262268,
@@ -111,6 +118,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/27262268?v=4",
       "htmlUrl": "https://github.com/t0astbandit",
       "contributions": 3
+    },
+    {
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 4
     },
     {
       "id": 4865,
@@ -124,7 +138,7 @@
       "login": "thande",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7946679?v=4",
       "htmlUrl": "https://github.com/thande",
-      "contributions": 107
+      "contributions": 111
     },
     {
       "id": 6836095,

--- a/src/data/project-stats/newrelic-newrelic-lambda-cli.json
+++ b/src/data/project-stats/newrelic-newrelic-lambda-cli.json
@@ -9,7 +9,7 @@
     "date": "2021-05-18T01:22:10Z"
   },
   "commits": 367,
-  "lastSixMonthsCommitTotal": 20,
+  "lastSixMonthsCommitTotal": 18,
   "contributors": 16,
   "pullRequests": {
     "open": 3
@@ -25,18 +25,11 @@
       "contributions": 7
     },
     {
-      "id": 11327,
-      "login": "mrickard",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11327?v=4",
-      "htmlUrl": "https://github.com/mrickard",
-      "contributions": 5
-    },
-    {
-      "id": 7001514,
-      "login": "bmcfeely",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7001514?v=4",
-      "htmlUrl": "https://github.com/bmcfeely",
-      "contributions": 2
+      "id": 61292402,
+      "login": "keegoid-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/61292402?v=4",
+      "htmlUrl": "https://github.com/keegoid-nr",
+      "contributions": 3
     },
     {
       "id": 4206754,
@@ -53,11 +46,18 @@
       "contributions": 133
     },
     {
-      "id": 61292402,
-      "login": "keegoid-nr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/61292402?v=4",
-      "htmlUrl": "https://github.com/keegoid-nr",
-      "contributions": 3
+      "id": 7001514,
+      "login": "bmcfeely",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7001514?v=4",
+      "htmlUrl": "https://github.com/bmcfeely",
+      "contributions": 2
+    },
+    {
+      "id": 11327,
+      "login": "mrickard",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11327?v=4",
+      "htmlUrl": "https://github.com/mrickard",
+      "contributions": 5
     },
     {
       "id": 585473,

--- a/src/data/project-stats/newrelic-newrelic-lambda-extension.json
+++ b/src/data/project-stats/newrelic-newrelic-lambda-extension.json
@@ -1,15 +1,15 @@
 {
   "projectFullName": "newrelic/newrelic-lambda-extension",
   "issues": {
-    "open": 5
+    "open": 3
   },
-  "releases": 17,
+  "releases": 18,
   "latestRelease": {
-    "name": "v2.0.1",
-    "date": "2021-06-07T14:44:18Z"
+    "name": "v2.0.2",
+    "date": "2021-07-01T16:57:15Z"
   },
-  "commits": 235,
-  "lastSixMonthsCommitTotal": 88,
+  "commits": 238,
+  "lastSixMonthsCommitTotal": 75,
   "contributors": 4,
   "pullRequests": {
     "open": 0
@@ -36,7 +36,7 @@
       "login": "MattWhelan",
       "avatarUrl": "https://avatars.githubusercontent.com/u/585473?v=4",
       "htmlUrl": "https://github.com/MattWhelan",
-      "contributions": 111
+      "contributions": 113
     },
     {
       "id": 11327,

--- a/src/data/project-stats/newrelic-newrelic-lambda-layers.json
+++ b/src/data/project-stats/newrelic-newrelic-lambda-layers.json
@@ -3,13 +3,13 @@
   "issues": {
     "open": 2
   },
-  "releases": 108,
+  "releases": 114,
   "latestRelease": {
-    "name": "v7.5.1_nodejs",
-    "date": "2021-06-07T16:25:28Z"
+    "name": "v7.5.2_nodejs",
+    "date": "2021-07-01T18:44:05Z"
   },
-  "commits": 126,
-  "lastSixMonthsCommitTotal": 31,
+  "commits": 130,
+  "lastSixMonthsCommitTotal": 33,
   "contributors": 7,
   "pullRequests": {
     "open": 0
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 11327,
+      "login": "mrickard",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11327?v=4",
+      "htmlUrl": "https://github.com/mrickard",
+      "contributions": 22
+    },
+    {
       "id": 13562672,
       "login": "jaesius",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
       "htmlUrl": "https://github.com/jaesius",
       "contributions": 1
-    },
-    {
-      "id": 73207,
-      "login": "ewindisch",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/73207?v=4",
-      "htmlUrl": "https://github.com/ewindisch",
-      "contributions": 2
     },
     {
       "id": 43244625,
@@ -46,11 +46,11 @@
       "contributions": 53
     },
     {
-      "id": 11327,
-      "login": "mrickard",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11327?v=4",
-      "htmlUrl": "https://github.com/mrickard",
-      "contributions": 22
+      "id": 73207,
+      "login": "ewindisch",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73207?v=4",
+      "htmlUrl": "https://github.com/ewindisch",
+      "contributions": 2
     },
     {
       "id": 28942544,
@@ -64,7 +64,7 @@
       "login": "MattWhelan",
       "avatarUrl": "https://avatars.githubusercontent.com/u/585473?v=4",
       "htmlUrl": "https://github.com/MattWhelan",
-      "contributions": 7
+      "contributions": 9
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-logenricher-dotnet.json
+++ b/src/data/project-stats/newrelic-newrelic-logenricher-dotnet.json
@@ -1,14 +1,14 @@
 {
   "projectFullName": "newrelic/newrelic-logenricher-dotnet",
   "issues": {
-    "open": 5
+    "open": 4
   },
-  "releases": 13,
+  "releases": 14,
   "latestRelease": {
-    "name": "Log4Net_v1.1.1",
-    "date": "2021-02-08T23:41:04Z"
+    "name": "NLog_v1.2.0",
+    "date": null
   },
-  "commits": 210,
+  "commits": 212,
   "lastSixMonthsCommitTotal": 5,
   "contributors": 11,
   "pullRequests": {
@@ -18,10 +18,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 188129,
-      "login": "bgrainger",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/188129?v=4",
-      "htmlUrl": "https://github.com/bgrainger",
+      "id": 5260112,
+      "login": "ltines",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5260112?v=4",
+      "htmlUrl": "https://github.com/ltines",
       "contributions": 1
     },
     {
@@ -32,10 +32,10 @@
       "contributions": 2
     },
     {
-      "id": 5260112,
-      "login": "ltines",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5260112?v=4",
-      "htmlUrl": "https://github.com/ltines",
+      "id": 188129,
+      "login": "bgrainger",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188129?v=4",
+      "htmlUrl": "https://github.com/bgrainger",
       "contributions": 1
     },
     {
@@ -78,7 +78,7 @@
       "login": "jaffinito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6098021?v=4",
       "htmlUrl": "https://github.com/jaffinito",
-      "contributions": 20
+      "contributions": 22
     },
     {
       "id": 57361211,

--- a/src/data/project-stats/newrelic-newrelic-module-util-java.json
+++ b/src/data/project-stats/newrelic-newrelic-module-util-java.json
@@ -25,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 49817386,
-      "login": "jeffalder",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
-      "htmlUrl": "https://github.com/jeffalder",
-      "contributions": 2
+      "id": 24482401,
+      "login": "XiXiaPdx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
+      "htmlUrl": "https://github.com/XiXiaPdx",
+      "contributions": 8
     },
     {
       "id": 43244625,
@@ -46,11 +46,11 @@
       "contributions": 14
     },
     {
-      "id": 24482401,
-      "login": "XiXiaPdx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24482401?v=4",
-      "htmlUrl": "https://github.com/XiXiaPdx",
-      "contributions": 8
+      "id": 49817386,
+      "login": "jeffalder",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
+      "htmlUrl": "https://github.com/jeffalder",
+      "contributions": 2
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-monolog-logenricher-php.json
+++ b/src/data/project-stats/newrelic-newrelic-monolog-logenricher-php.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 43715151,
-      "login": "zsistla",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43715151?v=4",
-      "htmlUrl": "https://github.com/zsistla",
-      "contributions": 5
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
     },
     {
       "id": 7992384,
@@ -46,11 +46,11 @@
       "contributions": 1
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
+      "id": 43715151,
+      "login": "zsistla",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43715151?v=4",
+      "htmlUrl": "https://github.com/zsistla",
+      "contributions": 5
     },
     {
       "id": 229984,

--- a/src/data/project-stats/newrelic-newrelic-node-apollo-server-plugin.json
+++ b/src/data/project-stats/newrelic-newrelic-node-apollo-server-plugin.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/newrelic-node-apollo-server-plugin",
   "issues": {
-    "open": 14
+    "open": 9
   },
-  "releases": 5,
+  "releases": 6,
   "latestRelease": {
-    "name": "v0.2.0",
+    "name": "v0.3.0",
     "date": null
   },
-  "commits": 161,
-  "lastSixMonthsCommitTotal": 37,
+  "commits": 230,
+  "lastSixMonthsCommitTotal": 106,
   "contributors": 8,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,11 +25,11 @@
       "contributions": 3
     },
     {
-      "id": 8594759,
-      "login": "MightySCollins",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8594759?v=4",
-      "htmlUrl": "https://github.com/MightySCollins",
-      "contributions": 1
+      "id": 11223178,
+      "login": "michaelgoin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11223178?v=4",
+      "htmlUrl": "https://github.com/michaelgoin",
+      "contributions": 55
     },
     {
       "id": 398399,
@@ -39,13 +39,6 @@
       "contributions": 9
     },
     {
-      "id": 2903325,
-      "login": "dnalborczyk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2903325?v=4",
-      "htmlUrl": "https://github.com/dnalborczyk",
-      "contributions": 3
-    },
-    {
       "id": 6722433,
       "login": "jbeveland27",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
@@ -53,25 +46,32 @@
       "contributions": 1
     },
     {
-      "id": 11223178,
-      "login": "michaelgoin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11223178?v=4",
-      "htmlUrl": "https://github.com/michaelgoin",
-      "contributions": 45
+      "id": 2903325,
+      "login": "dnalborczyk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2903325?v=4",
+      "htmlUrl": "https://github.com/dnalborczyk",
+      "contributions": 3
+    },
+    {
+      "id": 8594759,
+      "login": "MightySCollins",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8594759?v=4",
+      "htmlUrl": "https://github.com/MightySCollins",
+      "contributions": 1
     },
     {
       "id": 1874937,
       "login": "bizob2828",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1874937?v=4",
       "htmlUrl": "https://github.com/bizob2828",
-      "contributions": 14
+      "contributions": 36
     },
     {
       "id": 54335840,
       "login": "carlo-808",
       "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
       "htmlUrl": "https://github.com/carlo-808",
-      "contributions": 40
+      "contributions": 62
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-observability-packs.json
+++ b/src/data/project-stats/newrelic-newrelic-observability-packs.json
@@ -1,35 +1,42 @@
 {
   "projectFullName": "newrelic/newrelic-observability-packs",
   "issues": {
-    "open": 17
+    "open": 14
   },
-  "releases": 14,
+  "releases": 18,
   "latestRelease": {
-    "name": "v0.8.2",
-    "date": "2021-06-11T12:26:19Z"
+    "name": "v0.10.0",
+    "date": "2021-07-01T16:54:57Z"
   },
-  "commits": 163,
-  "lastSixMonthsCommitTotal": 163,
-  "contributors": 10,
+  "commits": 245,
+  "lastSixMonthsCommitTotal": 245,
+  "contributors": 12,
   "pullRequests": {
-    "open": 3
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 52407257,
+      "login": "JakubKotkowiak",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/52407257?v=4",
+      "htmlUrl": "https://github.com/JakubKotkowiak",
+      "contributions": 18
+    },
+    {
       "id": 66321197,
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 13
+      "contributions": 17
     },
     {
       "id": 70179215,
       "login": "nr-kkenney",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
       "htmlUrl": "https://github.com/nr-kkenney",
-      "contributions": 3
+      "contributions": 18
     },
     {
       "id": 30831476,
@@ -37,6 +44,41 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
       "htmlUrl": "https://github.com/thezackm",
       "contributions": 8
+    },
+    {
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 49
+    },
+    {
+      "id": 39655074,
+      "login": "LizBaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
+      "htmlUrl": "https://github.com/LizBaker",
+      "contributions": 1
+    },
+    {
+      "id": 1946433,
+      "login": "zstix",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1946433?v=4",
+      "htmlUrl": "https://github.com/zstix",
+      "contributions": 5
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 36
+    },
+    {
+      "id": 1395158,
+      "login": "jpvajda",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
+      "htmlUrl": "https://github.com/jpvajda",
+      "contributions": 11
     },
     {
       "id": 45029322,
@@ -50,42 +92,14 @@
       "login": "aswanson-nr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179303?v=4",
       "htmlUrl": "https://github.com/aswanson-nr",
-      "contributions": 14
-    },
-    {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
-      "contributions": 49
-    },
-    {
-      "id": 1395158,
-      "login": "jpvajda",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
-      "htmlUrl": "https://github.com/jpvajda",
-      "contributions": 6
+      "contributions": 32
     },
     {
       "id": 17122543,
       "login": "rudouglas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
       "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 3
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 19
-    },
-    {
-      "id": 52407257,
-      "login": "JakubKotkowiak",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/52407257?v=4",
-      "htmlUrl": "https://github.com/JakubKotkowiak",
-      "contributions": 18
+      "contributions": 8
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-newrelic-ocoe-launch-pad.json
+++ b/src/data/project-stats/newrelic-newrelic-ocoe-launch-pad.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 13,
-  "lastSixMonthsCommitTotal": 5,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-newrelic-opentelemetry-examples.json
+++ b/src/data/project-stats/newrelic-newrelic-opentelemetry-examples.json
@@ -5,9 +5,9 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 84,
-  "lastSixMonthsCommitTotal": 84,
-  "contributors": 5,
+  "commits": 96,
+  "lastSixMonthsCommitTotal": 96,
+  "contributors": 6,
   "pullRequests": {
     "open": 0
   },
@@ -15,18 +15,25 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 34418638,
-      "login": "jack-berg",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34418638?v=4",
-      "htmlUrl": "https://github.com/jack-berg",
-      "contributions": 34
-    },
-    {
       "id": 43244625,
       "login": "melissaklein24",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
       "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
+    },
+    {
+      "id": 45495992,
+      "login": "nrcventura",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45495992?v=4",
+      "htmlUrl": "https://github.com/nrcventura",
+      "contributions": 9
+    },
+    {
+      "id": 34418638,
+      "login": "jack-berg",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34418638?v=4",
+      "htmlUrl": "https://github.com/jack-berg",
+      "contributions": 34
     },
     {
       "id": 3676547,

--- a/src/data/project-stats/newrelic-newrelic-oss-cli.json
+++ b/src/data/project-stats/newrelic-newrelic-oss-cli.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 1
-    },
-    {
       "id": 197140,
       "login": "devfreddy",
       "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
@@ -36,6 +29,13 @@
       "login": "prototypicalpro",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
       "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 1
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-newrelic-pcf-nozzle-tile.json
+++ b/src/data/project-stats/newrelic-newrelic-pcf-nozzle-tile.json
@@ -25,18 +25,18 @@
       "contributions": 9
     },
     {
-      "id": 4672940,
-      "login": "shahramk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4672940?v=4",
-      "htmlUrl": "https://github.com/shahramk",
-      "contributions": 31
-    },
-    {
       "id": 2054195,
       "login": "ardias",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2054195?v=4",
       "htmlUrl": "https://github.com/ardias",
       "contributions": 1
+    },
+    {
+      "id": 4672940,
+      "login": "shahramk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4672940?v=4",
+      "htmlUrl": "https://github.com/shahramk",
+      "contributions": 31
     },
     {
       "id": 5143130,

--- a/src/data/project-stats/newrelic-newrelic-php-agent.json
+++ b/src/data/project-stats/newrelic-newrelic-php-agent.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/newrelic-php-agent",
   "issues": {
-    "open": 33
+    "open": 26
   },
   "releases": 5,
   "latestRelease": {
@@ -9,10 +9,10 @@
     "date": null
   },
   "commits": 93,
-  "lastSixMonthsCommitTotal": 49,
+  "lastSixMonthsCommitTotal": 46,
   "contributors": 9,
   "pullRequests": {
-    "open": 2
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -57,6 +57,13 @@
       "contributions": 1
     },
     {
+      "id": 43715151,
+      "login": "zsistla",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43715151?v=4",
+      "htmlUrl": "https://github.com/zsistla",
+      "contributions": 18
+    },
+    {
       "id": 1904430,
       "login": "TysonAndre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1904430?v=4",
@@ -69,13 +76,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
       "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
-    },
-    {
-      "id": 43715151,
-      "login": "zsistla",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43715151?v=4",
-      "htmlUrl": "https://github.com/zsistla",
-      "contributions": 18
     },
     {
       "id": 6722433,

--- a/src/data/project-stats/newrelic-newrelic-php-daemon-docker.json
+++ b/src/data/project-stats/newrelic-newrelic-php-daemon-docker.json
@@ -18,6 +18,13 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 306384,
+      "login": "joshuabenuck",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/306384?v=4",
+      "htmlUrl": "https://github.com/joshuabenuck",
+      "contributions": 2
+    },
+    {
       "id": 62488,
       "login": "danielocallaghan",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62488?v=4",
@@ -25,18 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 42678939,
-      "login": "bradleycamacho",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
-      "htmlUrl": "https://github.com/bradleycamacho",
+      "id": 28364881,
+      "login": "Fahmy-Mohammed",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28364881?v=4",
+      "htmlUrl": "https://github.com/Fahmy-Mohammed",
       "contributions": 1
-    },
-    {
-      "id": 306384,
-      "login": "joshuabenuck",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/306384?v=4",
-      "htmlUrl": "https://github.com/joshuabenuck",
-      "contributions": 2
     },
     {
       "id": 7244569,
@@ -46,10 +46,10 @@
       "contributions": 10
     },
     {
-      "id": 28364881,
-      "login": "Fahmy-Mohammed",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28364881?v=4",
-      "htmlUrl": "https://github.com/Fahmy-Mohammed",
+      "id": 42678939,
+      "login": "bradleycamacho",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42678939?v=4",
+      "htmlUrl": "https://github.com/bradleycamacho",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-newrelic-pixie-integration.json
+++ b/src/data/project-stats/newrelic-newrelic-pixie-integration.json
@@ -3,9 +3,9 @@
   "issues": {
     "open": 1
   },
-  "releases": 8,
+  "releases": 9,
   "latestRelease": {
-    "name": "v0.1.7",
+    "name": "v1.0.0",
     "date": "2021-05-28T13:11:14Z"
   },
   "commits": 58,
@@ -25,18 +25,18 @@
       "contributions": 1
     },
     {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 14
-    },
-    {
       "id": 6374032,
       "login": "a-feld",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
       "htmlUrl": "https://github.com/a-feld",
       "contributions": 2
+    },
+    {
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 14
     },
     {
       "id": 12560219,

--- a/src/data/project-stats/newrelic-newrelic-prometheus-exporters-packages.json
+++ b/src/data/project-stats/newrelic-newrelic-prometheus-exporters-packages.json
@@ -1,0 +1,99 @@
+{
+  "projectFullName": "newrelic/newrelic-prometheus-exporters-packages",
+  "issues": {
+    "open": 1
+  },
+  "releases": 14,
+  "latestRelease": {
+    "name": "nri-powerdns-0.0.2",
+    "date": "2021-07-06T11:00:47Z"
+  },
+  "commits": 115,
+  "lastSixMonthsCommitTotal": 49,
+  "contributors": 6,
+  "pullRequests": {
+    "open": 2
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 12560219,
+      "login": "ivancorrales",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12560219?v=4",
+      "htmlUrl": "https://github.com/ivancorrales",
+      "contributions": 33
+    },
+    {
+      "id": 2054195,
+      "login": "ardias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2054195?v=4",
+      "htmlUrl": "https://github.com/ardias",
+      "contributions": 18
+    },
+    {
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 23
+    },
+    {
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 17
+    },
+    {
+      "id": 73652669,
+      "login": "arvdias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
+      "htmlUrl": "https://github.com/arvdias",
+      "contributions": 10
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2U0MDM=",
+      "name": "Makefile",
+      "color": "#427819"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2UyNjQ=",
+      "name": "PowerShell",
+      "color": "#012456"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2UxMzk=",
+      "name": "Shell",
+      "color": "#89e051"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2UxOTA=",
+      "name": "Go",
+      "color": "#00ADD8"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2U1MzU=",
+      "name": "Dockerfile",
+      "color": "#384d54"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-newrelic-python-agent.json
+++ b/src/data/project-stats/newrelic-newrelic-python-agent.json
@@ -1,22 +1,29 @@
 {
   "projectFullName": "newrelic/newrelic-python-agent",
   "issues": {
-    "open": 10
+    "open": 25
   },
-  "releases": 276,
+  "releases": 277,
   "latestRelease": {
-    "name": "v6.4.3.160",
-    "date": "2021-06-23T21:07:50Z"
+    "name": "v6.4.4.161",
+    "date": "2021-07-06T18:36:45Z"
   },
-  "commits": 232,
-  "lastSixMonthsCommitTotal": 84,
+  "commits": 234,
+  "lastSixMonthsCommitTotal": 65,
   "contributors": 14,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 42199516,
+      "login": "qvik-olli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/42199516?v=4",
+      "htmlUrl": "https://github.com/qvik-olli",
+      "contributions": 1
+    },
     {
       "id": 1428400,
       "login": "coreyarnold",
@@ -25,10 +32,10 @@
       "contributions": 1
     },
     {
-      "id": 1413267,
-      "login": "stianjensen",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1413267?v=4",
-      "htmlUrl": "https://github.com/stianjensen",
+      "id": 44993916,
+      "login": "k2mahajan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/44993916?v=4",
+      "htmlUrl": "https://github.com/k2mahajan",
       "contributions": 1
     },
     {
@@ -37,13 +44,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
       "htmlUrl": "https://github.com/a-feld",
       "contributions": 62
-    },
-    {
-      "id": 42199516,
-      "login": "qvik-olli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/42199516?v=4",
-      "htmlUrl": "https://github.com/qvik-olli",
-      "contributions": 1
     },
     {
       "id": 929261,
@@ -71,7 +71,7 @@
       "login": "TimPansino",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11214426?v=4",
       "htmlUrl": "https://github.com/TimPansino",
-      "contributions": 87
+      "contributions": 89
     },
     {
       "id": 578029,
@@ -95,10 +95,10 @@
       "contributions": 1
     },
     {
-      "id": 44993916,
-      "login": "k2mahajan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/44993916?v=4",
-      "htmlUrl": "https://github.com/k2mahajan",
+      "id": 1413267,
+      "login": "stianjensen",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1413267?v=4",
+      "htmlUrl": "https://github.com/stianjensen",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-newrelic-ruby-agent.json
+++ b/src/data/project-stats/newrelic-newrelic-ruby-agent.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/newrelic-ruby-agent",
   "issues": {
-    "open": 35
+    "open": 41
   },
-  "releases": 372,
+  "releases": 374,
   "latestRelease": {
-    "name": "7.1.0",
-    "date": "2021-06-03T17:59:45Z"
+    "name": "7.2.0",
+    "date": "2021-06-25T17:13:41Z"
   },
-  "commits": 14758,
-  "lastSixMonthsCommitTotal": 169,
+  "commits": 14785,
+  "lastSixMonthsCommitTotal": 186,
   "contributors": 100,
   "pullRequests": {
-    "open": 5
+    "open": 3
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -50,11 +50,11 @@
       "contributions": 2
     },
     {
-      "id": 933055,
-      "login": "kenichi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/933055?v=4",
-      "htmlUrl": "https://github.com/kenichi",
-      "contributions": 177
+      "id": 1649699,
+      "login": "nbolser",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1649699?v=4",
+      "htmlUrl": "https://github.com/nbolser",
+      "contributions": 1
     },
     {
       "id": 218237,
@@ -71,18 +71,18 @@
       "contributions": 369
     },
     {
-      "id": 199,
-      "login": "jeremy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/199?v=4",
-      "htmlUrl": "https://github.com/jeremy",
+      "id": 112037,
+      "login": "callumj",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/112037?v=4",
+      "htmlUrl": "https://github.com/callumj",
       "contributions": 5
     },
     {
-      "id": 1388118,
-      "login": "hasghari",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1388118?v=4",
-      "htmlUrl": "https://github.com/hasghari",
-      "contributions": 1
+      "id": 115,
+      "login": "lawrencepit",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/115?v=4",
+      "htmlUrl": "https://github.com/lawrencepit",
+      "contributions": 2
     },
     {
       "id": 929261,
@@ -113,11 +113,11 @@
       "contributions": 1
     },
     {
-      "id": 35549,
-      "login": "rykov",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/35549?v=4",
-      "htmlUrl": "https://github.com/rykov",
-      "contributions": 2
+      "id": 8124558,
+      "login": "ChaelCodes",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8124558?v=4",
+      "htmlUrl": "https://github.com/ChaelCodes",
+      "contributions": 1
     },
     {
       "id": 444656,
@@ -127,25 +127,18 @@
       "contributions": 1
     },
     {
+      "id": 22148,
+      "login": "samg",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22148?v=4",
+      "htmlUrl": "https://github.com/samg",
+      "contributions": 7
+    },
+    {
       "id": 3467,
       "login": "kovyrin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3467?v=4",
       "htmlUrl": "https://github.com/kovyrin",
       "contributions": 9
-    },
-    {
-      "id": 300471,
-      "login": "rafaelpetry",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/300471?v=4",
-      "htmlUrl": "https://github.com/rafaelpetry",
-      "contributions": 1
-    },
-    {
-      "id": 2377,
-      "login": "jdelStrother",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2377?v=4",
-      "htmlUrl": "https://github.com/jdelStrother",
-      "contributions": 3
     },
     {
       "id": 982820,
@@ -155,25 +148,25 @@
       "contributions": 1331
     },
     {
-      "id": 4725264,
-      "login": "rdokov",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4725264?v=4",
-      "htmlUrl": "https://github.com/rdokov",
-      "contributions": 2
+      "id": 4865,
+      "login": "gnarg",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4865?v=4",
+      "htmlUrl": "https://github.com/gnarg",
+      "contributions": 701
     },
     {
-      "id": 860,
-      "login": "bkudria",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/860?v=4",
-      "htmlUrl": "https://github.com/bkudria",
-      "contributions": 2
+      "id": 542335,
+      "login": "dblock",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/542335?v=4",
+      "htmlUrl": "https://github.com/dblock",
+      "contributions": 3
     },
     {
-      "id": 12992,
-      "login": "wyhaines",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12992?v=4",
-      "htmlUrl": "https://github.com/wyhaines",
-      "contributions": 2
+      "id": 1020,
+      "login": "justinweiss",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1020?v=4",
+      "htmlUrl": "https://github.com/justinweiss",
+      "contributions": 3
     },
     {
       "id": 2911,
@@ -187,14 +180,14 @@
       "login": "amhuntsman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/738047?v=4",
       "htmlUrl": "https://github.com/amhuntsman",
-      "contributions": 7
+      "contributions": 21
     },
     {
-      "id": 263409,
-      "login": "soupmatt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/263409?v=4",
-      "htmlUrl": "https://github.com/soupmatt",
-      "contributions": 2
+      "id": 887,
+      "login": "mislav",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/887?v=4",
+      "htmlUrl": "https://github.com/mislav",
+      "contributions": 5
     },
     {
       "id": 19192189,
@@ -204,59 +197,10 @@
       "contributions": 1
     },
     {
-      "id": 4865,
-      "login": "gnarg",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4865?v=4",
-      "htmlUrl": "https://github.com/gnarg",
-      "contributions": 701
-    },
-    {
-      "id": 153388,
-      "login": "ojab",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/153388?v=4",
-      "htmlUrl": "https://github.com/ojab",
-      "contributions": 1
-    },
-    {
-      "id": 115,
-      "login": "lawrencepit",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/115?v=4",
-      "htmlUrl": "https://github.com/lawrencepit",
-      "contributions": 2
-    },
-    {
-      "id": 270746,
-      "login": "thejonanshow",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/270746?v=4",
-      "htmlUrl": "https://github.com/thejonanshow",
-      "contributions": 476
-    },
-    {
-      "id": 3170392,
-      "login": "justinfoote",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3170392?v=4",
-      "htmlUrl": "https://github.com/justinfoote",
-      "contributions": 252
-    },
-    {
-      "id": 10120,
-      "login": "warp",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10120?v=4",
-      "htmlUrl": "https://github.com/warp",
-      "contributions": 1
-    },
-    {
-      "id": 1020,
-      "login": "justinweiss",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1020?v=4",
-      "htmlUrl": "https://github.com/justinweiss",
-      "contributions": 3
-    },
-    {
-      "id": 1811616,
-      "login": "ohbarye",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1811616?v=4",
-      "htmlUrl": "https://github.com/ohbarye",
+      "id": 216,
+      "login": "henrik",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/216?v=4",
+      "htmlUrl": "https://github.com/henrik",
       "contributions": 1
     },
     {
@@ -267,6 +211,62 @@
       "contributions": 2
     },
     {
+      "id": 1388118,
+      "login": "hasghari",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1388118?v=4",
+      "htmlUrl": "https://github.com/hasghari",
+      "contributions": 1
+    },
+    {
+      "id": 436912,
+      "login": "troex",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/436912?v=4",
+      "htmlUrl": "https://github.com/troex",
+      "contributions": 2
+    },
+    {
+      "id": 270746,
+      "login": "thejonanshow",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/270746?v=4",
+      "htmlUrl": "https://github.com/thejonanshow",
+      "contributions": 476
+    },
+    {
+      "id": 504083,
+      "login": "cwholt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/504083?v=4",
+      "htmlUrl": "https://github.com/cwholt",
+      "contributions": 2
+    },
+    {
+      "id": 10120,
+      "login": "warp",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10120?v=4",
+      "htmlUrl": "https://github.com/warp",
+      "contributions": 1
+    },
+    {
+      "id": 6506296,
+      "login": "v-kolesnikov",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6506296?v=4",
+      "htmlUrl": "https://github.com/v-kolesnikov",
+      "contributions": 1
+    },
+    {
+      "id": 1811616,
+      "login": "ohbarye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1811616?v=4",
+      "htmlUrl": "https://github.com/ohbarye",
+      "contributions": 1
+    },
+    {
+      "id": 300471,
+      "login": "rafaelpetry",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/300471?v=4",
+      "htmlUrl": "https://github.com/rafaelpetry",
+      "contributions": 1
+    },
+    {
       "id": 12275387,
       "login": "keels125",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12275387?v=4",
@@ -274,11 +274,11 @@
       "contributions": 2
     },
     {
-      "id": 479496,
-      "login": "nihonjinrxs",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/479496?v=4",
-      "htmlUrl": "https://github.com/nihonjinrxs",
-      "contributions": 2
+      "id": 153388,
+      "login": "ojab",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/153388?v=4",
+      "htmlUrl": "https://github.com/ojab",
+      "contributions": 1
     },
     {
       "id": 86065,
@@ -295,13 +295,6 @@
       "contributions": 2
     },
     {
-      "id": 8124558,
-      "login": "ChaelCodes",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8124558?v=4",
-      "htmlUrl": "https://github.com/ChaelCodes",
-      "contributions": 1
-    },
-    {
       "id": 4761745,
       "login": "elucus",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4761745?v=4",
@@ -309,25 +302,32 @@
       "contributions": 4
     },
     {
-      "id": 22148,
-      "login": "samg",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/22148?v=4",
-      "htmlUrl": "https://github.com/samg",
-      "contributions": 7
+      "id": 3559,
+      "login": "jaggederest",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3559?v=4",
+      "htmlUrl": "https://github.com/jaggederest",
+      "contributions": 441
     },
     {
-      "id": 27471,
-      "login": "bkayser",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/27471?v=4",
-      "htmlUrl": "https://github.com/bkayser",
-      "contributions": 1573
+      "id": 82603,
+      "login": "brucek",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/82603?v=4",
+      "htmlUrl": "https://github.com/brucek",
+      "contributions": 2
     },
     {
-      "id": 130504,
-      "login": "jasonrclark",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/130504?v=4",
-      "htmlUrl": "https://github.com/jasonrclark",
-      "contributions": 1897
+      "id": 933055,
+      "login": "kenichi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/933055?v=4",
+      "htmlUrl": "https://github.com/kenichi",
+      "contributions": 177
+    },
+    {
+      "id": 4725264,
+      "login": "rdokov",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4725264?v=4",
+      "htmlUrl": "https://github.com/rdokov",
+      "contributions": 2
     },
     {
       "id": 4361134,
@@ -344,18 +344,18 @@
       "contributions": 3
     },
     {
-      "id": 386,
-      "login": "brainopia",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/386?v=4",
-      "htmlUrl": "https://github.com/brainopia",
-      "contributions": 2
+      "id": 176691,
+      "login": "jessedearing",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/176691?v=4",
+      "htmlUrl": "https://github.com/jessedearing",
+      "contributions": 14
     },
     {
-      "id": 542335,
-      "login": "dblock",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/542335?v=4",
-      "htmlUrl": "https://github.com/dblock",
-      "contributions": 3
+      "id": 2567,
+      "login": "tmm1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2567?v=4",
+      "htmlUrl": "https://github.com/tmm1",
+      "contributions": 2
     },
     {
       "id": 30514,
@@ -372,10 +372,10 @@
       "contributions": 144
     },
     {
-      "id": 887,
-      "login": "mislav",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/887?v=4",
-      "htmlUrl": "https://github.com/mislav",
+      "id": 199,
+      "login": "jeremy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/199?v=4",
+      "htmlUrl": "https://github.com/jeremy",
       "contributions": 5
     },
     {
@@ -386,11 +386,11 @@
       "contributions": 1
     },
     {
-      "id": 1048314,
-      "login": "athurn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1048314?v=4",
-      "htmlUrl": "https://github.com/athurn",
-      "contributions": 2
+      "id": 18387,
+      "login": "mwlang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18387?v=4",
+      "htmlUrl": "https://github.com/mwlang",
+      "contributions": 67
     },
     {
       "id": 7865781,
@@ -421,25 +421,11 @@
       "contributions": 1241
     },
     {
-      "id": 82603,
-      "login": "brucek",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/82603?v=4",
-      "htmlUrl": "https://github.com/brucek",
-      "contributions": 2
-    },
-    {
-      "id": 188063,
-      "login": "viraptor",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/188063?v=4",
-      "htmlUrl": "https://github.com/viraptor",
-      "contributions": 2
-    },
-    {
-      "id": 86957,
-      "login": "jpr5",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/86957?v=4",
-      "htmlUrl": "https://github.com/jpr5",
-      "contributions": 18
+      "id": 2377,
+      "login": "jdelStrother",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2377?v=4",
+      "htmlUrl": "https://github.com/jdelStrother",
+      "contributions": 3
     },
     {
       "id": 13501,
@@ -447,6 +433,20 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/13501?v=4",
       "htmlUrl": "https://github.com/ged",
       "contributions": 55
+    },
+    {
+      "id": 1420650,
+      "login": "koleksiuk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1420650?v=4",
+      "htmlUrl": "https://github.com/koleksiuk",
+      "contributions": 1
+    },
+    {
+      "id": 35549,
+      "login": "rykov",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/35549?v=4",
+      "htmlUrl": "https://github.com/rykov",
+      "contributions": 2
     },
     {
       "id": 337117,
@@ -463,11 +463,11 @@
       "contributions": 3
     },
     {
-      "id": 176691,
-      "login": "jessedearing",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/176691?v=4",
-      "htmlUrl": "https://github.com/jessedearing",
-      "contributions": 14
+      "id": 12992,
+      "login": "wyhaines",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12992?v=4",
+      "htmlUrl": "https://github.com/wyhaines",
+      "contributions": 2
     },
     {
       "id": 12839,
@@ -505,11 +505,11 @@
       "contributions": 5
     },
     {
-      "id": 497874,
-      "login": "orien",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/497874?v=4",
-      "htmlUrl": "https://github.com/orien",
-      "contributions": 1
+      "id": 4481921,
+      "login": "gabeobrien",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4481921?v=4",
+      "htmlUrl": "https://github.com/gabeobrien",
+      "contributions": 5
     },
     {
       "id": 6454794,
@@ -519,24 +519,24 @@
       "contributions": 5
     },
     {
-      "id": 216,
-      "login": "henrik",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/216?v=4",
-      "htmlUrl": "https://github.com/henrik",
-      "contributions": 1
+      "id": 188063,
+      "login": "viraptor",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188063?v=4",
+      "htmlUrl": "https://github.com/viraptor",
+      "contributions": 2
     },
     {
       "id": 69914680,
       "login": "angelatan2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/69914680?v=4",
       "htmlUrl": "https://github.com/angelatan2",
-      "contributions": 11
+      "contributions": 12
     },
     {
-      "id": 2567,
-      "login": "tmm1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2567?v=4",
-      "htmlUrl": "https://github.com/tmm1",
+      "id": 860,
+      "login": "bkudria",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/860?v=4",
+      "htmlUrl": "https://github.com/bkudria",
       "contributions": 2
     },
     {
@@ -554,11 +554,11 @@
       "contributions": 4
     },
     {
-      "id": 4481921,
-      "login": "gabeobrien",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4481921?v=4",
-      "htmlUrl": "https://github.com/gabeobrien",
-      "contributions": 5
+      "id": 263409,
+      "login": "soupmatt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/263409?v=4",
+      "htmlUrl": "https://github.com/soupmatt",
+      "contributions": 2
     },
     {
       "id": 63880,
@@ -568,18 +568,18 @@
       "contributions": 3
     },
     {
-      "id": 1420650,
-      "login": "koleksiuk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1420650?v=4",
-      "htmlUrl": "https://github.com/koleksiuk",
-      "contributions": 1
+      "id": 1048314,
+      "login": "athurn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1048314?v=4",
+      "htmlUrl": "https://github.com/athurn",
+      "contributions": 2
     },
     {
-      "id": 18387,
-      "login": "mwlang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18387?v=4",
-      "htmlUrl": "https://github.com/mwlang",
-      "contributions": 67
+      "id": 497874,
+      "login": "orien",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/497874?v=4",
+      "htmlUrl": "https://github.com/orien",
+      "contributions": 1
     },
     {
       "id": 9030,
@@ -603,18 +603,18 @@
       "contributions": 92
     },
     {
-      "id": 112037,
-      "login": "callumj",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/112037?v=4",
-      "htmlUrl": "https://github.com/callumj",
-      "contributions": 5
+      "id": 27471,
+      "login": "bkayser",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/27471?v=4",
+      "htmlUrl": "https://github.com/bkayser",
+      "contributions": 1573
     },
     {
       "id": 11799492,
       "login": "tannalynn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11799492?v=4",
       "htmlUrl": "https://github.com/tannalynn",
-      "contributions": 222
+      "contributions": 226
     },
     {
       "id": 1930,
@@ -645,11 +645,11 @@
       "contributions": 7
     },
     {
-      "id": 436912,
-      "login": "troex",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/436912?v=4",
-      "htmlUrl": "https://github.com/troex",
-      "contributions": 2
+      "id": 130504,
+      "login": "jasonrclark",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/130504?v=4",
+      "htmlUrl": "https://github.com/jasonrclark",
+      "contributions": 1897
     },
     {
       "id": 51594,
@@ -666,10 +666,10 @@
       "contributions": 1
     },
     {
-      "id": 504083,
-      "login": "cwholt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/504083?v=4",
-      "htmlUrl": "https://github.com/cwholt",
+      "id": 479496,
+      "login": "nihonjinrxs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/479496?v=4",
+      "htmlUrl": "https://github.com/nihonjinrxs",
       "contributions": 2
     },
     {
@@ -715,18 +715,18 @@
       "contributions": 3
     },
     {
-      "id": 3559,
-      "login": "jaggederest",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3559?v=4",
-      "htmlUrl": "https://github.com/jaggederest",
-      "contributions": 441
+      "id": 3170392,
+      "login": "justinfoote",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3170392?v=4",
+      "htmlUrl": "https://github.com/justinfoote",
+      "contributions": 252
     },
     {
-      "id": 1649699,
-      "login": "nbolser",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1649699?v=4",
-      "htmlUrl": "https://github.com/nbolser",
-      "contributions": 1
+      "id": 86957,
+      "login": "jpr5",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/86957?v=4",
+      "htmlUrl": "https://github.com/jpr5",
+      "contributions": 18
     },
     {
       "id": 283234,

--- a/src/data/project-stats/newrelic-newrelic-snowflake-integration.json
+++ b/src/data/project-stats/newrelic-newrelic-snowflake-integration.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/newrelic-snowflake-integration",
   "issues": {
-    "open": 3
+    "open": 4
   },
   "releases": 6,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-06-24T13:45:27Z"
   },
   "commits": 64,
-  "lastSixMonthsCommitTotal": 30,
+  "lastSixMonthsCommitTotal": 28,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-c.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-c.json
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 1672581,
-      "login": "barbnewrelic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1672581?v=4",
-      "htmlUrl": "https://github.com/barbnewrelic",
-      "contributions": 1
-    },
-    {
       "id": 28364881,
       "login": "Fahmy-Mohammed",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28364881?v=4",
       "htmlUrl": "https://github.com/Fahmy-Mohammed",
       "contributions": 8
+    },
+    {
+      "id": 1672581,
+      "login": "barbnewrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1672581?v=4",
+      "htmlUrl": "https://github.com/barbnewrelic",
+      "contributions": 1
     },
     {
       "id": 43244625,

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-dotnet.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-dotnet.json
@@ -18,11 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 9435570,
-      "login": "zuluecho9",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9435570?v=4",
-      "htmlUrl": "https://github.com/zuluecho9",
-      "contributions": 4
+      "id": 57361211,
+      "login": "nr-ahemsath",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
+      "htmlUrl": "https://github.com/nr-ahemsath",
+      "contributions": 3
+    },
+    {
+      "id": 4761745,
+      "login": "elucus",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4761745?v=4",
+      "htmlUrl": "https://github.com/elucus",
+      "contributions": 2
     },
     {
       "id": 69914680,
@@ -39,18 +46,18 @@
       "contributions": 3
     },
     {
-      "id": 57361211,
-      "login": "nr-ahemsath",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
-      "htmlUrl": "https://github.com/nr-ahemsath",
-      "contributions": 3
-    },
-    {
       "id": 20267975,
       "login": "lspangler584",
       "avatarUrl": "https://avatars.githubusercontent.com/u/20267975?v=4",
       "htmlUrl": "https://github.com/lspangler584",
       "contributions": 67
+    },
+    {
+      "id": 9435570,
+      "login": "zuluecho9",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9435570?v=4",
+      "htmlUrl": "https://github.com/zuluecho9",
+      "contributions": 4
     },
     {
       "id": 17498,
@@ -65,13 +72,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3522458?v=4",
       "htmlUrl": "https://github.com/jifeingo",
       "contributions": 138
-    },
-    {
-      "id": 4761745,
-      "login": "elucus",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4761745?v=4",
-      "htmlUrl": "https://github.com/elucus",
-      "contributions": 2
     },
     {
       "id": 3676547,

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-go.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-go.json
@@ -3,16 +3,16 @@
   "issues": {
     "open": 7
   },
-  "releases": 10,
+  "releases": 11,
   "latestRelease": {
-    "name": "v0.7.1",
-    "date": "2021-05-07T14:46:09Z"
+    "name": "v0.8.0",
+    "date": "2021-07-12T19:10:55Z"
   },
-  "commits": 163,
-  "lastSixMonthsCommitTotal": 109,
-  "contributors": 17,
+  "commits": 174,
+  "lastSixMonthsCommitTotal": 120,
+  "contributors": 18,
   "pullRequests": {
-    "open": 3
+    "open": 2
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -39,11 +39,25 @@
       "contributions": 2
     },
     {
+      "id": 52838839,
+      "login": "rob-sch1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/52838839?v=4",
+      "htmlUrl": "https://github.com/rob-sch1",
+      "contributions": 1
+    },
+    {
       "id": 34418638,
       "login": "jack-berg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34418638?v=4",
       "htmlUrl": "https://github.com/jack-berg",
       "contributions": 8
+    },
+    {
+      "id": 28708077,
+      "login": "blakeroberts-wk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28708077?v=4",
+      "htmlUrl": "https://github.com/blakeroberts-wk",
+      "contributions": 1
     },
     {
       "id": 9435570,
@@ -71,7 +85,7 @@
       "login": "alanwest",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3676547?v=4",
       "htmlUrl": "https://github.com/alanwest",
-      "contributions": 9
+      "contributions": 10
     },
     {
       "id": 13123145,
@@ -85,7 +99,7 @@
       "login": "a-feld",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
       "htmlUrl": "https://github.com/a-feld",
-      "contributions": 32
+      "contributions": 36
     },
     {
       "id": 3595851,
@@ -107,13 +121,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/1462042?v=4",
       "htmlUrl": "https://github.com/rvanderwal-newrelic",
       "contributions": 6
-    },
-    {
-      "id": 52838839,
-      "login": "rob-sch1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/52838839?v=4",
-      "htmlUrl": "https://github.com/rob-sch1",
-      "contributions": 1
     },
     {
       "id": 3170392,

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-java.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-java.json
@@ -1,15 +1,15 @@
 {
   "projectFullName": "newrelic/newrelic-telemetry-sdk-java",
   "issues": {
-    "open": 7
+    "open": 5
   },
   "releases": 15,
   "latestRelease": {
     "name": "v0.12.0",
     "date": "2021-02-16T20:47:29Z"
   },
-  "commits": 793,
-  "lastSixMonthsCommitTotal": 38,
+  "commits": 804,
+  "lastSixMonthsCommitTotal": 37,
   "contributors": 22,
   "pullRequests": {
     "open": 1
@@ -18,25 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 50001,
-      "login": "kscaldef",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/50001?v=4",
-      "htmlUrl": "https://github.com/kscaldef",
+      "id": 130504,
+      "login": "jasonrclark",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/130504?v=4",
+      "htmlUrl": "https://github.com/jasonrclark",
       "contributions": 1
-    },
-    {
-      "id": 858731,
-      "login": "jkwatson",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
-      "htmlUrl": "https://github.com/jkwatson",
-      "contributions": 4
-    },
-    {
-      "id": 30092781,
-      "login": "mjarvie",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30092781?v=4",
-      "htmlUrl": "https://github.com/mjarvie",
-      "contributions": 2
     },
     {
       "id": 81539,
@@ -46,13 +32,6 @@
       "contributions": 64
     },
     {
-      "id": 7992384,
-      "login": "paperclypse",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
-      "htmlUrl": "https://github.com/paperclypse",
-      "contributions": 1
-    },
-    {
       "id": 842717,
       "login": "tspring",
       "avatarUrl": "https://avatars.githubusercontent.com/u/842717?v=4",
@@ -60,39 +39,11 @@
       "contributions": 10
     },
     {
-      "id": 9435570,
-      "login": "zuluecho9",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9435570?v=4",
-      "htmlUrl": "https://github.com/zuluecho9",
-      "contributions": 3
-    },
-    {
-      "id": 130504,
-      "login": "jasonrclark",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/130504?v=4",
-      "htmlUrl": "https://github.com/jasonrclark",
-      "contributions": 1
-    },
-    {
-      "id": 2014377,
-      "login": "uaihebert",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2014377?v=4",
-      "htmlUrl": "https://github.com/uaihebert",
-      "contributions": 6
-    },
-    {
-      "id": 907624,
-      "login": "ysb33r",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/907624?v=4",
-      "htmlUrl": "https://github.com/ysb33r",
-      "contributions": 11
-    },
-    {
-      "id": 6374032,
-      "login": "a-feld",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
-      "htmlUrl": "https://github.com/a-feld",
-      "contributions": 1
+      "id": 30092781,
+      "login": "mjarvie",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30092781?v=4",
+      "htmlUrl": "https://github.com/mjarvie",
+      "contributions": 2
     },
     {
       "id": 34418638,
@@ -102,11 +53,39 @@
       "contributions": 4
     },
     {
+      "id": 1375860,
+      "login": "Yogendra0Sharma",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1375860?v=4",
+      "htmlUrl": "https://github.com/Yogendra0Sharma",
+      "contributions": 8
+    },
+    {
+      "id": 907624,
+      "login": "ysb33r",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/907624?v=4",
+      "htmlUrl": "https://github.com/ysb33r",
+      "contributions": 11
+    },
+    {
       "id": 3496648,
       "login": "jasonjkeller",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3496648?v=4",
       "htmlUrl": "https://github.com/jasonjkeller",
       "contributions": 4
+    },
+    {
+      "id": 2014377,
+      "login": "uaihebert",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2014377?v=4",
+      "htmlUrl": "https://github.com/uaihebert",
+      "contributions": 6
+    },
+    {
+      "id": 6374032,
+      "login": "a-feld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
+      "htmlUrl": "https://github.com/a-feld",
+      "contributions": 1
     },
     {
       "id": 7401258,
@@ -116,11 +95,25 @@
       "contributions": 18
     },
     {
+      "id": 50001,
+      "login": "kscaldef",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/50001?v=4",
+      "htmlUrl": "https://github.com/kscaldef",
+      "contributions": 1
+    },
+    {
+      "id": 7992384,
+      "login": "paperclypse",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
+      "htmlUrl": "https://github.com/paperclypse",
+      "contributions": 1
+    },
+    {
       "id": 42107100,
       "login": "yamnihcg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/42107100?v=4",
       "htmlUrl": "https://github.com/yamnihcg",
-      "contributions": 5
+      "contributions": 15
     },
     {
       "id": 308915,
@@ -144,11 +137,18 @@
       "contributions": 205
     },
     {
-      "id": 1375860,
-      "login": "Yogendra0Sharma",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1375860?v=4",
-      "htmlUrl": "https://github.com/Yogendra0Sharma",
-      "contributions": 8
+      "id": 9435570,
+      "login": "zuluecho9",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9435570?v=4",
+      "htmlUrl": "https://github.com/zuluecho9",
+      "contributions": 3
+    },
+    {
+      "id": 858731,
+      "login": "jkwatson",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/858731?v=4",
+      "htmlUrl": "https://github.com/jkwatson",
+      "contributions": 4
     },
     {
       "id": 24482401,

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-node.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-node.json
@@ -25,11 +25,11 @@
       "contributions": 34
     },
     {
-      "id": 585473,
-      "login": "MattWhelan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/585473?v=4",
-      "htmlUrl": "https://github.com/MattWhelan",
-      "contributions": 4
+      "id": 1342804,
+      "login": "lykkin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1342804?v=4",
+      "htmlUrl": "https://github.com/lykkin",
+      "contributions": 5
     },
     {
       "id": 17498,
@@ -53,11 +53,11 @@
       "contributions": 35
     },
     {
-      "id": 1342804,
-      "login": "lykkin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1342804?v=4",
-      "htmlUrl": "https://github.com/lykkin",
-      "contributions": 5
+      "id": 585473,
+      "login": "MattWhelan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/585473?v=4",
+      "htmlUrl": "https://github.com/MattWhelan",
+      "contributions": 4
     },
     {
       "id": 6722433,

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-python.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-python.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 6374032,
-      "login": "a-feld",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
-      "htmlUrl": "https://github.com/a-feld",
-      "contributions": 134
-    },
-    {
       "id": 9435570,
       "login": "zuluecho9",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9435570?v=4",
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/13881487?v=4",
       "htmlUrl": "https://github.com/BrandonTheBuilder",
       "contributions": 2
+    },
+    {
+      "id": 6374032,
+      "login": "a-feld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
+      "htmlUrl": "https://github.com/a-feld",
+      "contributions": 134
     },
     {
       "id": 11214426,

--- a/src/data/project-stats/newrelic-newrelic-telemetry-sdk-specs.json
+++ b/src/data/project-stats/newrelic-newrelic-telemetry-sdk-specs.json
@@ -22,11 +22,11 @@
       "contributions": 1
     },
     {
-      "id": 6374032,
-      "login": "a-feld",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
-      "htmlUrl": "https://github.com/a-feld",
-      "contributions": 6
+      "id": 54335840,
+      "login": "carlo-808",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
+      "htmlUrl": "https://github.com/carlo-808",
+      "contributions": 1
     },
     {
       "id": 1342804,
@@ -71,11 +71,11 @@
       "contributions": 1
     },
     {
-      "id": 54335840,
-      "login": "carlo-808",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
-      "htmlUrl": "https://github.com/carlo-808",
-      "contributions": 1
+      "id": 6374032,
+      "login": "a-feld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
+      "htmlUrl": "https://github.com/a-feld",
+      "contributions": 6
     }
   ],
   "languages": [],

--- a/src/data/project-stats/newrelic-newrelic-unix-monitor.json
+++ b/src/data/project-stats/newrelic-newrelic-unix-monitor.json
@@ -18,18 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 3860745,
+      "login": "csandels",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3860745?v=4",
+      "htmlUrl": "https://github.com/csandels",
+      "contributions": 3
+    },
+    {
       "id": 28734586,
       "login": "Devin-Li",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28734586?v=4",
       "htmlUrl": "https://github.com/Devin-Li",
       "contributions": 2
-    },
-    {
-      "id": 45947764,
-      "login": "bpeckNR",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
-      "htmlUrl": "https://github.com/bpeckNR",
-      "contributions": 1
     },
     {
       "id": 20245790,
@@ -39,10 +39,10 @@
       "contributions": 4
     },
     {
-      "id": 14909998,
-      "login": "Steve24by7",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14909998?v=4",
-      "htmlUrl": "https://github.com/Steve24by7",
+      "id": 45947764,
+      "login": "bpeckNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
+      "htmlUrl": "https://github.com/bpeckNR",
       "contributions": 1
     },
     {
@@ -67,11 +67,11 @@
       "contributions": 1
     },
     {
-      "id": 3860745,
-      "login": "csandels",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3860745?v=4",
-      "htmlUrl": "https://github.com/csandels",
-      "contributions": 3
+      "id": 14909998,
+      "login": "Steve24by7",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14909998?v=4",
+      "htmlUrl": "https://github.com/Steve24by7",
+      "contributions": 1
     },
     {
       "id": 466745,

--- a/src/data/project-stats/newrelic-node-native-metrics.json
+++ b/src/data/project-stats/newrelic-node-native-metrics.json
@@ -25,13 +25,6 @@
       "contributions": 1
     },
     {
-      "id": 846454,
-      "login": "abetomo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/846454?v=4",
-      "htmlUrl": "https://github.com/abetomo",
-      "contributions": 4
-    },
-    {
       "id": 5694695,
       "login": "eyedean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5694695?v=4",
@@ -46,24 +39,17 @@
       "contributions": 19
     },
     {
-      "id": 1333608,
-      "login": "bettiolo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1333608?v=4",
-      "htmlUrl": "https://github.com/bettiolo",
-      "contributions": 2
+      "id": 466761,
+      "login": "NatalieWolfe",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/466761?v=4",
+      "htmlUrl": "https://github.com/NatalieWolfe",
+      "contributions": 59
     },
     {
       "id": 75139737,
       "login": "paulgoertzen-merico",
       "avatarUrl": "https://avatars.githubusercontent.com/u/75139737?v=4",
       "htmlUrl": "https://github.com/paulgoertzen-merico",
-      "contributions": 1
-    },
-    {
-      "id": 1378615,
-      "login": "eboureau",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1378615?v=4",
-      "htmlUrl": "https://github.com/eboureau",
       "contributions": 1
     },
     {
@@ -74,18 +60,18 @@
       "contributions": 1
     },
     {
-      "id": 466761,
-      "login": "NatalieWolfe",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/466761?v=4",
-      "htmlUrl": "https://github.com/NatalieWolfe",
-      "contributions": 59
+      "id": 1378615,
+      "login": "eboureau",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1378615?v=4",
+      "htmlUrl": "https://github.com/eboureau",
+      "contributions": 1
     },
     {
-      "id": 54335840,
-      "login": "carlo-808",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
-      "htmlUrl": "https://github.com/carlo-808",
-      "contributions": 41
+      "id": 181527,
+      "login": "samshull",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/181527?v=4",
+      "htmlUrl": "https://github.com/samshull",
+      "contributions": 1
     },
     {
       "id": 4933147,
@@ -95,6 +81,20 @@
       "contributions": 9
     },
     {
+      "id": 54335840,
+      "login": "carlo-808",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
+      "htmlUrl": "https://github.com/carlo-808",
+      "contributions": 41
+    },
+    {
+      "id": 1333608,
+      "login": "bettiolo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1333608?v=4",
+      "htmlUrl": "https://github.com/bettiolo",
+      "contributions": 2
+    },
+    {
       "id": 1874937,
       "login": "bizob2828",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1874937?v=4",
@@ -102,18 +102,18 @@
       "contributions": 3
     },
     {
+      "id": 846454,
+      "login": "abetomo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/846454?v=4",
+      "htmlUrl": "https://github.com/abetomo",
+      "contributions": 4
+    },
+    {
       "id": 145340,
       "login": "adambrett",
       "avatarUrl": "https://avatars.githubusercontent.com/u/145340?v=4",
       "htmlUrl": "https://github.com/adambrett",
       "contributions": 2
-    },
-    {
-      "id": 181527,
-      "login": "samshull",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/181527?v=4",
-      "htmlUrl": "https://github.com/samshull",
-      "contributions": 1
     },
     {
       "id": 7992384,

--- a/src/data/project-stats/newrelic-node-newrelic-aws-sdk.json
+++ b/src/data/project-stats/newrelic-node-newrelic-aws-sdk.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 211,
-  "lastSixMonthsCommitTotal": 9,
+  "lastSixMonthsCommitTotal": 5,
   "contributors": 10,
   "pullRequests": {
     "open": 1
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 1904430,
-      "login": "TysonAndre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1904430?v=4",
-      "htmlUrl": "https://github.com/TysonAndre",
-      "contributions": 2
+      "id": 32520944,
+      "login": "astormnewrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32520944?v=4",
+      "htmlUrl": "https://github.com/astormnewrelic",
+      "contributions": 20
     },
     {
       "id": 7992384,
@@ -46,11 +46,11 @@
       "contributions": 4
     },
     {
-      "id": 32520944,
-      "login": "astormnewrelic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32520944?v=4",
-      "htmlUrl": "https://github.com/astormnewrelic",
-      "contributions": 20
+      "id": 1904430,
+      "login": "TysonAndre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1904430?v=4",
+      "htmlUrl": "https://github.com/TysonAndre",
+      "contributions": 2
     },
     {
       "id": 466761,

--- a/src/data/project-stats/newrelic-node-newrelic-koa.json
+++ b/src/data/project-stats/newrelic-node-newrelic-koa.json
@@ -25,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 158937,
-      "login": "jgeurts",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/158937?v=4",
-      "htmlUrl": "https://github.com/jgeurts",
-      "contributions": 2
+      "id": 7945073,
+      "login": "psvet",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7945073?v=4",
+      "htmlUrl": "https://github.com/psvet",
+      "contributions": 6
     },
     {
       "id": 1342804,
@@ -46,6 +46,13 @@
       "contributions": 1
     },
     {
+      "id": 12520493,
+      "login": "zacanger",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12520493?v=4",
+      "htmlUrl": "https://github.com/zacanger",
+      "contributions": 1
+    },
+    {
       "id": 929261,
       "login": "tangollama",
       "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
@@ -53,11 +60,11 @@
       "contributions": 1
     },
     {
-      "id": 12520493,
-      "login": "zacanger",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12520493?v=4",
-      "htmlUrl": "https://github.com/zacanger",
-      "contributions": 1
+      "id": 158937,
+      "login": "jgeurts",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/158937?v=4",
+      "htmlUrl": "https://github.com/jgeurts",
+      "contributions": 2
     },
     {
       "id": 58010132,
@@ -121,13 +128,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/11223178?v=4",
       "htmlUrl": "https://github.com/michaelgoin",
       "contributions": 25
-    },
-    {
-      "id": 7945073,
-      "login": "psvet",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7945073?v=4",
-      "htmlUrl": "https://github.com/psvet",
-      "contributions": 6
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-node-newrelic.json
+++ b/src/data/project-stats/newrelic-node-newrelic.json
@@ -1,21 +1,39 @@
 {
   "projectFullName": "newrelic/node-newrelic",
   "issues": {
-    "open": 102
+    "open": 109
   },
-  "releases": 284,
+  "releases": 285,
   "latestRelease": {
-    "name": "v7.5.1",
+    "name": "v7.5.2",
     "date": null
   },
-  "commits": 6675,
-  "lastSixMonthsCommitTotal": 276,
+  "commits": 6682,
+  "lastSixMonthsCommitTotal": 267,
   "contributors": 81,
   "pullRequests": {
     "open": 3
   },
   "searchCategory": "good first issue",
-  "cachedIssues": [],
+  "cachedIssues": [
+    {
+      "id": "MDU6SXNzdWU3NjA0NTI3Nzg=",
+      "title": "DOC ISSUE: Datastore Example Not Accurate",
+      "url": "https://github.com/newrelic/node-newrelic/issues/564",
+      "createdAt": "2020-12-09T15:57:35Z",
+      "comments": {
+        "totalCount": 1
+      },
+      "author": {
+        "login": "icpenguins",
+        "id": "MDQ6VXNlcjEwOTg0NTUx",
+        "email": "",
+        "name": "Brian Rogers"
+      },
+      "number": 564,
+      "createdBy": "Brian Rogers"
+    }
+  ],
   "cachedContributors": [
     {
       "id": 14006450,
@@ -25,11 +43,11 @@
       "contributions": 1
     },
     {
-      "id": 11327,
-      "login": "mrickard",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11327?v=4",
-      "htmlUrl": "https://github.com/mrickard",
-      "contributions": 6
+      "id": 171515,
+      "login": "nullvariable",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/171515?v=4",
+      "htmlUrl": "https://github.com/nullvariable",
+      "contributions": 1
     },
     {
       "id": 3165635,
@@ -39,10 +57,10 @@
       "contributions": 1
     },
     {
-      "id": 90898,
-      "login": "wraithan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/90898?v=4",
-      "htmlUrl": "https://github.com/wraithan",
+      "id": 3799709,
+      "login": "jakecraige",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3799709?v=4",
+      "htmlUrl": "https://github.com/jakecraige",
       "contributions": 1
     },
     {
@@ -60,18 +78,25 @@
       "contributions": 2
     },
     {
-      "id": 474603,
-      "login": "joaovieira",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/474603?v=4",
-      "htmlUrl": "https://github.com/joaovieira",
-      "contributions": 2
+      "id": 21225410,
+      "login": "uturunku1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21225410?v=4",
+      "htmlUrl": "https://github.com/uturunku1",
+      "contributions": 13
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
+      "id": 1074881,
+      "login": "dy-dx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1074881?v=4",
+      "htmlUrl": "https://github.com/dy-dx",
       "contributions": 1
+    },
+    {
+      "id": 816527,
+      "login": "hayes",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/816527?v=4",
+      "htmlUrl": "https://github.com/hayes",
+      "contributions": 82
     },
     {
       "id": 538488,
@@ -88,11 +113,11 @@
       "contributions": 1
     },
     {
-      "id": 21225410,
-      "login": "uturunku1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21225410?v=4",
-      "htmlUrl": "https://github.com/uturunku1",
-      "contributions": 13
+      "id": 6374032,
+      "login": "a-feld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
+      "htmlUrl": "https://github.com/a-feld",
+      "contributions": 4
     },
     {
       "id": 1162380,
@@ -107,20 +132,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/353768?v=4",
       "htmlUrl": "https://github.com/sebastianhoitz",
       "contributions": 1
-    },
-    {
-      "id": 3799709,
-      "login": "jakecraige",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3799709?v=4",
-      "htmlUrl": "https://github.com/jakecraige",
-      "contributions": 1
-    },
-    {
-      "id": 4933147,
-      "login": "martinkuba",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4933147?v=4",
-      "htmlUrl": "https://github.com/martinkuba",
-      "contributions": 141
     },
     {
       "id": 70015,
@@ -144,10 +155,10 @@
       "contributions": 3
     },
     {
-      "id": 10441551,
-      "login": "rr0214",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10441551?v=4",
-      "htmlUrl": "https://github.com/rr0214",
+      "id": 7992384,
+      "login": "paperclypse",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
+      "htmlUrl": "https://github.com/paperclypse",
       "contributions": 2
     },
     {
@@ -158,32 +169,39 @@
       "contributions": 1
     },
     {
-      "id": 6374032,
-      "login": "a-feld",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6374032?v=4",
-      "htmlUrl": "https://github.com/a-feld",
-      "contributions": 4
+      "id": 474603,
+      "login": "joaovieira",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/474603?v=4",
+      "htmlUrl": "https://github.com/joaovieira",
+      "contributions": 2
     },
     {
-      "id": 1074881,
-      "login": "dy-dx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1074881?v=4",
-      "htmlUrl": "https://github.com/dy-dx",
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
     },
     {
-      "id": 2061434,
-      "login": "AKPWebDesign",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2061434?v=4",
-      "htmlUrl": "https://github.com/AKPWebDesign",
+      "id": 18589982,
+      "login": "mastfissh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18589982?v=4",
+      "htmlUrl": "https://github.com/mastfissh",
       "contributions": 1
     },
     {
-      "id": 16082,
-      "login": "wesrog",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/16082?v=4",
-      "htmlUrl": "https://github.com/wesrog",
+      "id": 2708180,
+      "login": "Maubic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2708180?v=4",
+      "htmlUrl": "https://github.com/Maubic",
       "contributions": 1
+    },
+    {
+      "id": 1125900,
+      "login": "StyleT",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1125900?v=4",
+      "htmlUrl": "https://github.com/StyleT",
+      "contributions": 2
     },
     {
       "id": 19733683,
@@ -193,11 +211,11 @@
       "contributions": 14
     },
     {
-      "id": 171515,
-      "login": "nullvariable",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/171515?v=4",
-      "htmlUrl": "https://github.com/nullvariable",
-      "contributions": 1
+      "id": 1342804,
+      "login": "lykkin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1342804?v=4",
+      "htmlUrl": "https://github.com/lykkin",
+      "contributions": 618
     },
     {
       "id": 422180,
@@ -221,11 +239,11 @@
       "contributions": 1
     },
     {
-      "id": 7992384,
-      "login": "paperclypse",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
-      "htmlUrl": "https://github.com/paperclypse",
-      "contributions": 2
+      "id": 11327,
+      "login": "mrickard",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11327?v=4",
+      "htmlUrl": "https://github.com/mrickard",
+      "contributions": 6
     },
     {
       "id": 28942544,
@@ -235,52 +253,10 @@
       "contributions": 9
     },
     {
-      "id": 18589982,
-      "login": "mastfissh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18589982?v=4",
-      "htmlUrl": "https://github.com/mastfissh",
-      "contributions": 1
-    },
-    {
-      "id": 4969737,
-      "login": "juanigallo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4969737?v=4",
-      "htmlUrl": "https://github.com/juanigallo",
-      "contributions": 1
-    },
-    {
-      "id": 1342804,
-      "login": "lykkin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1342804?v=4",
-      "htmlUrl": "https://github.com/lykkin",
-      "contributions": 618
-    },
-    {
-      "id": 101073,
-      "login": "guilhermef",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/101073?v=4",
-      "htmlUrl": "https://github.com/guilhermef",
-      "contributions": 1
-    },
-    {
-      "id": 2708180,
-      "login": "Maubic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2708180?v=4",
-      "htmlUrl": "https://github.com/Maubic",
-      "contributions": 1
-    },
-    {
-      "id": 816527,
-      "login": "hayes",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/816527?v=4",
-      "htmlUrl": "https://github.com/hayes",
-      "contributions": 82
-    },
-    {
-      "id": 1244486,
-      "login": "tomashanacek",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1244486?v=4",
-      "htmlUrl": "https://github.com/tomashanacek",
+      "id": 20105,
+      "login": "case",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20105?v=4",
+      "htmlUrl": "https://github.com/case",
       "contributions": 1
     },
     {
@@ -291,6 +267,34 @@
       "contributions": 1
     },
     {
+      "id": 4969737,
+      "login": "juanigallo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4969737?v=4",
+      "htmlUrl": "https://github.com/juanigallo",
+      "contributions": 1
+    },
+    {
+      "id": 4933147,
+      "login": "martinkuba",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4933147?v=4",
+      "htmlUrl": "https://github.com/martinkuba",
+      "contributions": 141
+    },
+    {
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 1
+    },
+    {
+      "id": 1244486,
+      "login": "tomashanacek",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1244486?v=4",
+      "htmlUrl": "https://github.com/tomashanacek",
+      "contributions": 1
+    },
+    {
       "id": 819591,
       "login": "RyanCopley",
       "avatarUrl": "https://avatars.githubusercontent.com/u/819591?v=4",
@@ -298,11 +302,11 @@
       "contributions": 5
     },
     {
-      "id": 4408911,
-      "login": "roymiloh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4408911?v=4",
-      "htmlUrl": "https://github.com/roymiloh",
-      "contributions": 2
+      "id": 90898,
+      "login": "wraithan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/90898?v=4",
+      "htmlUrl": "https://github.com/wraithan",
+      "contributions": 1
     },
     {
       "id": 585473,
@@ -312,11 +316,11 @@
       "contributions": 9
     },
     {
-      "id": 20105,
-      "login": "case",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/20105?v=4",
-      "htmlUrl": "https://github.com/case",
-      "contributions": 1
+      "id": 10441551,
+      "login": "rr0214",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10441551?v=4",
+      "htmlUrl": "https://github.com/rr0214",
+      "contributions": 2
     },
     {
       "id": 1904430,
@@ -340,17 +344,24 @@
       "contributions": 1
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 1
+      "id": 4408911,
+      "login": "roymiloh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4408911?v=4",
+      "htmlUrl": "https://github.com/roymiloh",
+      "contributions": 2
     },
     {
       "id": 50803,
       "login": "lightbody",
       "avatarUrl": "https://avatars.githubusercontent.com/u/50803?v=4",
       "htmlUrl": "https://github.com/lightbody",
+      "contributions": 1
+    },
+    {
+      "id": 16082,
+      "login": "wesrog",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16082?v=4",
+      "htmlUrl": "https://github.com/wesrog",
       "contributions": 1
     },
     {
@@ -372,6 +383,13 @@
       "login": "kennethaasan",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1437394?v=4",
       "htmlUrl": "https://github.com/kennethaasan",
+      "contributions": 1
+    },
+    {
+      "id": 2061434,
+      "login": "AKPWebDesign",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2061434?v=4",
+      "htmlUrl": "https://github.com/AKPWebDesign",
       "contributions": 1
     },
     {
@@ -421,7 +439,7 @@
       "login": "bizob2828",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1874937?v=4",
       "htmlUrl": "https://github.com/bizob2828",
-      "contributions": 23
+      "contributions": 26
     },
     {
       "id": 54335840,
@@ -543,11 +561,11 @@
       "contributions": 2
     },
     {
-      "id": 1125900,
-      "login": "StyleT",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1125900?v=4",
-      "htmlUrl": "https://github.com/StyleT",
-      "contributions": 2
+      "id": 101073,
+      "login": "guilhermef",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/101073?v=4",
+      "htmlUrl": "https://github.com/guilhermef",
+      "contributions": 1
     },
     {
       "id": 20630,

--- a/src/data/project-stats/newrelic-node-test-utilities.json
+++ b/src/data/project-stats/newrelic-node-test-utilities.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 32520944,
-      "login": "astormnewrelic",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32520944?v=4",
-      "htmlUrl": "https://github.com/astormnewrelic",
-      "contributions": 5
-    },
-    {
       "id": 7992384,
       "login": "paperclypse",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7992384?v=4",
@@ -46,11 +39,11 @@
       "contributions": 6
     },
     {
-      "id": 7945073,
-      "login": "psvet",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7945073?v=4",
-      "htmlUrl": "https://github.com/psvet",
-      "contributions": 3
+      "id": 4933147,
+      "login": "martinkuba",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4933147?v=4",
+      "htmlUrl": "https://github.com/martinkuba",
+      "contributions": 2
     },
     {
       "id": 466761,
@@ -60,6 +53,20 @@
       "contributions": 36
     },
     {
+      "id": 1874937,
+      "login": "bizob2828",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1874937?v=4",
+      "htmlUrl": "https://github.com/bizob2828",
+      "contributions": 5
+    },
+    {
+      "id": 32520944,
+      "login": "astormnewrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32520944?v=4",
+      "htmlUrl": "https://github.com/astormnewrelic",
+      "contributions": 5
+    },
+    {
       "id": 11223178,
       "login": "michaelgoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11223178?v=4",
@@ -67,18 +74,11 @@
       "contributions": 27
     },
     {
-      "id": 4933147,
-      "login": "martinkuba",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4933147?v=4",
-      "htmlUrl": "https://github.com/martinkuba",
-      "contributions": 2
-    },
-    {
-      "id": 1874937,
-      "login": "bizob2828",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1874937?v=4",
-      "htmlUrl": "https://github.com/bizob2828",
-      "contributions": 5
+      "id": 7945073,
+      "login": "psvet",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7945073?v=4",
+      "htmlUrl": "https://github.com/psvet",
+      "contributions": 3
     },
     {
       "id": 54335840,

--- a/src/data/project-stats/newrelic-nr-integrations-builder.json
+++ b/src/data/project-stats/newrelic-nr-integrations-builder.json
@@ -10,20 +10,13 @@
   },
   "commits": 94,
   "lastSixMonthsCommitTotal": 0,
-  "contributors": 5,
+  "contributors": 4,
   "pullRequests": {
     "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 1902623,
-      "login": "trutx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1902623?v=4",
-      "htmlUrl": "https://github.com/trutx",
-      "contributions": 1
-    },
     {
       "id": 939550,
       "login": "mariomac",
@@ -32,10 +25,10 @@
       "contributions": 1
     },
     {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
+      "id": 1902623,
+      "login": "trutx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1902623?v=4",
+      "htmlUrl": "https://github.com/trutx",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nr-jenkins-plugin.json
+++ b/src/data/project-stats/newrelic-nr-jenkins-plugin.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nr-jenkins-plugin",
   "issues": {
-    "open": 5
+    "open": 6
   },
   "releases": 7,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-02-25T22:19:10Z"
   },
   "commits": 19,
-  "lastSixMonthsCommitTotal": 9,
+  "lastSixMonthsCommitTotal": 7,
   "contributors": 2,
   "pullRequests": {
     "open": 2

--- a/src/data/project-stats/newrelic-nr-ngo-validation-serverless.json
+++ b/src/data/project-stats/newrelic-nr-ngo-validation-serverless.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 299,
-  "lastSixMonthsCommitTotal": 112,
+  "lastSixMonthsCommitTotal": 111,
   "contributors": 4,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-nr1-account-maturity.json
+++ b/src/data/project-stats/newrelic-nr1-account-maturity.json
@@ -3,16 +3,16 @@
   "issues": {
     "open": 7
   },
-  "releases": 12,
+  "releases": 13,
   "latestRelease": {
-    "name": "v0.6.5",
-    "date": "2021-05-07T18:12:12Z"
+    "name": "v0.6.6",
+    "date": "2021-06-28T16:57:30Z"
   },
-  "commits": 99,
-  "lastSixMonthsCommitTotal": 17,
+  "commits": 108,
+  "lastSixMonthsCommitTotal": 25,
   "contributors": 10,
   "pullRequests": {
-    "open": 2
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -36,24 +36,17 @@
   ],
   "cachedContributors": [
     {
-      "id": 1395158,
-      "login": "jpvajda",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
-      "htmlUrl": "https://github.com/jpvajda",
-      "contributions": 1
-    },
-    {
       "id": 66321197,
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 17
+      "contributions": 19
     },
     {
-      "id": 1773616,
-      "login": "theletterf",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
-      "htmlUrl": "https://github.com/theletterf",
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
       "contributions": 1
     },
     {
@@ -64,11 +57,11 @@
       "contributions": 1
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 1
+      "id": 1395158,
+      "login": "jpvajda",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
+      "htmlUrl": "https://github.com/jpvajda",
+      "contributions": 5
     },
     {
       "id": 32174276,
@@ -85,11 +78,18 @@
       "contributions": 8
     },
     {
+      "id": 1773616,
+      "login": "theletterf",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1773616?v=4",
+      "htmlUrl": "https://github.com/theletterf",
+      "contributions": 1
+    },
+    {
       "id": 19733683,
       "login": "snyk-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
       "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 7
+      "contributions": 8
     },
     {
       "id": 6722433,

--- a/src/data/project-stats/newrelic-nr1-alerts-los-migrator.json
+++ b/src/data/project-stats/newrelic-nr1-alerts-los-migrator.json
@@ -9,7 +9,7 @@
     "date": "2021-03-29T14:23:41Z"
   },
   "commits": 56,
-  "lastSixMonthsCommitTotal": 17,
+  "lastSixMonthsCommitTotal": 15,
   "contributors": 7,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-nr1-apdex-optimizer.json
+++ b/src/data/project-stats/newrelic-nr1-apdex-optimizer.json
@@ -9,7 +9,7 @@
     "date": "2021-02-24T20:42:18Z"
   },
   "commits": 66,
-  "lastSixMonthsCommitTotal": 21,
+  "lastSixMonthsCommitTotal": 20,
   "contributors": 5,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-nr1-attributory.json
+++ b/src/data/project-stats/newrelic-nr1-attributory.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 2
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 3
     },
     {
       "id": 66321197,
@@ -39,11 +39,11 @@
       "contributions": 1
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 3
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 2
     },
     {
       "id": 6021115,

--- a/src/data/project-stats/newrelic-nr1-bootstrap-theme.json
+++ b/src/data/project-stats/newrelic-nr1-bootstrap-theme.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 2
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 5
     },
     {
       "id": 66321197,
@@ -39,11 +39,11 @@
       "contributions": 1
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 5
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 2
     },
     {
       "id": 32174276,

--- a/src/data/project-stats/newrelic-nr1-browser-analyzer.json
+++ b/src/data/project-stats/newrelic-nr1-browser-analyzer.json
@@ -8,22 +8,15 @@
     "name": "v1.3.7",
     "date": "2021-02-02T20:39:01Z"
   },
-  "commits": 182,
-  "lastSixMonthsCommitTotal": 10,
+  "commits": 190,
+  "lastSixMonthsCommitTotal": 15,
   "contributors": 15,
   "pullRequests": {
-    "open": 5
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 26434192,
-      "login": "Tirslo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/26434192?v=4",
-      "htmlUrl": "https://github.com/Tirslo",
-      "contributions": 1
-    },
     {
       "id": 32174276,
       "login": "semantic-release-bot",
@@ -39,10 +32,24 @@
       "contributions": 3
     },
     {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 20
+    },
+    {
       "id": 3023056,
       "login": "timglaser",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3023056?v=4",
       "htmlUrl": "https://github.com/timglaser",
+      "contributions": 2
+    },
+    {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
       "contributions": 2
     },
     {
@@ -60,18 +67,11 @@
       "contributions": 3
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 20
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 23
+      "id": 26434192,
+      "login": "Tirslo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26434192?v=4",
+      "htmlUrl": "https://github.com/Tirslo",
+      "contributions": 1
     },
     {
       "id": 66321197,
@@ -88,11 +88,11 @@
       "contributions": 1
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 2
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 23
     },
     {
       "id": 12318362,

--- a/src/data/project-stats/newrelic-nr1-catalog-manager.json
+++ b/src/data/project-stats/newrelic-nr1-catalog-manager.json
@@ -9,7 +9,7 @@
     "date": "2020-10-15T18:53:43Z"
   },
   "commits": 57,
-  "lastSixMonthsCommitTotal": 5,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 3,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-nr1-catalog.json
+++ b/src/data/project-stats/newrelic-nr1-catalog.json
@@ -1,12 +1,12 @@
 {
   "projectFullName": "newrelic/nr1-catalog",
   "issues": {
-    "open": 8
+    "open": 9
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 601,
-  "lastSixMonthsCommitTotal": 188,
+  "commits": 606,
+  "lastSixMonthsCommitTotal": 184,
   "contributors": 17,
   "pullRequests": {
     "open": 0
@@ -40,11 +40,11 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 78
+      "id": 1395158,
+      "login": "jpvajda",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
+      "htmlUrl": "https://github.com/jpvajda",
+      "contributions": 2
     },
     {
       "id": 58010132,
@@ -54,13 +54,6 @@
       "contributions": 4
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 1
-    },
-    {
       "id": 55132258,
       "login": "jsbnr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
@@ -68,11 +61,11 @@
       "contributions": 1
     },
     {
-      "id": 38332422,
-      "login": "caylahamann",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/38332422?v=4",
-      "htmlUrl": "https://github.com/caylahamann",
-      "contributions": 7
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 1
     },
     {
       "id": 929261,
@@ -82,31 +75,38 @@
       "contributions": 15
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 7
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 1
     },
     {
-      "id": 1395158,
-      "login": "jpvajda",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
-      "htmlUrl": "https://github.com/jpvajda",
-      "contributions": 2
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 80
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 97
+    },
+    {
+      "id": 38332422,
+      "login": "caylahamann",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38332422?v=4",
+      "htmlUrl": "https://github.com/caylahamann",
+      "contributions": 7
     },
     {
       "id": 1786630,
       "login": "aso1124",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1786630?v=4",
       "htmlUrl": "https://github.com/aso1124",
-      "contributions": 1
-    },
-    {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
       "contributions": 1
     },
     {
@@ -117,11 +117,11 @@
       "contributions": 8
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 97
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 7
     },
     {
       "id": 53268450,

--- a/src/data/project-stats/newrelic-nr1-cloud-optimize.json
+++ b/src/data/project-stats/newrelic-nr1-cloud-optimize.json
@@ -9,7 +9,7 @@
     "date": "2021-04-12T01:52:15Z"
   },
   "commits": 197,
-  "lastSixMonthsCommitTotal": 25,
+  "lastSixMonthsCommitTotal": 24,
   "contributors": 17,
   "pullRequests": {
     "open": 0
@@ -60,11 +60,18 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 23
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 12
+    },
+    {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 2
     },
     {
       "id": 812989,
@@ -74,11 +81,11 @@
       "contributions": 11
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 9
+      "id": 1082112,
+      "login": "ericmittelhammer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1082112?v=4",
+      "htmlUrl": "https://github.com/ericmittelhammer",
+      "contributions": 2
     },
     {
       "id": 5859975,
@@ -95,18 +102,11 @@
       "contributions": 2
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 12
-    },
-    {
-      "id": 13043208,
-      "login": "Kav91",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13043208?v=4",
-      "htmlUrl": "https://github.com/Kav91",
-      "contributions": 72
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 23
     },
     {
       "id": 55203603,
@@ -123,11 +123,11 @@
       "contributions": 1
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 2
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 9
     },
     {
       "id": 8731013,
@@ -158,11 +158,11 @@
       "contributions": 1
     },
     {
-      "id": 1082112,
-      "login": "ericmittelhammer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1082112?v=4",
-      "htmlUrl": "https://github.com/ericmittelhammer",
-      "contributions": 2
+      "id": 13043208,
+      "login": "Kav91",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13043208?v=4",
+      "htmlUrl": "https://github.com/Kav91",
+      "contributions": 72
     },
     {
       "id": 45473904,

--- a/src/data/project-stats/newrelic-nr1-community.json
+++ b/src/data/project-stats/newrelic-nr1-community.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/nr1-community",
   "issues": {
-    "open": 24
+    "open": 25
   },
   "releases": 4,
   "latestRelease": {
     "name": "v1.2.0",
     "date": "2020-06-09T16:26:07Z"
   },
-  "commits": 223,
-  "lastSixMonthsCommitTotal": 0,
-  "contributors": 7,
+  "commits": 228,
+  "lastSixMonthsCommitTotal": 3,
+  "contributors": 8,
   "pullRequests": {
-    "open": 8
+    "open": 5
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -70,11 +70,11 @@
   ],
   "cachedContributors": [
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 2
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 72
     },
     {
       "id": 21367523,
@@ -84,11 +84,18 @@
       "contributions": 5
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 72
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 2
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
     },
     {
       "id": 929261,
@@ -102,7 +109,7 @@
       "login": "snyk-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
       "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 9
+      "contributions": 11
     },
     {
       "id": 812989,
@@ -126,9 +133,9 @@
       "color": "#f1e05a"
     },
     {
-      "id": "MDg6TGFuZ3VhZ2UzMDg=",
-      "name": "CSS",
-      "color": "#563d7c"
+      "id": "MDg6TGFuZ3VhZ2U2MDU=",
+      "name": "SCSS",
+      "color": "#c6538c"
     }
   ],
   "screenshots": [

--- a/src/data/project-stats/newrelic-nr1-container-explorer.json
+++ b/src/data/project-stats/newrelic-nr1-container-explorer.json
@@ -9,7 +9,7 @@
     "date": "2021-04-05T21:18:49Z"
   },
   "commits": 166,
-  "lastSixMonthsCommitTotal": 11,
+  "lastSixMonthsCommitTotal": 10,
   "contributors": 12,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-nr1-customer-journey.json
+++ b/src/data/project-stats/newrelic-nr1-customer-journey.json
@@ -9,7 +9,7 @@
     "date": "2020-07-01T02:52:07Z"
   },
   "commits": 278,
-  "lastSixMonthsCommitTotal": 2,
+  "lastSixMonthsCommitTotal": 1,
   "contributors": 12,
   "pullRequests": {
     "open": 3
@@ -25,18 +25,18 @@
       "contributions": 5
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 2
-    },
-    {
       "id": 32961497,
       "login": "artuone83",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32961497?v=4",
       "htmlUrl": "https://github.com/artuone83",
       "contributions": 24
+    },
+    {
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 2
     },
     {
       "id": 13562672,
@@ -46,18 +46,18 @@
       "contributions": 1
     },
     {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 72
+    },
+    {
       "id": 929261,
       "login": "tangollama",
       "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
       "htmlUrl": "https://github.com/tangollama",
       "contributions": 5
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 2
     },
     {
       "id": 5214156,
@@ -67,11 +67,11 @@
       "contributions": 29
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 72
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 2
     },
     {
       "id": 32174276,

--- a/src/data/project-stats/newrelic-nr1-datalyzer.json
+++ b/src/data/project-stats/newrelic-nr1-datalyzer.json
@@ -9,7 +9,7 @@
     "date": "2021-04-02T17:02:53Z"
   },
   "commits": 206,
-  "lastSixMonthsCommitTotal": 5,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 15,
   "pullRequests": {
     "open": 1
@@ -36,13 +36,6 @@
   ],
   "cachedContributors": [
     {
-      "id": 175638,
-      "login": "danielguillan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/175638?v=4",
-      "htmlUrl": "https://github.com/danielguillan",
-      "contributions": 1
-    },
-    {
       "id": 66321197,
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
@@ -50,11 +43,11 @@
       "contributions": 11
     },
     {
-      "id": 55203603,
-      "login": "austin-schaefer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
-      "htmlUrl": "https://github.com/austin-schaefer",
-      "contributions": 2
+      "id": 30514,
+      "login": "cirne",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
+      "htmlUrl": "https://github.com/cirne",
+      "contributions": 70
     },
     {
       "id": 13562672,
@@ -71,11 +64,18 @@
       "contributions": 1
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 3
+      "id": 55203603,
+      "login": "austin-schaefer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
+      "htmlUrl": "https://github.com/austin-schaefer",
+      "contributions": 2
+    },
+    {
+      "id": 175638,
+      "login": "danielguillan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/175638?v=4",
+      "htmlUrl": "https://github.com/danielguillan",
+      "contributions": 1
     },
     {
       "id": 6722433,
@@ -106,11 +106,11 @@
       "contributions": 4
     },
     {
-      "id": 30514,
-      "login": "cirne",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
-      "htmlUrl": "https://github.com/cirne",
-      "contributions": 70
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 3
     },
     {
       "id": 12318362,

--- a/src/data/project-stats/newrelic-nr1-deployment-analyzer.json
+++ b/src/data/project-stats/newrelic-nr1-deployment-analyzer.json
@@ -9,7 +9,7 @@
     "date": "2021-05-07T18:19:39Z"
   },
   "commits": 95,
-  "lastSixMonthsCommitTotal": 25,
+  "lastSixMonthsCommitTotal": 24,
   "contributors": 12,
   "pullRequests": {
     "open": 0
@@ -22,13 +22,6 @@
       "login": "jpvajda",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
       "htmlUrl": "https://github.com/jpvajda",
-      "contributions": 1
-    },
-    {
-      "id": 17086744,
-      "login": "sarabartell",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17086744?v=4",
-      "htmlUrl": "https://github.com/sarabartell",
       "contributions": 1
     },
     {
@@ -67,11 +60,18 @@
       "contributions": 2
     },
     {
-      "id": 5214156,
-      "login": "norbertsuski",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5214156?v=4",
-      "htmlUrl": "https://github.com/norbertsuski",
-      "contributions": 4
+      "id": 812989,
+      "login": "danielgolden",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
+      "htmlUrl": "https://github.com/danielgolden",
+      "contributions": 3
+    },
+    {
+      "id": 17086744,
+      "login": "sarabartell",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17086744?v=4",
+      "htmlUrl": "https://github.com/sarabartell",
+      "contributions": 1
     },
     {
       "id": 19733683,
@@ -88,11 +88,11 @@
       "contributions": 8
     },
     {
-      "id": 812989,
-      "login": "danielgolden",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
-      "htmlUrl": "https://github.com/danielgolden",
-      "contributions": 3
+      "id": 5214156,
+      "login": "norbertsuski",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5214156?v=4",
+      "htmlUrl": "https://github.com/norbertsuski",
+      "contributions": 4
     },
     {
       "id": 13043208,

--- a/src/data/project-stats/newrelic-nr1-donor-analyzer.json
+++ b/src/data/project-stats/newrelic-nr1-donor-analyzer.json
@@ -9,10 +9,10 @@
     "date": "2021-05-07T13:06:11Z"
   },
   "commits": 194,
-  "lastSixMonthsCommitTotal": 16,
+  "lastSixMonthsCommitTotal": 15,
   "contributors": 18,
   "pullRequests": {
-    "open": 2
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -43,11 +43,11 @@
       "contributions": 5
     },
     {
-      "id": 39655074,
-      "login": "LizBaker",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
-      "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 2
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 7
     },
     {
       "id": 754009,
@@ -57,10 +57,10 @@
       "contributions": 1
     },
     {
-      "id": 58010132,
-      "login": "mmfred",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/58010132?v=4",
-      "htmlUrl": "https://github.com/mmfred",
+      "id": 26434192,
+      "login": "Tirslo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26434192?v=4",
+      "htmlUrl": "https://github.com/Tirslo",
       "contributions": 1
     },
     {
@@ -85,18 +85,18 @@
       "contributions": 3
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 23
+      "id": 19733683,
+      "login": "snyk-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
+      "htmlUrl": "https://github.com/snyk-bot",
+      "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 7
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 8
     },
     {
       "id": 13562672,
@@ -106,10 +106,10 @@
       "contributions": 28
     },
     {
-      "id": 26434192,
-      "login": "Tirslo",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/26434192?v=4",
-      "htmlUrl": "https://github.com/Tirslo",
+      "id": 58010132,
+      "login": "mmfred",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/58010132?v=4",
+      "htmlUrl": "https://github.com/mmfred",
       "contributions": 1
     },
     {
@@ -120,11 +120,11 @@
       "contributions": 1
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 8
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 23
     },
     {
       "id": 8731013,
@@ -141,11 +141,11 @@
       "contributions": 1
     },
     {
-      "id": 19733683,
-      "login": "snyk-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
-      "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 1
+      "id": 39655074,
+      "login": "LizBaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
+      "htmlUrl": "https://github.com/LizBaker",
+      "contributions": 2
     },
     {
       "id": 812989,

--- a/src/data/project-stats/newrelic-nr1-event-stream.json
+++ b/src/data/project-stats/newrelic-nr1-event-stream.json
@@ -9,7 +9,7 @@
     "date": "2021-05-07T18:20:06Z"
   },
   "commits": 130,
-  "lastSixMonthsCommitTotal": 11,
+  "lastSixMonthsCommitTotal": 10,
   "contributors": 11,
   "pullRequests": {
     "open": 0
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 1
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 9
     },
     {
       "id": 66321197,
@@ -32,11 +32,11 @@
       "contributions": 14
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 9
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 1
     },
     {
       "id": 32174276,
@@ -53,17 +53,17 @@
       "contributions": 2
     },
     {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 1
+    },
+    {
       "id": 55203603,
       "login": "austin-schaefer",
       "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
       "htmlUrl": "https://github.com/austin-schaefer",
-      "contributions": 1
-    },
-    {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nr1-github.json
+++ b/src/data/project-stats/newrelic-nr1-github.json
@@ -9,14 +9,21 @@
     "date": "2021-06-21T09:08:28Z"
   },
   "commits": 215,
-  "lastSixMonthsCommitTotal": 64,
+  "lastSixMonthsCommitTotal": 63,
   "contributors": 17,
   "pullRequests": {
-    "open": 2
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 1
+    },
     {
       "id": 66321197,
       "login": "nr-opensource-bot",
@@ -32,32 +39,11 @@
       "contributions": 2
     },
     {
-      "id": 55203603,
-      "login": "austin-schaefer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
-      "htmlUrl": "https://github.com/austin-schaefer",
-      "contributions": 4
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 9
-    },
-    {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
-    },
-    {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 3
+      "id": 39655074,
+      "login": "LizBaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
+      "htmlUrl": "https://github.com/LizBaker",
+      "contributions": 5
     },
     {
       "id": 455419,
@@ -67,11 +53,18 @@
       "contributions": 1
     },
     {
-      "id": 17122543,
-      "login": "rudouglas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
-      "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 32
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
+    },
+    {
+      "id": 55203603,
+      "login": "austin-schaefer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
+      "htmlUrl": "https://github.com/austin-schaefer",
+      "contributions": 4
     },
     {
       "id": 197140,
@@ -81,11 +74,18 @@
       "contributions": 16
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 1
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 3
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 9
     },
     {
       "id": 30514,
@@ -116,11 +116,11 @@
       "contributions": 4
     },
     {
-      "id": 39655074,
-      "login": "LizBaker",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
-      "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 5
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
+      "contributions": 32
     },
     {
       "id": 812989,

--- a/src/data/project-stats/newrelic-nr1-graphiql-notebook.json
+++ b/src/data/project-stats/newrelic-nr1-graphiql-notebook.json
@@ -9,7 +9,7 @@
     "date": "2021-05-07T17:16:43Z"
   },
   "commits": 139,
-  "lastSixMonthsCommitTotal": 10,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 11,
   "pullRequests": {
     "open": 1
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 55203603,
-      "login": "austin-schaefer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
-      "htmlUrl": "https://github.com/austin-schaefer",
-      "contributions": 1
-    },
-    {
       "id": 66321197,
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
@@ -32,11 +25,11 @@
       "contributions": 8
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 1
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 8
     },
     {
       "id": 929261,
@@ -46,11 +39,18 @@
       "contributions": 2
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 11
+      "id": 55203603,
+      "login": "austin-schaefer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55203603?v=4",
+      "htmlUrl": "https://github.com/austin-schaefer",
+      "contributions": 1
+    },
+    {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 1
     },
     {
       "id": 55462,
@@ -60,11 +60,11 @@
       "contributions": 54
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 8
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 11
     },
     {
       "id": 8731013,

--- a/src/data/project-stats/newrelic-nr1-groundskeeper.json
+++ b/src/data/project-stats/newrelic-nr1-groundskeeper.json
@@ -9,7 +9,7 @@
     "date": "2021-05-07T17:20:37Z"
   },
   "commits": 127,
-  "lastSixMonthsCommitTotal": 24,
+  "lastSixMonthsCommitTotal": 21,
   "contributors": 11,
   "pullRequests": {
     "open": 1
@@ -43,18 +43,11 @@
       "contributions": 1
     },
     {
-      "id": 20293876,
-      "login": "tyreer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/20293876?v=4",
-      "htmlUrl": "https://github.com/tyreer",
-      "contributions": 12
-    },
-    {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 4
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 6
     },
     {
       "id": 8731013,
@@ -64,6 +57,13 @@
       "contributions": 1
     },
     {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 4
+    },
+    {
       "id": 32174276,
       "login": "semantic-release-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
@@ -71,11 +71,11 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 6
+      "id": 20293876,
+      "login": "tyreer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20293876?v=4",
+      "htmlUrl": "https://github.com/tyreer",
+      "contributions": 12
     },
     {
       "id": 929261,

--- a/src/data/project-stats/newrelic-nr1-integrations-manager.json
+++ b/src/data/project-stats/newrelic-nr1-integrations-manager.json
@@ -9,7 +9,7 @@
     "date": "2021-05-14T23:58:54Z"
   },
   "commits": 139,
-  "lastSixMonthsCommitTotal": 13,
+  "lastSixMonthsCommitTotal": 12,
   "contributors": 12,
   "pullRequests": {
     "open": 0
@@ -25,18 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
       "contributions": 1
-    },
-    {
-      "id": 70179215,
-      "login": "nr-kkenney",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
-      "htmlUrl": "https://github.com/nr-kkenney",
-      "contributions": 2
     },
     {
       "id": 66321197,
@@ -46,17 +39,17 @@
       "contributions": 24
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 13
+      "id": 70179215,
+      "login": "nr-kkenney",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
+      "htmlUrl": "https://github.com/nr-kkenney",
+      "contributions": 2
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
       "contributions": 1
     },
     {
@@ -72,6 +65,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
       "htmlUrl": "https://github.com/jbeveland27",
       "contributions": 7
+    },
+    {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 13
     },
     {
       "id": 32174276,

--- a/src/data/project-stats/newrelic-nr1-learn-nrql.json
+++ b/src/data/project-stats/newrelic-nr1-learn-nrql.json
@@ -9,7 +9,7 @@
     "date": "2021-02-24T12:12:36Z"
   },
   "commits": 143,
-  "lastSixMonthsCommitTotal": 13,
+  "lastSixMonthsCommitTotal": 12,
   "contributors": 15,
   "pullRequests": {
     "open": 0
@@ -32,25 +32,25 @@
       "contributions": 9
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 4
-    },
-    {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
+      "id": 6836095,
+      "login": "kaojiri",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6836095?v=4",
+      "htmlUrl": "https://github.com/kaojiri",
       "contributions": 1
     },
     {
-      "id": 8429820,
-      "login": "courtneyphillips",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8429820?v=4",
-      "htmlUrl": "https://github.com/courtneyphillips",
-      "contributions": 40
+      "id": 28544519,
+      "login": "goldenplec",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28544519?v=4",
+      "htmlUrl": "https://github.com/goldenplec",
+      "contributions": 1
+    },
+    {
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 1
     },
     {
       "id": 66958286,
@@ -81,11 +81,11 @@
       "contributions": 10
     },
     {
-      "id": 28544519,
-      "login": "goldenplec",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28544519?v=4",
-      "htmlUrl": "https://github.com/goldenplec",
-      "contributions": 1
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 4
     },
     {
       "id": 7992384,
@@ -95,18 +95,18 @@
       "contributions": 2
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
       "contributions": 1
     },
     {
-      "id": 6836095,
-      "login": "kaojiri",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6836095?v=4",
-      "htmlUrl": "https://github.com/kaojiri",
-      "contributions": 1
+      "id": 8429820,
+      "login": "courtneyphillips",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8429820?v=4",
+      "htmlUrl": "https://github.com/courtneyphillips",
+      "contributions": 40
     },
     {
       "id": 19733683,

--- a/src/data/project-stats/newrelic-nr1-mande.json
+++ b/src/data/project-stats/newrelic-nr1-mande.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 487,
-  "lastSixMonthsCommitTotal": 3,
+  "lastSixMonthsCommitTotal": 2,
   "contributors": 7,
   "pullRequests": {
     "open": 0
@@ -25,11 +25,11 @@
       "contributions": 4
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 1
+      "id": 1786630,
+      "login": "aso1124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1786630?v=4",
+      "htmlUrl": "https://github.com/aso1124",
+      "contributions": 260
     },
     {
       "id": 197140,
@@ -46,11 +46,11 @@
       "contributions": 98
     },
     {
-      "id": 1786630,
-      "login": "aso1124",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1786630?v=4",
-      "htmlUrl": "https://github.com/aso1124",
-      "contributions": 260
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
     },
     {
       "id": 812989,

--- a/src/data/project-stats/newrelic-nr1-metrics-aggregator.json
+++ b/src/data/project-stats/newrelic-nr1-metrics-aggregator.json
@@ -3,16 +3,16 @@
   "issues": {
     "open": 2
   },
-  "releases": 13,
+  "releases": 14,
   "latestRelease": {
-    "name": "v0.9.18",
-    "date": "2021-06-03T16:57:01Z"
+    "name": "v0.9.19",
+    "date": "2021-06-25T22:02:57Z"
   },
-  "commits": 165,
-  "lastSixMonthsCommitTotal": 59,
+  "commits": 168,
+  "lastSixMonthsCommitTotal": 61,
   "contributors": 11,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -32,11 +32,11 @@
       "contributions": 2
     },
     {
-      "id": 53268450,
-      "login": "jake-codes",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/53268450?v=4",
-      "htmlUrl": "https://github.com/jake-codes",
-      "contributions": 53
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 24
     },
     {
       "id": 8731013,
@@ -46,11 +46,11 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 23
+      "id": 53268450,
+      "login": "jake-codes",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/53268450?v=4",
+      "htmlUrl": "https://github.com/jake-codes",
+      "contributions": 53
     },
     {
       "id": 32174276,
@@ -85,7 +85,7 @@
       "login": "snyk-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
       "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 5
+      "contributions": 6
     },
     {
       "id": 6722433,

--- a/src/data/project-stats/newrelic-nr1-neon.json
+++ b/src/data/project-stats/newrelic-nr1-neon.json
@@ -9,7 +9,7 @@
     "date": "2021-02-17T23:03:00Z"
   },
   "commits": 368,
-  "lastSixMonthsCommitTotal": 17,
+  "lastSixMonthsCommitTotal": 13,
   "contributors": 9,
   "pullRequests": {
     "open": 0
@@ -50,6 +50,13 @@
       "contributions": 1
     },
     {
+      "id": 20893240,
+      "login": "glitton",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20893240?v=4",
+      "htmlUrl": "https://github.com/glitton",
+      "contributions": 151
+    },
+    {
       "id": 104112,
       "login": "siva-epari",
       "avatarUrl": "https://avatars.githubusercontent.com/u/104112?v=4",
@@ -83,13 +90,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
       "htmlUrl": "https://github.com/jbeveland27",
       "contributions": 8
-    },
-    {
-      "id": 20893240,
-      "login": "glitton",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/20893240?v=4",
-      "htmlUrl": "https://github.com/glitton",
-      "contributions": 151
     },
     {
       "id": 6021115,

--- a/src/data/project-stats/newrelic-nr1-nerdlet-zero-to-hero.json
+++ b/src/data/project-stats/newrelic-nr1-nerdlet-zero-to-hero.json
@@ -6,7 +6,7 @@
   "releases": 0,
   "latestRelease": null,
   "commits": 10,
-  "lastSixMonthsCommitTotal": 6,
+  "lastSixMonthsCommitTotal": 4,
   "contributors": 3,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-nr1-network-telemetry.json
+++ b/src/data/project-stats/newrelic-nr1-network-telemetry.json
@@ -9,7 +9,7 @@
     "date": "2021-02-26T18:49:42Z"
   },
   "commits": 160,
-  "lastSixMonthsCommitTotal": 10,
+  "lastSixMonthsCommitTotal": 9,
   "contributors": 13,
   "pullRequests": {
     "open": 1
@@ -25,18 +25,18 @@
       "contributions": 1
     },
     {
+      "id": 24775098,
+      "login": "madecki",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24775098?v=4",
+      "htmlUrl": "https://github.com/madecki",
+      "contributions": 12
+    },
+    {
       "id": 66321197,
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
       "contributions": 8
-    },
-    {
-      "id": 14294477,
-      "login": "jaguilar87",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14294477?v=4",
-      "htmlUrl": "https://github.com/jaguilar87",
-      "contributions": 1
     },
     {
       "id": 8731013,
@@ -46,18 +46,11 @@
       "contributions": 1
     },
     {
-      "id": 30514,
-      "login": "cirne",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
-      "htmlUrl": "https://github.com/cirne",
-      "contributions": 3
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 8
+      "id": 32174276,
+      "login": "semantic-release-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
+      "htmlUrl": "https://github.com/semantic-release-bot",
+      "contributions": 2
     },
     {
       "id": 455419,
@@ -67,6 +60,13 @@
       "contributions": 72
     },
     {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 8
+    },
+    {
       "id": 197140,
       "login": "devfreddy",
       "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
@@ -74,18 +74,18 @@
       "contributions": 7
     },
     {
-      "id": 24775098,
-      "login": "madecki",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24775098?v=4",
-      "htmlUrl": "https://github.com/madecki",
-      "contributions": 12
+      "id": 30514,
+      "login": "cirne",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
+      "htmlUrl": "https://github.com/cirne",
+      "contributions": 3
     },
     {
-      "id": 32174276,
-      "login": "semantic-release-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
-      "htmlUrl": "https://github.com/semantic-release-bot",
-      "contributions": 2
+      "id": 14294477,
+      "login": "jaguilar87",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14294477?v=4",
+      "htmlUrl": "https://github.com/jaguilar87",
+      "contributions": 1
     },
     {
       "id": 39655074,

--- a/src/data/project-stats/newrelic-nr1-nimbus.json
+++ b/src/data/project-stats/newrelic-nr1-nimbus.json
@@ -9,10 +9,10 @@
     "date": "2021-05-07T17:22:28Z"
   },
   "commits": 80,
-  "lastSixMonthsCommitTotal": 22,
+  "lastSixMonthsCommitTotal": 21,
   "contributors": 8,
   "pullRequests": {
-    "open": 2
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,18 +25,18 @@
       "contributions": 8
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 5
-    },
-    {
       "id": 1395158,
       "login": "jpvajda",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
       "htmlUrl": "https://github.com/jpvajda",
       "contributions": 3
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 5
     },
     {
       "id": 197140,

--- a/src/data/project-stats/newrelic-nr1-observability-maps.json
+++ b/src/data/project-stats/newrelic-nr1-observability-maps.json
@@ -1,15 +1,15 @@
 {
   "projectFullName": "newrelic/nr1-observability-maps",
   "issues": {
-    "open": 12
+    "open": 9
   },
-  "releases": 21,
+  "releases": 22,
   "latestRelease": {
-    "name": "v0.15.0",
-    "date": "2021-05-27T09:37:47Z"
+    "name": "v0.15.1",
+    "date": "2021-07-07T06:49:52Z"
   },
-  "commits": 191,
-  "lastSixMonthsCommitTotal": 45,
+  "commits": 193,
+  "lastSixMonthsCommitTotal": 46,
   "contributors": 10,
   "pullRequests": {
     "open": 0
@@ -22,14 +22,7 @@
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 31
-    },
-    {
-      "id": 58010132,
-      "login": "mmfred",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/58010132?v=4",
-      "htmlUrl": "https://github.com/mmfred",
-      "contributions": 1
+      "contributions": 32
     },
     {
       "id": 70179215,
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
       "htmlUrl": "https://github.com/nr-kkenney",
       "contributions": 2
+    },
+    {
+      "id": 58010132,
+      "login": "mmfred",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/58010132?v=4",
+      "htmlUrl": "https://github.com/mmfred",
+      "contributions": 1
     },
     {
       "id": 11946809,
@@ -85,7 +85,7 @@
       "login": "Kav91",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13043208?v=4",
       "htmlUrl": "https://github.com/Kav91",
-      "contributions": 115
+      "contributions": 116
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-nr1-pageview-map.json
+++ b/src/data/project-stats/newrelic-nr1-pageview-map.json
@@ -9,7 +9,7 @@
     "date": "2021-03-23T23:04:29Z"
   },
   "commits": 196,
-  "lastSixMonthsCommitTotal": 24,
+  "lastSixMonthsCommitTotal": 23,
   "contributors": 13,
   "pullRequests": {
     "open": 0
@@ -18,17 +18,17 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 712701,
-      "login": "adamlukaszczyk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/712701?v=4",
-      "htmlUrl": "https://github.com/adamlukaszczyk",
-      "contributions": 1
-    },
-    {
       "id": 1395158,
       "login": "jpvajda",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
       "htmlUrl": "https://github.com/jpvajda",
+      "contributions": 1
+    },
+    {
+      "id": 712701,
+      "login": "adamlukaszczyk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/712701?v=4",
+      "htmlUrl": "https://github.com/adamlukaszczyk",
       "contributions": 1
     },
     {
@@ -39,11 +39,11 @@
       "contributions": 13
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 1
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 13
     },
     {
       "id": 24775098,
@@ -67,13 +67,6 @@
       "contributions": 3
     },
     {
-      "id": 38174486,
-      "login": "dulcineapena1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/38174486?v=4",
-      "htmlUrl": "https://github.com/dulcineapena1",
-      "contributions": 2
-    },
-    {
       "id": 929261,
       "login": "tangollama",
       "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
@@ -81,11 +74,18 @@
       "contributions": 4
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 13
+      "id": 38174486,
+      "login": "dulcineapena1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38174486?v=4",
+      "htmlUrl": "https://github.com/dulcineapena1",
+      "contributions": 2
+    },
+    {
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 1
     },
     {
       "id": 39655074,

--- a/src/data/project-stats/newrelic-nr1-pathpoint.json
+++ b/src/data/project-stats/newrelic-nr1-pathpoint.json
@@ -25,11 +25,11 @@
       "contributions": 12
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 1
+      "id": 13436647,
+      "login": "psimkins",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13436647?v=4",
+      "htmlUrl": "https://github.com/psimkins",
+      "contributions": 3
     },
     {
       "id": 23143210,
@@ -46,11 +46,11 @@
       "contributions": 23
     },
     {
-      "id": 13436647,
-      "login": "psimkins",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13436647?v=4",
-      "htmlUrl": "https://github.com/psimkins",
-      "contributions": 3
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 1
     },
     {
       "id": 77402070,

--- a/src/data/project-stats/newrelic-nr1-quickstarts.json
+++ b/src/data/project-stats/newrelic-nr1-quickstarts.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nr1-quickstarts",
   "issues": {
-    "open": 6
+    "open": 7
   },
   "releases": 9,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-03-31T19:09:36Z"
   },
   "commits": 305,
-  "lastSixMonthsCommitTotal": 154,
+  "lastSixMonthsCommitTotal": 115,
   "contributors": 8,
   "pullRequests": {
     "open": 10
@@ -32,11 +32,11 @@
       "contributions": 9
     },
     {
-      "id": 30831476,
-      "login": "thezackm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
-      "htmlUrl": "https://github.com/thezackm",
-      "contributions": 7
+      "id": 12893310,
+      "login": "DarrenDoyle",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12893310?v=4",
+      "htmlUrl": "https://github.com/DarrenDoyle",
+      "contributions": 1
     },
     {
       "id": 43244625,
@@ -46,11 +46,11 @@
       "contributions": 1
     },
     {
-      "id": 9002169,
-      "login": "bpschmitt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9002169?v=4",
-      "htmlUrl": "https://github.com/bpschmitt",
-      "contributions": 8
+      "id": 30831476,
+      "login": "thezackm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
+      "htmlUrl": "https://github.com/thezackm",
+      "contributions": 7
     },
     {
       "id": 184273,
@@ -67,11 +67,11 @@
       "contributions": 1
     },
     {
-      "id": 12893310,
-      "login": "DarrenDoyle",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12893310?v=4",
-      "htmlUrl": "https://github.com/DarrenDoyle",
-      "contributions": 1
+      "id": 9002169,
+      "login": "bpschmitt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9002169?v=4",
+      "htmlUrl": "https://github.com/bpschmitt",
+      "contributions": 8
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-nr1-slo-r.json
+++ b/src/data/project-stats/newrelic-nr1-slo-r.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nr1-slo-r",
   "issues": {
-    "open": 49
+    "open": 50
   },
   "releases": 33,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-05-07T17:21:06Z"
   },
   "commits": 517,
-  "lastSixMonthsCommitTotal": 24,
+  "lastSixMonthsCommitTotal": 17,
   "contributors": 18,
   "pullRequests": {
     "open": 1
@@ -43,6 +43,13 @@
       "contributions": 3
     },
     {
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 35
+    },
+    {
       "id": 32961497,
       "login": "artuone83",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32961497?v=4",
@@ -50,11 +57,11 @@
       "contributions": 18
     },
     {
-      "id": 30607359,
-      "login": "peetk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30607359?v=4",
-      "htmlUrl": "https://github.com/peetk",
-      "contributions": 9
+      "id": 32174276,
+      "login": "semantic-release-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
+      "htmlUrl": "https://github.com/semantic-release-bot",
+      "contributions": 1
     },
     {
       "id": 9435570,
@@ -64,11 +71,11 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 35
+      "id": 30607359,
+      "login": "peetk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30607359?v=4",
+      "htmlUrl": "https://github.com/peetk",
+      "contributions": 9
     },
     {
       "id": 929261,
@@ -78,11 +85,11 @@
       "contributions": 1
     },
     {
-      "id": 3860745,
-      "login": "csandels",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3860745?v=4",
-      "htmlUrl": "https://github.com/csandels",
-      "contributions": 6
+      "id": 854297,
+      "login": "seankcarpenter",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/854297?v=4",
+      "htmlUrl": "https://github.com/seankcarpenter",
+      "contributions": 1
     },
     {
       "id": 6722433,
@@ -104,13 +111,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5214156?v=4",
       "htmlUrl": "https://github.com/norbertsuski",
       "contributions": 45
-    },
-    {
-      "id": 32174276,
-      "login": "semantic-release-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
-      "htmlUrl": "https://github.com/semantic-release-bot",
-      "contributions": 1
     },
     {
       "id": 197140,
@@ -155,11 +155,11 @@
       "contributions": 52
     },
     {
-      "id": 854297,
-      "login": "seankcarpenter",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/854297?v=4",
-      "htmlUrl": "https://github.com/seankcarpenter",
-      "contributions": 1
+      "id": 3860745,
+      "login": "csandels",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3860745?v=4",
+      "htmlUrl": "https://github.com/csandels",
+      "contributions": 6
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-nr1-status-pages.json
+++ b/src/data/project-stats/newrelic-nr1-status-pages.json
@@ -9,7 +9,7 @@
     "date": "2021-05-07T18:04:56Z"
   },
   "commits": 360,
-  "lastSixMonthsCommitTotal": 27,
+  "lastSixMonthsCommitTotal": 25,
   "contributors": 23,
   "pullRequests": {
     "open": 0
@@ -43,32 +43,11 @@
       "contributions": 1
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 1
-    },
-    {
-      "id": 70179215,
-      "login": "nr-kkenney",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
-      "htmlUrl": "https://github.com/nr-kkenney",
-      "contributions": 1
-    },
-    {
       "id": 30900815,
       "login": "ericSpence",
       "avatarUrl": "https://avatars.githubusercontent.com/u/30900815?v=4",
       "htmlUrl": "https://github.com/ericSpence",
       "contributions": 34
-    },
-    {
-      "id": 32961497,
-      "login": "artuone83",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32961497?v=4",
-      "htmlUrl": "https://github.com/artuone83",
-      "contributions": 2
     },
     {
       "id": 66321197,
@@ -78,11 +57,32 @@
       "contributions": 44
     },
     {
-      "id": 19733683,
-      "login": "snyk-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
-      "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 12
+      "id": 32961497,
+      "login": "artuone83",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32961497?v=4",
+      "htmlUrl": "https://github.com/artuone83",
+      "contributions": 2
+    },
+    {
+      "id": 23065140,
+      "login": "tschmidtnimble",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/23065140?v=4",
+      "htmlUrl": "https://github.com/tschmidtnimble",
+      "contributions": 1
+    },
+    {
+      "id": 39655074,
+      "login": "LizBaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
+      "htmlUrl": "https://github.com/LizBaker",
+      "contributions": 1
+    },
+    {
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
+      "contributions": 1
     },
     {
       "id": 55203603,
@@ -99,10 +99,10 @@
       "contributions": 1
     },
     {
-      "id": 455419,
-      "login": "jthurman42",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
-      "htmlUrl": "https://github.com/jthurman42",
+      "id": 70179215,
+      "login": "nr-kkenney",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
+      "htmlUrl": "https://github.com/nr-kkenney",
       "contributions": 1
     },
     {
@@ -111,6 +111,27 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5214156?v=4",
       "htmlUrl": "https://github.com/norbertsuski",
       "contributions": 25
+    },
+    {
+      "id": 24775098,
+      "login": "madecki",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24775098?v=4",
+      "htmlUrl": "https://github.com/madecki",
+      "contributions": 10
+    },
+    {
+      "id": 455419,
+      "login": "jthurman42",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
+      "htmlUrl": "https://github.com/jthurman42",
+      "contributions": 1
+    },
+    {
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
+      "contributions": 1
     },
     {
       "id": 6722433,
@@ -127,20 +148,6 @@
       "contributions": 23
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
-      "contributions": 1
-    },
-    {
-      "id": 17122543,
-      "login": "rudouglas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
-      "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 1
-    },
-    {
       "id": 40477042,
       "login": "aminoz007",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40477042?v=4",
@@ -148,11 +155,11 @@
       "contributions": 2
     },
     {
-      "id": 24775098,
-      "login": "madecki",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24775098?v=4",
-      "htmlUrl": "https://github.com/madecki",
-      "contributions": 10
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
+      "contributions": 1
     },
     {
       "id": 32174276,
@@ -162,18 +169,11 @@
       "contributions": 1
     },
     {
-      "id": 23065140,
-      "login": "tschmidtnimble",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/23065140?v=4",
-      "htmlUrl": "https://github.com/tschmidtnimble",
-      "contributions": 1
-    },
-    {
-      "id": 39655074,
-      "login": "LizBaker",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
-      "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 1
+      "id": 19733683,
+      "login": "snyk-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
+      "htmlUrl": "https://github.com/snyk-bot",
+      "contributions": 12
     },
     {
       "id": 22622963,

--- a/src/data/project-stats/newrelic-nr1-status-widgets.json
+++ b/src/data/project-stats/newrelic-nr1-status-widgets.json
@@ -1,0 +1,70 @@
+{
+  "projectFullName": "newrelic/nr1-status-widgets",
+  "issues": {
+    "open": 0
+  },
+  "releases": 8,
+  "latestRelease": {
+    "name": "v2.3.1",
+    "date": "2021-07-15T12:23:19Z"
+  },
+  "commits": 38,
+  "lastSixMonthsCommitTotal": 38,
+  "contributors": 4,
+  "pullRequests": {
+    "open": 0
+  },
+  "searchCategory": "good first issue",
+  "cachedIssues": [],
+  "cachedContributors": [
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 1
+    },
+    {
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 9
+    },
+    {
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 1
+    },
+    {
+      "id": 13043208,
+      "login": "Kav91",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13043208?v=4",
+      "htmlUrl": "https://github.com/Kav91",
+      "contributions": 22
+    }
+  ],
+  "languages": [
+    {
+      "id": "MDg6TGFuZ3VhZ2UxNDA=",
+      "name": "JavaScript",
+      "color": "#f1e05a"
+    },
+    {
+      "id": "MDg6TGFuZ3VhZ2U2MDU=",
+      "name": "SCSS",
+      "color": "#c6538c"
+    }
+  ],
+  "screenshots": [],
+  "license": {
+    "id": "MDc6TGljZW5zZTI=",
+    "name": "Apache License 2.0",
+    "spdxId": "Apache-2.0",
+    "url": "http://choosealicense.com/licenses/apache-2.0/",
+    "featured": true,
+    "key": "apache-2.0"
+  }
+}

--- a/src/data/project-stats/newrelic-nr1-tag-improver.json
+++ b/src/data/project-stats/newrelic-nr1-tag-improver.json
@@ -9,7 +9,7 @@
     "date": "2021-04-07T19:29:17Z"
   },
   "commits": 121,
-  "lastSixMonthsCommitTotal": 77,
+  "lastSixMonthsCommitTotal": 49,
   "contributors": 9,
   "pullRequests": {
     "open": 1
@@ -39,11 +39,11 @@
       "contributions": 9
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
+      "id": 482671,
+      "login": "fightingmonk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/482671?v=4",
+      "htmlUrl": "https://github.com/fightingmonk",
+      "contributions": 21
     },
     {
       "id": 4672940,
@@ -60,11 +60,11 @@
       "contributions": 5
     },
     {
-      "id": 482671,
-      "login": "fightingmonk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/482671?v=4",
-      "htmlUrl": "https://github.com/fightingmonk",
-      "contributions": 21
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
     },
     {
       "id": 6722433,

--- a/src/data/project-stats/newrelic-nr1-top.json
+++ b/src/data/project-stats/newrelic-nr1-top.json
@@ -9,7 +9,7 @@
     "date": "2021-03-23T21:46:36Z"
   },
   "commits": 133,
-  "lastSixMonthsCommitTotal": 13,
+  "lastSixMonthsCommitTotal": 12,
   "contributors": 15,
   "pullRequests": {
     "open": 0
@@ -25,10 +25,10 @@
       "contributions": 1
     },
     {
-      "id": 13562672,
-      "login": "jaesius",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
-      "htmlUrl": "https://github.com/jaesius",
+      "id": 8731013,
+      "login": "prototypicalpro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
+      "htmlUrl": "https://github.com/prototypicalpro",
       "contributions": 1
     },
     {
@@ -39,17 +39,17 @@
       "contributions": 2
     },
     {
-      "id": 30514,
-      "login": "cirne",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
-      "htmlUrl": "https://github.com/cirne",
-      "contributions": 15
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 16
     },
     {
-      "id": 19733683,
-      "login": "snyk-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
-      "htmlUrl": "https://github.com/snyk-bot",
+      "id": 13562672,
+      "login": "jaesius",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
+      "htmlUrl": "https://github.com/jaesius",
       "contributions": 1
     },
     {
@@ -74,18 +74,11 @@
       "contributions": 2
     },
     {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 9
-    },
-    {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 16
+      "id": 19733683,
+      "login": "snyk-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
+      "htmlUrl": "https://github.com/snyk-bot",
+      "contributions": 1
     },
     {
       "id": 197140,
@@ -95,11 +88,18 @@
       "contributions": 17
     },
     {
-      "id": 8731013,
-      "login": "prototypicalpro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8731013?v=4",
-      "htmlUrl": "https://github.com/prototypicalpro",
-      "contributions": 1
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 9
+    },
+    {
+      "id": 30514,
+      "login": "cirne",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30514?v=4",
+      "htmlUrl": "https://github.com/cirne",
+      "contributions": 15
     },
     {
       "id": 32174276,

--- a/src/data/project-stats/newrelic-nr1-victory-visualizations.json
+++ b/src/data/project-stats/newrelic-nr1-victory-visualizations.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nr1-victory-visualizations",
   "issues": {
-    "open": 0
+    "open": 1
   },
   "releases": 19,
   "latestRelease": {
@@ -17,6 +17,13 @@
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 20293876,
+      "login": "tyreer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20293876?v=4",
+      "htmlUrl": "https://github.com/tyreer",
+      "contributions": 30
+    },
     {
       "id": 66321197,
       "login": "nr-opensource-bot",
@@ -37,13 +44,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3023056?v=4",
       "htmlUrl": "https://github.com/timglaser",
       "contributions": 47
-    },
-    {
-      "id": 20293876,
-      "login": "tyreer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/20293876?v=4",
-      "htmlUrl": "https://github.com/tyreer",
-      "contributions": 30
     },
     {
       "id": 565661,

--- a/src/data/project-stats/newrelic-nr1-vscode-extension.json
+++ b/src/data/project-stats/newrelic-nr1-vscode-extension.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/nr1-vscode-extension",
   "issues": {
-    "open": 4
+    "open": 3
   },
-  "releases": 8,
+  "releases": 9,
   "latestRelease": {
-    "name": "v1.1.0",
-    "date": "2021-03-16T16:16:19Z"
+    "name": "v1.2.0",
+    "date": "2021-07-15T18:38:42Z"
   },
-  "commits": 141,
-  "lastSixMonthsCommitTotal": 9,
-  "contributors": 8,
+  "commits": 144,
+  "lastSixMonthsCommitTotal": 12,
+  "contributors": 9,
   "pullRequests": {
     "open": 1
   },
@@ -23,13 +23,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
       "htmlUrl": "https://github.com/jpvajda",
       "contributions": 10
-    },
-    {
-      "id": 39655074,
-      "login": "LizBaker",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
-      "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 7
     },
     {
       "id": 6426523,
@@ -50,7 +43,14 @@
       "login": "semantic-release-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
       "htmlUrl": "https://github.com/semantic-release-bot",
-      "contributions": 6
+      "contributions": 7
+    },
+    {
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
+      "contributions": 1
     },
     {
       "id": 929261,
@@ -58,6 +58,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
       "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
+    },
+    {
+      "id": 39655074,
+      "login": "LizBaker",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
+      "htmlUrl": "https://github.com/LizBaker",
+      "contributions": 7
     },
     {
       "id": 12112563,

--- a/src/data/project-stats/newrelic-nr1-workload-geoops.json
+++ b/src/data/project-stats/newrelic-nr1-workload-geoops.json
@@ -9,7 +9,7 @@
     "date": "2021-05-07T18:13:12Z"
   },
   "commits": 589,
-  "lastSixMonthsCommitTotal": 50,
+  "lastSixMonthsCommitTotal": 49,
   "contributors": 16,
   "pullRequests": {
     "open": 0
@@ -84,46 +84,11 @@
       "contributions": 1
     },
     {
-      "id": 66321197,
-      "login": "nr-opensource-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
-      "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 52
-    },
-    {
-      "id": 1663955,
-      "login": "mbazhlekova",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1663955?v=4",
-      "htmlUrl": "https://github.com/mbazhlekova",
-      "contributions": 1
-    },
-    {
-      "id": 24775098,
-      "login": "madecki",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24775098?v=4",
-      "htmlUrl": "https://github.com/madecki",
-      "contributions": 15
-    },
-    {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 5
-    },
-    {
-      "id": 19733683,
-      "login": "snyk-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
-      "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 10
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 8
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 127
     },
     {
       "id": 58010132,
@@ -133,6 +98,41 @@
       "contributions": 1
     },
     {
+      "id": 1663955,
+      "login": "mbazhlekova",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1663955?v=4",
+      "htmlUrl": "https://github.com/mbazhlekova",
+      "contributions": 1
+    },
+    {
+      "id": 19733683,
+      "login": "snyk-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
+      "htmlUrl": "https://github.com/snyk-bot",
+      "contributions": 10
+    },
+    {
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 5
+    },
+    {
+      "id": 24775098,
+      "login": "madecki",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24775098?v=4",
+      "htmlUrl": "https://github.com/madecki",
+      "contributions": 15
+    },
+    {
+      "id": 66321197,
+      "login": "nr-opensource-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
+      "htmlUrl": "https://github.com/nr-opensource-bot",
+      "contributions": 52
+    },
+    {
       "id": 5214156,
       "login": "norbertsuski",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5214156?v=4",
@@ -140,11 +140,11 @@
       "contributions": 18
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 127
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 8
     },
     {
       "id": 8731013,

--- a/src/data/project-stats/newrelic-nr1-workshop.json
+++ b/src/data/project-stats/newrelic-nr1-workshop.json
@@ -1,12 +1,12 @@
 {
   "projectFullName": "newrelic/nr1-workshop",
   "issues": {
-    "open": 10
+    "open": 11
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 259,
-  "lastSixMonthsCommitTotal": 0,
+  "commits": 307,
+  "lastSixMonthsCommitTotal": 48,
   "contributors": 25,
   "pullRequests": {
     "open": 65
@@ -50,11 +50,11 @@
   ],
   "cachedContributors": [
     {
-      "id": 10779981,
-      "login": "screenshotjy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10779981?v=4",
-      "htmlUrl": "https://github.com/screenshotjy",
-      "contributions": 3
+      "id": 1659686,
+      "login": "stephencrowley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1659686?v=4",
+      "htmlUrl": "https://github.com/stephencrowley",
+      "contributions": 1
     },
     {
       "id": 13163939,
@@ -64,25 +64,18 @@
       "contributions": 1
     },
     {
-      "id": 3536684,
-      "login": "sschwartzman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
-      "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 3
-    },
-    {
-      "id": 54085190,
-      "login": "breedx-nr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54085190?v=4",
-      "htmlUrl": "https://github.com/breedx-nr",
-      "contributions": 2
-    },
-    {
       "id": 358253,
       "login": "harihar",
       "avatarUrl": "https://avatars.githubusercontent.com/u/358253?v=4",
       "htmlUrl": "https://github.com/harihar",
       "contributions": 1
+    },
+    {
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 7
     },
     {
       "id": 197140,
@@ -92,11 +85,18 @@
       "contributions": 16
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 7
+      "id": 3536684,
+      "login": "sschwartzman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
+      "htmlUrl": "https://github.com/sschwartzman",
+      "contributions": 3
+    },
+    {
+      "id": 10779981,
+      "login": "screenshotjy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10779981?v=4",
+      "htmlUrl": "https://github.com/screenshotjy",
+      "contributions": 3
     },
     {
       "id": 46351606,
@@ -127,11 +127,11 @@
       "contributions": 1
     },
     {
-      "id": 12243827,
-      "login": "JonathanMerklin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12243827?v=4",
-      "htmlUrl": "https://github.com/JonathanMerklin",
-      "contributions": 5
+      "id": 1209293,
+      "login": "ahosking",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1209293?v=4",
+      "htmlUrl": "https://github.com/ahosking",
+      "contributions": 1
     },
     {
       "id": 707312,
@@ -148,6 +148,13 @@
       "contributions": 1
     },
     {
+      "id": 12243827,
+      "login": "JonathanMerklin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12243827?v=4",
+      "htmlUrl": "https://github.com/JonathanMerklin",
+      "contributions": 5
+    },
+    {
       "id": 7143309,
       "login": "ddarwin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7143309?v=4",
@@ -155,18 +162,11 @@
       "contributions": 1
     },
     {
-      "id": 829269,
-      "login": "mjesun",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/829269?v=4",
-      "htmlUrl": "https://github.com/mjesun",
-      "contributions": 1
-    },
-    {
       "id": 13562672,
       "login": "jaesius",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13562672?v=4",
       "htmlUrl": "https://github.com/jaesius",
-      "contributions": 27
+      "contributions": 35
     },
     {
       "id": 1683569,
@@ -176,11 +176,11 @@
       "contributions": 1
     },
     {
-      "id": 1659686,
-      "login": "stephencrowley",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1659686?v=4",
-      "htmlUrl": "https://github.com/stephencrowley",
-      "contributions": 1
+      "id": 54085190,
+      "login": "breedx-nr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54085190?v=4",
+      "htmlUrl": "https://github.com/breedx-nr",
+      "contributions": 2
     },
     {
       "id": 2590905,
@@ -208,7 +208,7 @@
       "login": "alexronquillo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8672090?v=4",
       "htmlUrl": "https://github.com/alexronquillo",
-      "contributions": 1
+      "contributions": 37
     },
     {
       "id": 4061375,
@@ -218,10 +218,10 @@
       "contributions": 2
     },
     {
-      "id": 1209293,
-      "login": "ahosking",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1209293?v=4",
-      "htmlUrl": "https://github.com/ahosking",
+      "id": 829269,
+      "login": "mjesun",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/829269?v=4",
+      "htmlUrl": "https://github.com/mjesun",
       "contributions": 1
     }
   ],
@@ -319,7 +319,8 @@
     "https://raw.githubusercontent.com/newrelic/nr1-workshop/master/screenshots/setup_screen03.png",
     "https://raw.githubusercontent.com/newrelic/nr1-workshop/master/screenshots/setup_screen04.png",
     "https://raw.githubusercontent.com/newrelic/nr1-workshop/master/screenshots/setup_screen05.png",
-    "https://raw.githubusercontent.com/newrelic/nr1-workshop/master/screenshots/setup_screen06.png"
+    "https://raw.githubusercontent.com/newrelic/nr1-workshop/master/screenshots/setup_screen06.png",
+    "https://raw.githubusercontent.com/newrelic/nr1-workshop/master/screenshots/setup_screen_2021.png"
   ],
   "license": {
     "id": "MDc6TGljZW5zZTI=",

--- a/src/data/project-stats/newrelic-nri-apache.json
+++ b/src/data/project-stats/newrelic-nri-apache.json
@@ -9,10 +9,10 @@
     "date": "2021-06-08T09:00:38Z"
   },
   "commits": 90,
-  "lastSixMonthsCommitTotal": 8,
+  "lastSixMonthsCommitTotal": 7,
   "contributors": 18,
   "pullRequests": {
-    "open": 2
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -39,25 +39,25 @@
       "contributions": 1
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 1
-    },
-    {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 4
-    },
-    {
       "id": 1300852,
       "login": "varas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
       "htmlUrl": "https://github.com/varas",
       "contributions": 7
+    },
+    {
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
+    },
+    {
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
     },
     {
       "id": 929261,
@@ -88,10 +88,17 @@
       "contributions": 12
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 4
+    },
+    {
+      "id": 13966363,
+      "login": "carlossscastro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
+      "htmlUrl": "https://github.com/carlossscastro",
       "contributions": 1
     },
     {
@@ -100,13 +107,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
       "htmlUrl": "https://github.com/gsanchezgavier",
       "contributions": 3
-    },
-    {
-      "id": 13966363,
-      "login": "carlossscastro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
-      "htmlUrl": "https://github.com/carlossscastro",
-      "contributions": 1
     },
     {
       "id": 717815,

--- a/src/data/project-stats/newrelic-nri-cassandra.json
+++ b/src/data/project-stats/newrelic-nri-cassandra.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 3
-    },
-    {
       "id": 5143130,
       "login": "gsanchezgavier",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
@@ -32,11 +25,18 @@
       "contributions": 3
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
+      "id": 4612272,
+      "login": "Noly",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
+      "htmlUrl": "https://github.com/Noly",
+      "contributions": 3
+    },
+    {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 3
     },
     {
       "id": 969721,
@@ -46,11 +46,11 @@
       "contributions": 3
     },
     {
-      "id": 4612272,
-      "login": "Noly",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4612272?v=4",
-      "htmlUrl": "https://github.com/Noly",
-      "contributions": 3
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 2
     },
     {
       "id": 929261,
@@ -67,11 +67,11 @@
       "contributions": 10
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 1
+      "id": 1876430,
+      "login": "xino12",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1876430?v=4",
+      "htmlUrl": "https://github.com/xino12",
+      "contributions": 10
     },
     {
       "id": 5297542,
@@ -81,18 +81,18 @@
       "contributions": 11
     },
     {
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
+    },
+    {
       "id": 13438133,
       "login": "matiasburni",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
       "htmlUrl": "https://github.com/matiasburni",
       "contributions": 2
-    },
-    {
-      "id": 13697136,
-      "login": "adamvialpando",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13697136?v=4",
-      "htmlUrl": "https://github.com/adamvialpando",
-      "contributions": 1
     },
     {
       "id": 939550,
@@ -102,11 +102,11 @@
       "contributions": 1
     },
     {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 2
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
     },
     {
       "id": 717815,
@@ -144,11 +144,11 @@
       "contributions": 7
     },
     {
-      "id": 1876430,
-      "login": "xino12",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1876430?v=4",
-      "htmlUrl": "https://github.com/xino12",
-      "contributions": 10
+      "id": 13697136,
+      "login": "adamvialpando",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13697136?v=4",
+      "htmlUrl": "https://github.com/adamvialpando",
+      "contributions": 1
     },
     {
       "id": 67997,

--- a/src/data/project-stats/newrelic-nri-collectd.json
+++ b/src/data/project-stats/newrelic-nri-collectd.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 30607359,
-      "login": "peetk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30607359?v=4",
-      "htmlUrl": "https://github.com/peetk",
-      "contributions": 1
-    },
-    {
       "id": 52978309,
       "login": "sri-shetty",
       "avatarUrl": "https://avatars.githubusercontent.com/u/52978309?v=4",
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
       "htmlUrl": "https://github.com/sschwartzman",
       "contributions": 2
+    },
+    {
+      "id": 30607359,
+      "login": "peetk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30607359?v=4",
+      "htmlUrl": "https://github.com/peetk",
+      "contributions": 1
     },
     {
       "id": 17014899,

--- a/src/data/project-stats/newrelic-nri-consul.json
+++ b/src/data/project-stats/newrelic-nri-consul.json
@@ -18,17 +18,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 39911991,
-      "login": "davidbrota",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39911991?v=4",
-      "htmlUrl": "https://github.com/davidbrota",
-      "contributions": 1
-    },
-    {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
+      "id": 4290399,
+      "login": "skatsaounis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4290399?v=4",
+      "htmlUrl": "https://github.com/skatsaounis",
       "contributions": 1
     },
     {
@@ -39,24 +32,17 @@
       "contributions": 4
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
-    },
-    {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 3
-    },
-    {
       "id": 43335750,
       "login": "paologallinaharbur",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
       "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
+    },
+    {
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
       "contributions": 1
     },
     {
@@ -81,11 +67,25 @@
       "contributions": 3
     },
     {
+      "id": 39911991,
+      "login": "davidbrota",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39911991?v=4",
+      "htmlUrl": "https://github.com/davidbrota",
+      "contributions": 1
+    },
+    {
       "id": 5297542,
       "login": "alejandrodnm",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
       "htmlUrl": "https://github.com/alejandrodnm",
       "contributions": 2
+    },
+    {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 3
     },
     {
       "id": 969721,
@@ -95,17 +95,17 @@
       "contributions": 2
     },
     {
-      "id": 4290399,
-      "login": "skatsaounis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4290399?v=4",
-      "htmlUrl": "https://github.com/skatsaounis",
-      "contributions": 1
-    },
-    {
       "id": 1408986,
       "login": "TylerLubeck",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1408986?v=4",
       "htmlUrl": "https://github.com/TylerLubeck",
+      "contributions": 1
+    },
+    {
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nri-couchbase.json
+++ b/src/data/project-stats/newrelic-nri-couchbase.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nri-couchbase",
   "issues": {
-    "open": 0
+    "open": 1
   },
   "releases": 23,
   "latestRelease": {
@@ -18,18 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 3
-    },
-    {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 3
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
     },
     {
       "id": 7229810,
@@ -39,17 +32,24 @@
       "contributions": 2
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 2
-    },
-    {
       "id": 5143130,
       "login": "gsanchezgavier",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
       "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 2
+    },
+    {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 3
+    },
+    {
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
       "contributions": 2
     },
     {
@@ -74,11 +74,11 @@
       "contributions": 2
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 3
     },
     {
       "id": 717815,

--- a/src/data/project-stats/newrelic-nri-docker.json
+++ b/src/data/project-stats/newrelic-nri-docker.json
@@ -12,7 +12,7 @@
   "lastSixMonthsCommitTotal": 11,
   "contributors": 14,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,11 +25,11 @@
       "contributions": 8
     },
     {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 1
+      "id": 15685307,
+      "login": "cristianciutea",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
+      "htmlUrl": "https://github.com/cristianciutea",
+      "contributions": 19
     },
     {
       "id": 5143130,
@@ -81,11 +81,11 @@
       "contributions": 1
     },
     {
-      "id": 15685307,
-      "login": "cristianciutea",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
-      "htmlUrl": "https://github.com/cristianciutea",
-      "contributions": 19
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 1
     },
     {
       "id": 939550,

--- a/src/data/project-stats/newrelic-nri-ecs.json
+++ b/src/data/project-stats/newrelic-nri-ecs.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nri-ecs",
   "issues": {
-    "open": 4
+    "open": 5
   },
   "releases": 6,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-04-19T08:51:42Z"
   },
   "commits": 19,
-  "lastSixMonthsCommitTotal": 4,
+  "lastSixMonthsCommitTotal": 2,
   "contributors": 6,
   "pullRequests": {
     "open": 5

--- a/src/data/project-stats/newrelic-nri-elasticsearch.json
+++ b/src/data/project-stats/newrelic-nri-elasticsearch.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nri-elasticsearch",
   "issues": {
-    "open": 4
+    "open": 3
   },
   "releases": 28,
   "latestRelease": {

--- a/src/data/project-stats/newrelic-nri-f5.json
+++ b/src/data/project-stats/newrelic-nri-f5.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nri-f5",
   "issues": {
-    "open": 1
+    "open": 2
   },
   "releases": 15,
   "latestRelease": {
@@ -9,7 +9,7 @@
     "date": "2021-06-10T15:18:54Z"
   },
   "commits": 190,
-  "lastSixMonthsCommitTotal": 12,
+  "lastSixMonthsCommitTotal": 11,
   "contributors": 16,
   "pullRequests": {
     "open": 1
@@ -25,18 +25,18 @@
       "contributions": 2
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 3
-    },
-    {
       "id": 7229810,
       "login": "zackkendra",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7229810?v=4",
       "htmlUrl": "https://github.com/zackkendra",
       "contributions": 4
+    },
+    {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 3
     },
     {
       "id": 43335750,

--- a/src/data/project-stats/newrelic-nri-flex.json
+++ b/src/data/project-stats/newrelic-nri-flex.json
@@ -1,15 +1,15 @@
 {
   "projectFullName": "newrelic/nri-flex",
   "issues": {
-    "open": 8
+    "open": 9
   },
-  "releases": 35,
+  "releases": 36,
   "latestRelease": {
-    "name": "v1.4.1",
-    "date": "2021-05-19T09:18:42Z"
+    "name": "v1.4.2",
+    "date": "2021-07-01T12:57:47Z"
   },
-  "commits": 625,
-  "lastSixMonthsCommitTotal": 58,
+  "commits": 627,
+  "lastSixMonthsCommitTotal": 43,
   "contributors": 46,
   "pullRequests": {
     "open": 9
@@ -18,25 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 39402771,
-      "login": "adiosspandit",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39402771?v=4",
-      "htmlUrl": "https://github.com/adiosspandit",
+      "id": 15201509,
+      "login": "aschmid13",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15201509?v=4",
+      "htmlUrl": "https://github.com/aschmid13",
+      "contributions": 2
+    },
+    {
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
-    },
-    {
-      "id": 46498444,
-      "login": "lchapman4",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46498444?v=4",
-      "htmlUrl": "https://github.com/lchapman4",
-      "contributions": 4
-    },
-    {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
-      "contributions": 3
     },
     {
       "id": 20245790,
@@ -53,18 +46,25 @@
       "contributions": 3
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 3
     },
     {
-      "id": 15201509,
-      "login": "aschmid13",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/15201509?v=4",
-      "htmlUrl": "https://github.com/aschmid13",
-      "contributions": 2
+      "id": 46498444,
+      "login": "lchapman4",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46498444?v=4",
+      "htmlUrl": "https://github.com/lchapman4",
+      "contributions": 4
+    },
+    {
+      "id": 39402771,
+      "login": "adiosspandit",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39402771?v=4",
+      "htmlUrl": "https://github.com/adiosspandit",
+      "contributions": 1
     },
     {
       "id": 44571906,
@@ -127,7 +127,7 @@
       "login": "mariomac",
       "avatarUrl": "https://avatars.githubusercontent.com/u/939550?v=4",
       "htmlUrl": "https://github.com/mariomac",
-      "contributions": 26
+      "contributions": 3
     },
     {
       "id": 3622298,
@@ -162,14 +162,14 @@
       "login": "cah-marc-netterfield",
       "avatarUrl": "https://avatars.githubusercontent.com/u/61323108?v=4",
       "htmlUrl": "https://github.com/cah-marc-netterfield",
-      "contributions": 1
+      "contributions": 2
     },
     {
       "id": 1300852,
       "login": "varas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
       "htmlUrl": "https://github.com/varas",
-      "contributions": 2
+      "contributions": 3
     },
     {
       "id": 1773616,

--- a/src/data/project-stats/newrelic-nri-jmx.json
+++ b/src/data/project-stats/newrelic-nri-jmx.json
@@ -5,11 +5,11 @@
   },
   "releases": 40,
   "latestRelease": {
-    "name": "v2.4.10",
-    "date": "2021-06-23T10:37:06Z"
+    "name": "v2.4.11",
+    "date": "2021-07-02T15:27:02Z"
   },
-  "commits": 268,
-  "lastSixMonthsCommitTotal": 51,
+  "commits": 270,
+  "lastSixMonthsCommitTotal": 47,
   "contributors": 20,
   "pullRequests": {
     "open": 3
@@ -25,11 +25,25 @@
       "contributions": 1
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 13
+      "id": 466745,
+      "login": "vvydier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/466745?v=4",
+      "htmlUrl": "https://github.com/vvydier",
+      "contributions": 1
+    },
+    {
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 5
+    },
+    {
+      "id": 947112,
+      "login": "ferranorriols",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/947112?v=4",
+      "htmlUrl": "https://github.com/ferranorriols",
+      "contributions": 1
     },
     {
       "id": 5143130,
@@ -37,20 +51,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
       "htmlUrl": "https://github.com/gsanchezgavier",
       "contributions": 1
-    },
-    {
-      "id": 3969485,
-      "login": "brushknight",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
-      "htmlUrl": "https://github.com/brushknight",
-      "contributions": 3
-    },
-    {
-      "id": 1300852,
-      "login": "varas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
-      "htmlUrl": "https://github.com/varas",
-      "contributions": 2
     },
     {
       "id": 929261,
@@ -64,14 +64,14 @@
       "login": "cristianciutea",
       "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
       "htmlUrl": "https://github.com/cristianciutea",
-      "contributions": 27
+      "contributions": 28
     },
     {
-      "id": 947112,
-      "login": "ferranorriols",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/947112?v=4",
-      "htmlUrl": "https://github.com/ferranorriols",
-      "contributions": 1
+      "id": 1300852,
+      "login": "varas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1300852?v=4",
+      "htmlUrl": "https://github.com/varas",
+      "contributions": 2
     },
     {
       "id": 5297542,
@@ -102,6 +102,13 @@
       "contributions": 1
     },
     {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 13
+    },
+    {
       "id": 717815,
       "login": "carlosroman",
       "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
@@ -109,18 +116,11 @@
       "contributions": 1
     },
     {
-      "id": 466745,
-      "login": "vvydier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/466745?v=4",
-      "htmlUrl": "https://github.com/vvydier",
-      "contributions": 1
-    },
-    {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 5
+      "id": 3969485,
+      "login": "brushknight",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
+      "htmlUrl": "https://github.com/brushknight",
+      "contributions": 3
     },
     {
       "id": 22507783,

--- a/src/data/project-stats/newrelic-nri-kafka.json
+++ b/src/data/project-stats/newrelic-nri-kafka.json
@@ -3,14 +3,14 @@
   "issues": {
     "open": 3
   },
-  "releases": 60,
+  "releases": 59,
   "latestRelease": {
     "name": "v2.16.2",
     "date": "2021-06-08T14:47:57Z"
   },
-  "commits": 256,
-  "lastSixMonthsCommitTotal": 18,
-  "contributors": 20,
+  "commits": 257,
+  "lastSixMonthsCommitTotal": 19,
+  "contributors": 19,
   "pullRequests": {
     "open": 3
   },
@@ -36,13 +36,6 @@
       "login": "matiasburni",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
       "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 1
-    },
-    {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
       "contributions": 1
     },
     {
@@ -74,13 +67,6 @@
       "contributions": 5
     },
     {
-      "id": 939550,
-      "login": "mariomac",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/939550?v=4",
-      "htmlUrl": "https://github.com/mariomac",
-      "contributions": 1
-    },
-    {
       "id": 5297542,
       "login": "alejandrodnm",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
@@ -88,11 +74,18 @@
       "contributions": 3
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 6
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
+    },
+    {
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
+      "contributions": 7
     },
     {
       "id": 30265338,
@@ -102,11 +95,11 @@
       "contributions": 1
     },
     {
-      "id": 109874,
-      "login": "dylanmei",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/109874?v=4",
-      "htmlUrl": "https://github.com/dylanmei",
-      "contributions": 1
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 6
     },
     {
       "id": 3969485,
@@ -123,11 +116,11 @@
       "contributions": 1
     },
     {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
-      "contributions": 6
+      "id": 109874,
+      "login": "dylanmei",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/109874?v=4",
+      "htmlUrl": "https://github.com/dylanmei",
+      "contributions": 1
     },
     {
       "id": 9164583,

--- a/src/data/project-stats/newrelic-nri-kube-events.json
+++ b/src/data/project-stats/newrelic-nri-kube-events.json
@@ -8,11 +8,11 @@
     "name": "v1.5.1",
     "date": "2021-06-01T11:12:03Z"
   },
-  "commits": 27,
-  "lastSixMonthsCommitTotal": 15,
-  "contributors": 7,
+  "commits": 28,
+  "lastSixMonthsCommitTotal": 16,
+  "contributors": 8,
   "pullRequests": {
-    "open": 8
+    "open": 7
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -40,6 +40,13 @@
       "login": "mfuentes-newrelic",
       "avatarUrl": "https://avatars.githubusercontent.com/u/59606623?v=4",
       "htmlUrl": "https://github.com/mfuentes-newrelic",
+      "contributions": 1
+    },
+    {
+      "id": 16539896,
+      "login": "invidian",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16539896?v=4",
+      "htmlUrl": "https://github.com/invidian",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nri-kubernetes.json
+++ b/src/data/project-stats/newrelic-nri-kubernetes.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/nri-kubernetes",
   "issues": {
-    "open": 17
+    "open": 30
   },
-  "releases": 22,
+  "releases": 23,
   "latestRelease": {
-    "name": "v2.6.0",
-    "date": "2021-06-07T15:28:38Z"
+    "name": "v2.6.1",
+    "date": "2021-06-28T07:10:11Z"
   },
-  "commits": 122,
-  "lastSixMonthsCommitTotal": 40,
-  "contributors": 16,
+  "commits": 127,
+  "lastSixMonthsCommitTotal": 44,
+  "contributors": 17,
   "pullRequests": {
     "open": 6
   },
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 503802,
-      "login": "jorik",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/503802?v=4",
-      "htmlUrl": "https://github.com/jorik",
-      "contributions": 13
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 11
     },
     {
       "id": 1479942,
@@ -32,17 +32,24 @@
       "contributions": 1
     },
     {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 11
+      "id": 16539896,
+      "login": "invidian",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16539896?v=4",
+      "htmlUrl": "https://github.com/invidian",
+      "contributions": 2
     },
     {
       "id": 3420583,
       "login": "ahoulgrave",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3420583?v=4",
       "htmlUrl": "https://github.com/ahoulgrave",
+      "contributions": 1
+    },
+    {
+      "id": 1083296,
+      "login": "smoya",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1083296?v=4",
+      "htmlUrl": "https://github.com/smoya",
       "contributions": 1
     },
     {
@@ -53,10 +60,10 @@
       "contributions": 4
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
       "contributions": 11
     },
     {
@@ -85,7 +92,7 @@
       "login": "alvarocabanas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
       "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 1
+      "contributions": 2
     },
     {
       "id": 717815,
@@ -106,14 +113,14 @@
       "login": "roobre",
       "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
       "htmlUrl": "https://github.com/roobre",
-      "contributions": 21
+      "contributions": 22
     },
     {
-      "id": 1083296,
-      "login": "smoya",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1083296?v=4",
-      "htmlUrl": "https://github.com/smoya",
-      "contributions": 1
+      "id": 503802,
+      "login": "jorik",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/503802?v=4",
+      "htmlUrl": "https://github.com/jorik",
+      "contributions": 13
     },
     {
       "id": 10852,

--- a/src/data/project-stats/newrelic-nri-memcached.json
+++ b/src/data/project-stats/newrelic-nri-memcached.json
@@ -18,24 +18,24 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 2
-    },
-    {
-      "id": 1753943,
-      "login": "gregbuehler",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1753943?v=4",
-      "htmlUrl": "https://github.com/gregbuehler",
-      "contributions": 1
-    },
-    {
       "id": 43335750,
       "login": "paologallinaharbur",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
       "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
+    },
+    {
+      "id": 7229810,
+      "login": "zackkendra",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7229810?v=4",
+      "htmlUrl": "https://github.com/zackkendra",
+      "contributions": 1
+    },
+    {
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
       "contributions": 1
     },
     {
@@ -46,18 +46,11 @@
       "contributions": 3
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "id": 1753943,
+      "login": "gregbuehler",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1753943?v=4",
+      "htmlUrl": "https://github.com/gregbuehler",
       "contributions": 1
-    },
-    {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 4
     },
     {
       "id": 929261,
@@ -74,11 +67,11 @@
       "contributions": 3
     },
     {
-      "id": 7229810,
-      "login": "zackkendra",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7229810?v=4",
-      "htmlUrl": "https://github.com/zackkendra",
-      "contributions": 1
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 4
     },
     {
       "id": 5297542,
@@ -86,6 +79,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
       "htmlUrl": "https://github.com/alejandrodnm",
       "contributions": 1
+    },
+    {
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 2
     },
     {
       "id": 717815,

--- a/src/data/project-stats/newrelic-nri-mongodb.json
+++ b/src/data/project-stats/newrelic-nri-mongodb.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 2
-    },
-    {
       "id": 7229810,
       "login": "zackkendra",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7229810?v=4",
@@ -32,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 3
+      "id": 11226795,
+      "login": "chelarua",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
+      "htmlUrl": "https://github.com/chelarua",
+      "contributions": 2
     },
     {
       "id": 3638421,
@@ -46,11 +39,11 @@
       "contributions": 2
     },
     {
-      "id": 11226795,
-      "login": "chelarua",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
-      "htmlUrl": "https://github.com/chelarua",
-      "contributions": 2
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
     },
     {
       "id": 5143130,
@@ -74,6 +67,13 @@
       "contributions": 3
     },
     {
+      "id": 3969485,
+      "login": "brushknight",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
+      "htmlUrl": "https://github.com/brushknight",
+      "contributions": 1
+    },
+    {
       "id": 5297542,
       "login": "alejandrodnm",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
@@ -81,11 +81,11 @@
       "contributions": 2
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 2
     },
     {
       "id": 969721,
@@ -102,11 +102,11 @@
       "contributions": 1
     },
     {
-      "id": 3969485,
-      "login": "brushknight",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
-      "htmlUrl": "https://github.com/brushknight",
-      "contributions": 1
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 3
     },
     {
       "id": 3752614,

--- a/src/data/project-stats/newrelic-nri-mssql.json
+++ b/src/data/project-stats/newrelic-nri-mssql.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/nri-mssql",
   "issues": {
-    "open": 5
+    "open": 2
   },
-  "releases": 32,
+  "releases": 33,
   "latestRelease": {
-    "name": "v2.6.1",
-    "date": "2021-06-09T13:11:59Z"
+    "name": "v2.6.2",
+    "date": "2021-07-09T08:52:33Z"
   },
-  "commits": 215,
-  "lastSixMonthsCommitTotal": 15,
-  "contributors": 18,
+  "commits": 218,
+  "lastSixMonthsCommitTotal": 17,
+  "contributors": 19,
   "pullRequests": {
     "open": 0
   },
@@ -25,10 +25,24 @@
       "contributions": 1
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
+      "contributions": 1
+    },
+    {
+      "id": 7229810,
+      "login": "zackkendra",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7229810?v=4",
+      "htmlUrl": "https://github.com/zackkendra",
+      "contributions": 1
+    },
+    {
+      "id": 558327,
+      "login": "maju6406",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/558327?v=4",
+      "htmlUrl": "https://github.com/maju6406",
       "contributions": 1
     },
     {
@@ -39,20 +53,6 @@
       "contributions": 1
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 2
-    },
-    {
-      "id": 7229810,
-      "login": "zackkendra",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7229810?v=4",
-      "htmlUrl": "https://github.com/zackkendra",
-      "contributions": 1
-    },
-    {
       "id": 43335750,
       "login": "paologallinaharbur",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
@@ -60,25 +60,25 @@
       "contributions": 1
     },
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
-      "contributions": 1
-    },
-    {
-      "id": 12631702,
-      "login": "camdencheek",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12631702?v=4",
-      "htmlUrl": "https://github.com/camdencheek",
-      "contributions": 44
-    },
-    {
       "id": 5143130,
       "login": "gsanchezgavier",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
       "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 7
+      "contributions": 9
+    },
+    {
+      "id": 46498444,
+      "login": "lchapman4",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46498444?v=4",
+      "htmlUrl": "https://github.com/lchapman4",
+      "contributions": 1
+    },
+    {
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
     },
     {
       "id": 5297542,
@@ -88,18 +88,25 @@
       "contributions": 2
     },
     {
-      "id": 558327,
-      "login": "maju6406",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/558327?v=4",
-      "htmlUrl": "https://github.com/maju6406",
-      "contributions": 1
-    },
-    {
       "id": 3638421,
       "login": "alvarocabanas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
       "htmlUrl": "https://github.com/alvarocabanas",
       "contributions": 3
+    },
+    {
+      "id": 14238114,
+      "login": "DavidSantia",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14238114?v=4",
+      "htmlUrl": "https://github.com/DavidSantia",
+      "contributions": 3
+    },
+    {
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 2
     },
     {
       "id": 7555235,
@@ -130,11 +137,11 @@
       "contributions": 2
     },
     {
-      "id": 14238114,
-      "login": "DavidSantia",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14238114?v=4",
-      "htmlUrl": "https://github.com/DavidSantia",
-      "contributions": 3
+      "id": 12631702,
+      "login": "camdencheek",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12631702?v=4",
+      "htmlUrl": "https://github.com/camdencheek",
+      "contributions": 44
     },
     {
       "id": 73652669,

--- a/src/data/project-stats/newrelic-nri-mysql.json
+++ b/src/data/project-stats/newrelic-nri-mysql.json
@@ -1,28 +1,28 @@
 {
   "projectFullName": "newrelic/nri-mysql",
   "issues": {
-    "open": 6
+    "open": 8
   },
   "releases": 14,
   "latestRelease": {
     "name": "v1.6.1",
     "date": "2021-06-09T09:14:41Z"
   },
-  "commits": 163,
-  "lastSixMonthsCommitTotal": 22,
-  "contributors": 19,
+  "commits": 165,
+  "lastSixMonthsCommitTotal": 23,
+  "contributors": 21,
   "pullRequests": {
-    "open": 2
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 1
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 2
     },
     {
       "id": 3969485,
@@ -32,10 +32,10 @@
       "contributions": 1
     },
     {
-      "id": 11226795,
-      "login": "chelarua",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
-      "htmlUrl": "https://github.com/chelarua",
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
       "contributions": 2
     },
     {
@@ -46,11 +46,11 @@
       "contributions": 2
     },
     {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 2
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
     },
     {
       "id": 929261,
@@ -67,11 +67,11 @@
       "contributions": 5
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
+      "id": 11226795,
+      "login": "chelarua",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
+      "htmlUrl": "https://github.com/chelarua",
+      "contributions": 2
     },
     {
       "id": 5297542,
@@ -81,11 +81,11 @@
       "contributions": 15
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 2
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
     },
     {
       "id": 3638421,
@@ -123,11 +123,25 @@
       "contributions": 31
     },
     {
+      "id": 1244503,
+      "login": "mvcaaa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1244503?v=4",
+      "htmlUrl": "https://github.com/mvcaaa",
+      "contributions": 1
+    },
+    {
       "id": 947112,
       "login": "ferranorriols",
       "avatarUrl": "https://avatars.githubusercontent.com/u/947112?v=4",
       "htmlUrl": "https://github.com/ferranorriols",
       "contributions": 2
+    },
+    {
+      "id": 3978234,
+      "login": "brybry192",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3978234?v=4",
+      "htmlUrl": "https://github.com/brybry192",
+      "contributions": 1
     },
     {
       "id": 39911991,

--- a/src/data/project-stats/newrelic-nri-nagios.json
+++ b/src/data/project-stats/newrelic-nri-nagios.json
@@ -12,7 +12,7 @@
   "lastSixMonthsCommitTotal": 22,
   "contributors": 12,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 3
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 2
     },
     {
       "id": 3380451,
@@ -67,11 +67,11 @@
       "contributions": 1
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 2
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 3
     },
     {
       "id": 7886905,

--- a/src/data/project-stats/newrelic-nri-nginx.json
+++ b/src/data/project-stats/newrelic-nri-nginx.json
@@ -10,7 +10,7 @@
   },
   "commits": 123,
   "lastSixMonthsCommitTotal": 10,
-  "contributors": 22,
+  "contributors": 21,
   "pullRequests": {
     "open": 0
   },
@@ -25,10 +25,10 @@
       "contributions": 5
     },
     {
-      "id": 3969485,
-      "login": "brushknight",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
-      "htmlUrl": "https://github.com/brushknight",
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
       "contributions": 1
     },
     {
@@ -39,11 +39,11 @@
       "contributions": 2
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 3
+      "id": 11226795,
+      "login": "chelarua",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
+      "htmlUrl": "https://github.com/chelarua",
+      "contributions": 2
     },
     {
       "id": 2054195,
@@ -53,11 +53,11 @@
       "contributions": 3
     },
     {
-      "id": 5143130,
-      "login": "gsanchezgavier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
-      "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 3
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
     },
     {
       "id": 929261,
@@ -74,11 +74,11 @@
       "contributions": 14
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 4
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 3
     },
     {
       "id": 5297542,
@@ -88,11 +88,11 @@
       "contributions": 10
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 4
     },
     {
       "id": 7886905,
@@ -109,11 +109,11 @@
       "contributions": 1
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 1
+      "id": 5143130,
+      "login": "gsanchezgavier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
+      "htmlUrl": "https://github.com/gsanchezgavier",
+      "contributions": 3
     },
     {
       "id": 717815,
@@ -123,18 +123,11 @@
       "contributions": 2
     },
     {
-      "id": 11226795,
-      "login": "chelarua",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
-      "htmlUrl": "https://github.com/chelarua",
-      "contributions": 2
-    },
-    {
-      "id": 939550,
-      "login": "mariomac",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/939550?v=4",
-      "htmlUrl": "https://github.com/mariomac",
-      "contributions": 14
+      "id": 3969485,
+      "login": "brushknight",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
+      "htmlUrl": "https://github.com/brushknight",
+      "contributions": 1
     },
     {
       "id": 969721,

--- a/src/data/project-stats/newrelic-nri-oracledb.json
+++ b/src/data/project-stats/newrelic-nri-oracledb.json
@@ -9,7 +9,7 @@
     "date": "2021-05-12T13:14:59Z"
   },
   "commits": 253,
-  "lastSixMonthsCommitTotal": 11,
+  "lastSixMonthsCommitTotal": 10,
   "contributors": 16,
   "pullRequests": {
     "open": 0
@@ -17,6 +17,13 @@
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 1
+    },
     {
       "id": 3638421,
       "login": "alvarocabanas",
@@ -72,13 +79,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
       "htmlUrl": "https://github.com/alejandrodnm",
       "contributions": 2
-    },
-    {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 1
     },
     {
       "id": 1703710,

--- a/src/data/project-stats/newrelic-nri-perfmon.json
+++ b/src/data/project-stats/newrelic-nri-perfmon.json
@@ -9,7 +9,7 @@
     "date": "2020-12-09T03:50:46Z"
   },
   "commits": 175,
-  "lastSixMonthsCommitTotal": 8,
+  "lastSixMonthsCommitTotal": 7,
   "contributors": 5,
   "pullRequests": {
     "open": 0
@@ -25,11 +25,11 @@
       "contributions": 2
     },
     {
-      "id": 3536684,
-      "login": "sschwartzman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
-      "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 138
+      "id": 30607359,
+      "login": "peetk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30607359?v=4",
+      "htmlUrl": "https://github.com/peetk",
+      "contributions": 6
     },
     {
       "id": 754009,
@@ -46,11 +46,11 @@
       "contributions": 2
     },
     {
-      "id": 30607359,
-      "login": "peetk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30607359?v=4",
-      "htmlUrl": "https://github.com/peetk",
-      "contributions": 6
+      "id": 3536684,
+      "login": "sschwartzman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
+      "htmlUrl": "https://github.com/sschwartzman",
+      "contributions": 138
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-nri-postgresql.json
+++ b/src/data/project-stats/newrelic-nri-postgresql.json
@@ -3,13 +3,13 @@
   "issues": {
     "open": 2
   },
-  "releases": 40,
+  "releases": 41,
   "latestRelease": {
-    "name": "v2.7.2",
-    "date": "2021-06-17T07:45:48Z"
+    "name": "v2.7.3",
+    "date": "2021-07-09T07:51:15Z"
   },
-  "commits": 214,
-  "lastSixMonthsCommitTotal": 15,
+  "commits": 215,
+  "lastSixMonthsCommitTotal": 16,
   "contributors": 20,
   "pullRequests": {
     "open": 0
@@ -18,6 +18,13 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 2
+    },
+    {
       "id": 473071,
       "login": "iserko",
       "avatarUrl": "https://avatars.githubusercontent.com/u/473071?v=4",
@@ -25,18 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 3
-    },
-    {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 2
+      "id": 156813,
+      "login": "rabbitt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/156813?v=4",
+      "htmlUrl": "https://github.com/rabbitt",
+      "contributions": 1
     },
     {
       "id": 2054195,
@@ -81,6 +81,13 @@
       "contributions": 3
     },
     {
+      "id": 11226795,
+      "login": "chelarua",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
+      "htmlUrl": "https://github.com/chelarua",
+      "contributions": 1
+    },
+    {
       "id": 13966363,
       "login": "carlossscastro",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
@@ -88,18 +95,11 @@
       "contributions": 3
     },
     {
-      "id": 156813,
-      "login": "rabbitt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/156813?v=4",
-      "htmlUrl": "https://github.com/rabbitt",
-      "contributions": 1
-    },
-    {
-      "id": 11226795,
-      "login": "chelarua",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
-      "htmlUrl": "https://github.com/chelarua",
-      "contributions": 1
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 4
     },
     {
       "id": 7555235,

--- a/src/data/project-stats/newrelic-nri-process-discovery.json
+++ b/src/data/project-stats/newrelic-nri-process-discovery.json
@@ -15,17 +15,17 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 1
-    },
-    {
       "id": 976883,
       "login": "jlegoff",
       "avatarUrl": "https://avatars.githubusercontent.com/u/976883?v=4",
       "htmlUrl": "https://github.com/jlegoff",
+      "contributions": 1
+    },
+    {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nri-prometheus.json
+++ b/src/data/project-stats/newrelic-nri-prometheus.json
@@ -3,16 +3,16 @@
   "issues": {
     "open": 21
   },
-  "releases": 23,
+  "releases": 24,
   "latestRelease": {
-    "name": "v2.7.0",
-    "date": "2021-05-28T14:08:49Z"
+    "name": "v2.7.1",
+    "date": "2021-07-01T15:28:25Z"
   },
-  "commits": 131,
-  "lastSixMonthsCommitTotal": 29,
+  "commits": 135,
+  "lastSixMonthsCommitTotal": 30,
   "contributors": 18,
   "pullRequests": {
-    "open": 14
+    "open": 11
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -47,7 +47,7 @@
       "login": "gsanchezgavier",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5143130?v=4",
       "htmlUrl": "https://github.com/gsanchezgavier",
-      "contributions": 11
+      "contributions": 14
     },
     {
       "id": 16539896,
@@ -64,10 +64,10 @@
       "contributions": 1
     },
     {
-      "id": 3638421,
-      "login": "alvarocabanas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
-      "htmlUrl": "https://github.com/alvarocabanas",
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
       "contributions": 1
     },
     {
@@ -82,7 +82,7 @@
       "login": "paologallinaharbur",
       "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
       "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 19
+      "contributions": 20
     },
     {
       "id": 929261,
@@ -106,10 +106,10 @@
       "contributions": 22
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nri-rabbitmq.json
+++ b/src/data/project-stats/newrelic-nri-rabbitmq.json
@@ -25,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 3236651,
-      "login": "shannonmitchell",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3236651?v=4",
-      "htmlUrl": "https://github.com/shannonmitchell",
-      "contributions": 1
+      "id": 11226795,
+      "login": "chelarua",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
+      "htmlUrl": "https://github.com/chelarua",
+      "contributions": 3
     },
     {
       "id": 3638421,
@@ -39,10 +39,10 @@
       "contributions": 5
     },
     {
-      "id": 2235616,
-      "login": "rhullah",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2235616?v=4",
-      "htmlUrl": "https://github.com/rhullah",
+      "id": 55132258,
+      "login": "jsbnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
+      "htmlUrl": "https://github.com/jsbnr",
       "contributions": 1
     },
     {
@@ -74,10 +74,10 @@
       "contributions": 3
     },
     {
-      "id": 9002169,
-      "login": "bpschmitt",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9002169?v=4",
-      "htmlUrl": "https://github.com/bpschmitt",
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
       "contributions": 1
     },
     {
@@ -88,20 +88,6 @@
       "contributions": 3
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
-    },
-    {
-      "id": 55132258,
-      "login": "jsbnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55132258?v=4",
-      "htmlUrl": "https://github.com/jsbnr",
-      "contributions": 1
-    },
-    {
       "id": 13438133,
       "login": "matiasburni",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
@@ -109,17 +95,31 @@
       "contributions": 1
     },
     {
-      "id": 11226795,
-      "login": "chelarua",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
-      "htmlUrl": "https://github.com/chelarua",
-      "contributions": 3
+      "id": 3236651,
+      "login": "shannonmitchell",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3236651?v=4",
+      "htmlUrl": "https://github.com/shannonmitchell",
+      "contributions": 1
     },
     {
       "id": 7555235,
       "login": "jportasa",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7555235?v=4",
       "htmlUrl": "https://github.com/jportasa",
+      "contributions": 1
+    },
+    {
+      "id": 2340253,
+      "login": "dbethke",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2340253?v=4",
+      "htmlUrl": "https://github.com/dbethke",
+      "contributions": 1
+    },
+    {
+      "id": 2235616,
+      "login": "rhullah",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2235616?v=4",
+      "htmlUrl": "https://github.com/rhullah",
       "contributions": 1
     },
     {
@@ -144,10 +144,10 @@
       "contributions": 1
     },
     {
-      "id": 2340253,
-      "login": "dbethke",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2340253?v=4",
-      "htmlUrl": "https://github.com/dbethke",
+      "id": 9002169,
+      "login": "bpschmitt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9002169?v=4",
+      "htmlUrl": "https://github.com/bpschmitt",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nri-redis.json
+++ b/src/data/project-stats/newrelic-nri-redis.json
@@ -8,15 +8,22 @@
     "name": "v1.6.3",
     "date": "2021-06-07T12:35:03Z"
   },
-  "commits": 141,
-  "lastSixMonthsCommitTotal": 7,
-  "contributors": 21,
+  "commits": 142,
+  "lastSixMonthsCommitTotal": 8,
+  "contributors": 22,
   "pullRequests": {
     "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
+    {
+      "id": 3969485,
+      "login": "brushknight",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
+      "htmlUrl": "https://github.com/brushknight",
+      "contributions": 6
+    },
     {
       "id": 15685307,
       "login": "cristianciutea",
@@ -25,18 +32,18 @@
       "contributions": 2
     },
     {
-      "id": 3380451,
-      "login": "rubenruizdegauna",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
-      "htmlUrl": "https://github.com/rubenruizdegauna",
-      "contributions": 1
+      "id": 70050,
+      "login": "katzchang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/70050?v=4",
+      "htmlUrl": "https://github.com/katzchang",
+      "contributions": 5
     },
     {
-      "id": 11226795,
-      "login": "chelarua",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
-      "htmlUrl": "https://github.com/chelarua",
-      "contributions": 2
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
     },
     {
       "id": 2054195,
@@ -60,17 +67,10 @@
       "contributions": 1
     },
     {
-      "id": 1408986,
-      "login": "TylerLubeck",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1408986?v=4",
-      "htmlUrl": "https://github.com/TylerLubeck",
-      "contributions": 2
-    },
-    {
-      "id": 939550,
-      "login": "mariomac",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/939550?v=4",
-      "htmlUrl": "https://github.com/mariomac",
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
       "contributions": 1
     },
     {
@@ -88,24 +88,24 @@
       "contributions": 3
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
+      "id": 13122042,
+      "login": "williamchanrico",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13122042?v=4",
+      "htmlUrl": "https://github.com/williamchanrico",
       "contributions": 1
     },
     {
-      "id": 70050,
-      "login": "katzchang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/70050?v=4",
-      "htmlUrl": "https://github.com/katzchang",
-      "contributions": 5
+      "id": 939550,
+      "login": "mariomac",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/939550?v=4",
+      "htmlUrl": "https://github.com/mariomac",
+      "contributions": 1
     },
     {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
       "contributions": 1
     },
     {
@@ -116,6 +116,13 @@
       "contributions": 1
     },
     {
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
+      "contributions": 1
+    },
+    {
       "id": 7886905,
       "login": "fryckbos",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
@@ -123,18 +130,18 @@
       "contributions": 4
     },
     {
-      "id": 3969485,
-      "login": "brushknight",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
-      "htmlUrl": "https://github.com/brushknight",
-      "contributions": 6
+      "id": 11226795,
+      "login": "chelarua",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11226795?v=4",
+      "htmlUrl": "https://github.com/chelarua",
+      "contributions": 2
     },
     {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
-      "contributions": 1
+      "id": 1408986,
+      "login": "TylerLubeck",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1408986?v=4",
+      "htmlUrl": "https://github.com/TylerLubeck",
+      "contributions": 2
     },
     {
       "id": 947112,

--- a/src/data/project-stats/newrelic-nri-snmp.json
+++ b/src/data/project-stats/newrelic-nri-snmp.json
@@ -10,9 +10,9 @@
   },
   "commits": 86,
   "lastSixMonthsCommitTotal": 17,
-  "contributors": 15,
+  "contributors": 14,
   "pullRequests": {
-    "open": 1
+    "open": 0
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -25,13 +25,6 @@
       "contributions": 1
     },
     {
-      "id": 13438133,
-      "login": "matiasburni",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
-      "htmlUrl": "https://github.com/matiasburni",
-      "contributions": 1
-    },
-    {
       "id": 3380451,
       "login": "rubenruizdegauna",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
@@ -39,11 +32,11 @@
       "contributions": 1
     },
     {
-      "id": 13966363,
-      "login": "carlossscastro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
-      "htmlUrl": "https://github.com/carlossscastro",
-      "contributions": 1
+      "id": 7886905,
+      "login": "fryckbos",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
+      "htmlUrl": "https://github.com/fryckbos",
+      "contributions": 2
     },
     {
       "id": 3969485,
@@ -51,6 +44,27 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
       "htmlUrl": "https://github.com/brushknight",
       "contributions": 2
+    },
+    {
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
+      "contributions": 1
+    },
+    {
+      "id": 73652669,
+      "login": "arvdias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
+      "htmlUrl": "https://github.com/arvdias",
+      "contributions": 1
+    },
+    {
+      "id": 13438133,
+      "login": "matiasburni",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
+      "htmlUrl": "https://github.com/matiasburni",
+      "contributions": 1
     },
     {
       "id": 5143130,
@@ -74,38 +88,17 @@
       "contributions": 5
     },
     {
+      "id": 13966363,
+      "login": "carlossscastro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
+      "htmlUrl": "https://github.com/carlossscastro",
+      "contributions": 1
+    },
+    {
       "id": 3638421,
       "login": "alvarocabanas",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
       "htmlUrl": "https://github.com/alvarocabanas",
-      "contributions": 1
-    },
-    {
-      "id": 717815,
-      "login": "carlosroman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
-      "htmlUrl": "https://github.com/carlosroman",
-      "contributions": 5
-    },
-    {
-      "id": 7886905,
-      "login": "fryckbos",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7886905?v=4",
-      "htmlUrl": "https://github.com/fryckbos",
-      "contributions": 2
-    },
-    {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
-      "contributions": 1
-    },
-    {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
       "contributions": 1
     },
     {
@@ -116,11 +109,11 @@
       "contributions": 25
     },
     {
-      "id": 73652669,
-      "login": "arvdias",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/73652669?v=4",
-      "htmlUrl": "https://github.com/arvdias",
-      "contributions": 1
+      "id": 717815,
+      "login": "carlosroman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
+      "htmlUrl": "https://github.com/carlosroman",
+      "contributions": 5
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-nri-varnish.json
+++ b/src/data/project-stats/newrelic-nri-varnish.json
@@ -12,24 +12,24 @@
   "lastSixMonthsCommitTotal": 11,
   "contributors": 13,
   "pullRequests": {
-    "open": 0
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 43335750,
-      "login": "paologallinaharbur",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
-      "htmlUrl": "https://github.com/paologallinaharbur",
-      "contributions": 1
-    },
     {
       "id": 13438133,
       "login": "matiasburni",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13438133?v=4",
       "htmlUrl": "https://github.com/matiasburni",
       "contributions": 2
+    },
+    {
+      "id": 43335750,
+      "login": "paologallinaharbur",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
+      "htmlUrl": "https://github.com/paologallinaharbur",
+      "contributions": 1
     },
     {
       "id": 7229810,

--- a/src/data/project-stats/newrelic-nri-vsphere.json
+++ b/src/data/project-stats/newrelic-nri-vsphere.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/nri-vsphere",
   "issues": {
-    "open": 6
+    "open": 7
   },
   "releases": 8,
   "latestRelease": {
@@ -18,10 +18,10 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 929261,
-      "login": "tangollama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
-      "htmlUrl": "https://github.com/tangollama",
+      "id": 482671,
+      "login": "fightingmonk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/482671?v=4",
+      "htmlUrl": "https://github.com/fightingmonk",
       "contributions": 1
     },
     {
@@ -39,10 +39,10 @@
       "contributions": 29
     },
     {
-      "id": 482671,
-      "login": "fightingmonk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/482671?v=4",
-      "htmlUrl": "https://github.com/fightingmonk",
+      "id": 929261,
+      "login": "tangollama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
+      "htmlUrl": "https://github.com/tangollama",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-nri-winservices.json
+++ b/src/data/project-stats/newrelic-nri-winservices.json
@@ -1,29 +1,22 @@
 {
   "projectFullName": "newrelic/nri-winservices",
   "issues": {
-    "open": 8
+    "open": 9
   },
   "releases": 3,
   "latestRelease": {
     "name": "v0.2.0-beta",
     "date": "2021-02-19T12:39:41Z"
   },
-  "commits": 89,
-  "lastSixMonthsCommitTotal": 9,
-  "contributors": 6,
+  "commits": 90,
+  "lastSixMonthsCommitTotal": 8,
+  "contributors": 7,
   "pullRequests": {
     "open": 9
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 969721,
-      "login": "roobre",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
-      "htmlUrl": "https://github.com/roobre",
-      "contributions": 2
-    },
     {
       "id": 43244625,
       "login": "melissaklein24",
@@ -39,6 +32,13 @@
       "contributions": 26
     },
     {
+      "id": 969721,
+      "login": "roobre",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/969721?v=4",
+      "htmlUrl": "https://github.com/roobre",
+      "contributions": 2
+    },
+    {
       "id": 929261,
       "login": "tangollama",
       "avatarUrl": "https://avatars.githubusercontent.com/u/929261?v=4",
@@ -51,6 +51,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/43335750?v=4",
       "htmlUrl": "https://github.com/paologallinaharbur",
       "contributions": 28
+    },
+    {
+      "id": 3638421,
+      "login": "alvarocabanas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3638421?v=4",
+      "htmlUrl": "https://github.com/alvarocabanas",
+      "contributions": 1
     },
     {
       "id": 39911991,

--- a/src/data/project-stats/newrelic-nrjmx.json
+++ b/src/data/project-stats/newrelic-nrjmx.json
@@ -10,7 +10,7 @@
   },
   "commits": 177,
   "lastSixMonthsCommitTotal": 0,
-  "contributors": 15,
+  "contributors": 14,
   "pullRequests": {
     "open": 1
   },
@@ -25,11 +25,11 @@
       "contributions": 1
     },
     {
-      "id": 717815,
-      "login": "carlosroman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
-      "htmlUrl": "https://github.com/carlosroman",
-      "contributions": 12
+      "id": 466745,
+      "login": "vvydier",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/466745?v=4",
+      "htmlUrl": "https://github.com/vvydier",
+      "contributions": 7
     },
     {
       "id": 907624,
@@ -74,24 +74,17 @@
       "contributions": 2
     },
     {
-      "id": 466745,
-      "login": "vvydier",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/466745?v=4",
-      "htmlUrl": "https://github.com/vvydier",
-      "contributions": 7
+      "id": 717815,
+      "login": "carlosroman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/717815?v=4",
+      "htmlUrl": "https://github.com/carlosroman",
+      "contributions": 12
     },
     {
       "id": 6081083,
       "login": "jaloren",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6081083?v=4",
       "htmlUrl": "https://github.com/jaloren",
-      "contributions": 1
-    },
-    {
-      "id": 877369,
-      "login": "ramonguiu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/877369?v=4",
-      "htmlUrl": "https://github.com/ramonguiu",
       "contributions": 1
     },
     {

--- a/src/data/project-stats/newrelic-oma-resource-center.json
+++ b/src/data/project-stats/newrelic-oma-resource-center.json
@@ -5,9 +5,9 @@
   },
   "releases": 0,
   "latestRelease": null,
-  "commits": 15,
-  "lastSixMonthsCommitTotal": 15,
-  "contributors": 4,
+  "commits": 25,
+  "lastSixMonthsCommitTotal": 25,
+  "contributors": 5,
   "pullRequests": {
     "open": 0
   },
@@ -41,6 +41,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
       "htmlUrl": "https://github.com/adwetzelnr",
       "contributions": 1
+    },
+    {
+      "id": 33837470,
+      "login": "khickey-newrelic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33837470?v=4",
+      "htmlUrl": "https://github.com/khickey-newrelic",
+      "contributions": 9
     }
   ],
   "languages": [],

--- a/src/data/project-stats/newrelic-open-install-library.json
+++ b/src/data/project-stats/newrelic-open-install-library.json
@@ -3,16 +3,16 @@
   "issues": {
     "open": 24
   },
-  "releases": 156,
+  "releases": 174,
   "latestRelease": {
-    "name": "v0.49.11",
+    "name": "v0.50.0",
     "date": null
   },
-  "commits": 1508,
-  "lastSixMonthsCommitTotal": 1009,
-  "contributors": 22,
+  "commits": 1614,
+  "lastSixMonthsCommitTotal": 1013,
+  "contributors": 25,
   "pullRequests": {
-    "open": 5
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
@@ -29,7 +29,14 @@
       "login": "ctrombley",
       "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
       "htmlUrl": "https://github.com/ctrombley",
-      "contributions": 19
+      "contributions": 20
+    },
+    {
+      "id": 3380451,
+      "login": "rubenruizdegauna",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3380451?v=4",
+      "htmlUrl": "https://github.com/rubenruizdegauna",
+      "contributions": 1
     },
     {
       "id": 37123078,
@@ -53,11 +60,95 @@
       "contributions": 2
     },
     {
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 30
+    },
+    {
       "id": 654808,
       "login": "tehbio",
       "avatarUrl": "https://avatars.githubusercontent.com/u/654808?v=4",
       "htmlUrl": "https://github.com/tehbio",
       "contributions": 5
+    },
+    {
+      "id": 4481921,
+      "login": "gabeobrien",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4481921?v=4",
+      "htmlUrl": "https://github.com/gabeobrien",
+      "contributions": 71
+    },
+    {
+      "id": 13966363,
+      "login": "carlossscastro",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
+      "htmlUrl": "https://github.com/carlossscastro",
+      "contributions": 19
+    },
+    {
+      "id": 54335840,
+      "login": "carlo-808",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
+      "htmlUrl": "https://github.com/carlo-808",
+      "contributions": 3
+    },
+    {
+      "id": 6098021,
+      "login": "jaffinito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6098021?v=4",
+      "htmlUrl": "https://github.com/jaffinito",
+      "contributions": 48
+    },
+    {
+      "id": 6722433,
+      "login": "jbeveland27",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
+      "htmlUrl": "https://github.com/jbeveland27",
+      "contributions": 178
+    },
+    {
+      "id": 3969485,
+      "login": "brushknight",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3969485?v=4",
+      "htmlUrl": "https://github.com/brushknight",
+      "contributions": 4
+    },
+    {
+      "id": 57361211,
+      "login": "nr-ahemsath",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
+      "htmlUrl": "https://github.com/nr-ahemsath",
+      "contributions": 32
+    },
+    {
+      "id": 2590905,
+      "login": "sanderblue",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
+      "htmlUrl": "https://github.com/sanderblue",
+      "contributions": 25
+    },
+    {
+      "id": 47485486,
+      "login": "noahmmcgivern",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47485486?v=4",
+      "htmlUrl": "https://github.com/noahmmcgivern",
+      "contributions": 19
+    },
+    {
+      "id": 292463,
+      "login": "meiao",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/292463?v=4",
+      "htmlUrl": "https://github.com/meiao",
+      "contributions": 26
+    },
+    {
+      "id": 15685307,
+      "login": "cristianciutea",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15685307?v=4",
+      "htmlUrl": "https://github.com/cristianciutea",
+      "contributions": 2
     },
     {
       "id": 3638421,
@@ -67,11 +158,11 @@
       "contributions": 6
     },
     {
-      "id": 13966363,
-      "login": "carlossscastro",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13966363?v=4",
-      "htmlUrl": "https://github.com/carlossscastro",
-      "contributions": 19
+      "id": 29264964,
+      "login": "zlesnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
+      "htmlUrl": "https://github.com/zlesnr",
+      "contributions": 17
     },
     {
       "id": 56414817,
@@ -88,88 +179,18 @@
       "contributions": 169
     },
     {
-      "id": 54335840,
-      "login": "carlo-808",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
-      "htmlUrl": "https://github.com/carlo-808",
-      "contributions": 2
-    },
-    {
-      "id": 6098021,
-      "login": "jaffinito",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6098021?v=4",
-      "htmlUrl": "https://github.com/jaffinito",
-      "contributions": 46
-    },
-    {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 30
-    },
-    {
-      "id": 4481921,
-      "login": "gabeobrien",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4481921?v=4",
-      "htmlUrl": "https://github.com/gabeobrien",
-      "contributions": 71
-    },
-    {
-      "id": 57361211,
-      "login": "nr-ahemsath",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
-      "htmlUrl": "https://github.com/nr-ahemsath",
-      "contributions": 32
-    },
-    {
-      "id": 6722433,
-      "login": "jbeveland27",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
-      "htmlUrl": "https://github.com/jbeveland27",
-      "contributions": 175
-    },
-    {
-      "id": 29264964,
-      "login": "zlesnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/29264964?v=4",
-      "htmlUrl": "https://github.com/zlesnr",
-      "contributions": 17
-    },
-    {
-      "id": 2590905,
-      "login": "sanderblue",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
-      "htmlUrl": "https://github.com/sanderblue",
-      "contributions": 25
-    },
-    {
-      "id": 47485486,
-      "login": "noahmmcgivern",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47485486?v=4",
-      "htmlUrl": "https://github.com/noahmmcgivern",
-      "contributions": 13
-    },
-    {
-      "id": 292463,
-      "login": "meiao",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/292463?v=4",
-      "htmlUrl": "https://github.com/meiao",
-      "contributions": 26
-    },
-    {
       "id": 976883,
       "login": "jlegoff",
       "avatarUrl": "https://avatars.githubusercontent.com/u/976883?v=4",
       "htmlUrl": "https://github.com/jlegoff",
-      "contributions": 8
+      "contributions": 11
     },
     {
       "id": 38018054,
       "login": "Julien4218",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38018054?v=4",
       "htmlUrl": "https://github.com/Julien4218",
-      "contributions": 442
+      "contributions": 496
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-opensource-website.json
+++ b/src/data/project-stats/newrelic-opensource-website.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/opensource-website",
   "issues": {
-    "open": 7
+    "open": 5
   },
   "releases": 85,
   "latestRelease": {
     "name": "v1.15.3",
     "date": "2021-06-11T18:46:32Z"
   },
-  "commits": 3604,
-  "lastSixMonthsCommitTotal": 1221,
+  "commits": 3612,
+  "lastSixMonthsCommitTotal": 1090,
   "contributors": 65,
   "pullRequests": {
-    "open": 2
+    "open": 5
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -22,7 +22,7 @@
       "url": "https://github.com/newrelic/opensource-website/issues/686",
       "createdAt": "2021-01-22T19:12:00Z",
       "comments": {
-        "totalCount": 8
+        "totalCount": 9
       },
       "author": {
         "login": "zstix",
@@ -36,13 +36,6 @@
   ],
   "cachedContributors": [
     {
-      "id": 20293876,
-      "login": "tyreer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/20293876?v=4",
-      "htmlUrl": "https://github.com/tyreer",
-      "contributions": 11
-    },
-    {
       "id": 52758187,
       "login": "newrelic-eheinlein",
       "avatarUrl": "https://avatars.githubusercontent.com/u/52758187?v=4",
@@ -50,25 +43,18 @@
       "contributions": 1
     },
     {
-      "id": 3536684,
-      "login": "sschwartzman",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
-      "htmlUrl": "https://github.com/sschwartzman",
-      "contributions": 14
+      "id": 57361211,
+      "login": "nr-ahemsath",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
+      "htmlUrl": "https://github.com/nr-ahemsath",
+      "contributions": 3
     },
     {
-      "id": 17122543,
-      "login": "rudouglas",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
-      "htmlUrl": "https://github.com/rudouglas",
-      "contributions": 6
-    },
-    {
-      "id": 6130000,
-      "login": "asllop",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6130000?v=4",
-      "htmlUrl": "https://github.com/asllop",
-      "contributions": 2
+      "id": 23487424,
+      "login": "jospdeleon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/23487424?v=4",
+      "htmlUrl": "https://github.com/jospdeleon",
+      "contributions": 1
     },
     {
       "id": 184273,
@@ -85,24 +71,24 @@
       "contributions": 5
     },
     {
-      "id": 19733683,
-      "login": "snyk-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
-      "htmlUrl": "https://github.com/snyk-bot",
-      "contributions": 15
+      "id": 6130000,
+      "login": "asllop",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6130000?v=4",
+      "htmlUrl": "https://github.com/asllop",
+      "contributions": 2
     },
     {
-      "id": 159076,
-      "login": "douglascamata",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
-      "htmlUrl": "https://github.com/douglascamata",
+      "id": 283858,
+      "login": "jonathanpdx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/283858?v=4",
+      "htmlUrl": "https://github.com/jonathanpdx",
       "contributions": 1
     },
     {
-      "id": 64921278,
-      "login": "lchockalingam",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/64921278?v=4",
-      "htmlUrl": "https://github.com/lchockalingam",
+      "id": 71456800,
+      "login": "azeazasloper",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/71456800?v=4",
+      "htmlUrl": "https://github.com/azeazasloper",
       "contributions": 1
     },
     {
@@ -127,11 +113,11 @@
       "contributions": 1
     },
     {
-      "id": 32174276,
-      "login": "semantic-release-bot",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
-      "htmlUrl": "https://github.com/semantic-release-bot",
-      "contributions": 28
+      "id": 398399,
+      "login": "nijotz",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/398399?v=4",
+      "htmlUrl": "https://github.com/nijotz",
+      "contributions": 1
     },
     {
       "id": 37779995,
@@ -148,13 +134,6 @@
       "contributions": 1
     },
     {
-      "id": 5297542,
-      "login": "alejandrodnm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
-      "htmlUrl": "https://github.com/alejandrodnm",
-      "contributions": 2
-    },
-    {
       "id": 1946433,
       "login": "zstix",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1946433?v=4",
@@ -162,11 +141,18 @@
       "contributions": 5
     },
     {
-      "id": 81539,
-      "login": "kittylyst",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/81539?v=4",
-      "htmlUrl": "https://github.com/kittylyst",
-      "contributions": 2
+      "id": 55376304,
+      "login": "DamonHolland",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55376304?v=4",
+      "htmlUrl": "https://github.com/DamonHolland",
+      "contributions": 3
+    },
+    {
+      "id": 64921278,
+      "login": "lchockalingam",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/64921278?v=4",
+      "htmlUrl": "https://github.com/lchockalingam",
+      "contributions": 1
     },
     {
       "id": 70179303,
@@ -176,32 +162,46 @@
       "contributions": 20
     },
     {
-      "id": 197140,
-      "login": "devfreddy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
-      "htmlUrl": "https://github.com/devfreddy",
-      "contributions": 138
-    },
-    {
-      "id": 5543599,
-      "login": "MrAlias",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5543599?v=4",
-      "htmlUrl": "https://github.com/MrAlias",
-      "contributions": 1
-    },
-    {
-      "id": 4761745,
-      "login": "elucus",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4761745?v=4",
-      "htmlUrl": "https://github.com/elucus",
-      "contributions": 1
-    },
-    {
       "id": 1395158,
       "login": "jpvajda",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1395158?v=4",
       "htmlUrl": "https://github.com/jpvajda",
       "contributions": 23
+    },
+    {
+      "id": 20293876,
+      "login": "tyreer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20293876?v=4",
+      "htmlUrl": "https://github.com/tyreer",
+      "contributions": 11
+    },
+    {
+      "id": 19733683,
+      "login": "snyk-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19733683?v=4",
+      "htmlUrl": "https://github.com/snyk-bot",
+      "contributions": 15
+    },
+    {
+      "id": 159076,
+      "login": "douglascamata",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/159076?v=4",
+      "htmlUrl": "https://github.com/douglascamata",
+      "contributions": 1
+    },
+    {
+      "id": 17122543,
+      "login": "rudouglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17122543?v=4",
+      "htmlUrl": "https://github.com/rudouglas",
+      "contributions": 6
+    },
+    {
+      "id": 812989,
+      "login": "danielgolden",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
+      "htmlUrl": "https://github.com/danielgolden",
+      "contributions": 181
     },
     {
       "id": 1082112,
@@ -211,11 +211,11 @@
       "contributions": 1
     },
     {
-      "id": 54335840,
-      "login": "carlo-808",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
-      "htmlUrl": "https://github.com/carlo-808",
-      "contributions": 1
+      "id": 197140,
+      "login": "devfreddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/197140?v=4",
+      "htmlUrl": "https://github.com/devfreddy",
+      "contributions": 138
     },
     {
       "id": 39402771,
@@ -236,21 +236,35 @@
       "login": "nr-opensource-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66321197?v=4",
       "htmlUrl": "https://github.com/nr-opensource-bot",
-      "contributions": 2222
+      "contributions": 2224
     },
     {
-      "id": 283858,
-      "login": "jonathanpdx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/283858?v=4",
-      "htmlUrl": "https://github.com/jonathanpdx",
+      "id": 2590905,
+      "login": "sanderblue",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
+      "htmlUrl": "https://github.com/sanderblue",
+      "contributions": 3
+    },
+    {
+      "id": 81539,
+      "login": "kittylyst",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/81539?v=4",
+      "htmlUrl": "https://github.com/kittylyst",
+      "contributions": 2
+    },
+    {
+      "id": 4761745,
+      "login": "elucus",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4761745?v=4",
+      "htmlUrl": "https://github.com/elucus",
       "contributions": 1
     },
     {
-      "id": 43244625,
-      "login": "melissaklein24",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
-      "htmlUrl": "https://github.com/melissaklein24",
-      "contributions": 21
+      "id": 39764444,
+      "login": "MattIGolden",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39764444?v=4",
+      "htmlUrl": "https://github.com/MattIGolden",
+      "contributions": 1
     },
     {
       "id": 6722433,
@@ -258,27 +272,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/6722433?v=4",
       "htmlUrl": "https://github.com/jbeveland27",
       "contributions": 89
-    },
-    {
-      "id": 455419,
-      "login": "jthurman42",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
-      "htmlUrl": "https://github.com/jthurman42",
-      "contributions": 3
-    },
-    {
-      "id": 812989,
-      "login": "danielgolden",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/812989?v=4",
-      "htmlUrl": "https://github.com/danielgolden",
-      "contributions": 181
-    },
-    {
-      "id": 57361211,
-      "login": "nr-ahemsath",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57361211?v=4",
-      "htmlUrl": "https://github.com/nr-ahemsath",
-      "contributions": 3
     },
     {
       "id": 21069727,
@@ -320,7 +313,14 @@
       "login": "LizBaker",
       "avatarUrl": "https://avatars.githubusercontent.com/u/39655074?v=4",
       "htmlUrl": "https://github.com/LizBaker",
-      "contributions": 9
+      "contributions": 12
+    },
+    {
+      "id": 3536684,
+      "login": "sschwartzman",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3536684?v=4",
+      "htmlUrl": "https://github.com/sschwartzman",
+      "contributions": 14
     },
     {
       "id": 58010132,
@@ -337,17 +337,17 @@
       "contributions": 1
     },
     {
-      "id": 71456800,
-      "login": "azeazasloper",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/71456800?v=4",
-      "htmlUrl": "https://github.com/azeazasloper",
-      "contributions": 1
+      "id": 455419,
+      "login": "jthurman42",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
+      "htmlUrl": "https://github.com/jthurman42",
+      "contributions": 3
     },
     {
-      "id": 23487424,
-      "login": "jospdeleon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/23487424?v=4",
-      "htmlUrl": "https://github.com/jospdeleon",
+      "id": 54335840,
+      "login": "carlo-808",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54335840?v=4",
+      "htmlUrl": "https://github.com/carlo-808",
       "contributions": 1
     },
     {
@@ -372,18 +372,18 @@
       "contributions": 1
     },
     {
-      "id": 398399,
-      "login": "nijotz",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/398399?v=4",
-      "htmlUrl": "https://github.com/nijotz",
+      "id": 5543599,
+      "login": "MrAlias",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5543599?v=4",
+      "htmlUrl": "https://github.com/MrAlias",
       "contributions": 1
     },
     {
-      "id": 39764444,
-      "login": "MattIGolden",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39764444?v=4",
-      "htmlUrl": "https://github.com/MattIGolden",
-      "contributions": 1
+      "id": 43244625,
+      "login": "melissaklein24",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43244625?v=4",
+      "htmlUrl": "https://github.com/melissaklein24",
+      "contributions": 21
     },
     {
       "id": 49817386,
@@ -393,11 +393,11 @@
       "contributions": 1
     },
     {
-      "id": 2590905,
-      "login": "sanderblue",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
-      "htmlUrl": "https://github.com/sanderblue",
-      "contributions": 3
+      "id": 32174276,
+      "login": "semantic-release-bot",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32174276?v=4",
+      "htmlUrl": "https://github.com/semantic-release-bot",
+      "contributions": 28
     },
     {
       "id": 11223178,
@@ -425,7 +425,7 @@
       "login": "nr-kkenney",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70179215?v=4",
       "htmlUrl": "https://github.com/nr-kkenney",
-      "contributions": 1
+      "contributions": 2
     },
     {
       "id": 3496648,
@@ -442,11 +442,11 @@
       "contributions": 1
     },
     {
-      "id": 55376304,
-      "login": "DamonHolland",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/55376304?v=4",
-      "htmlUrl": "https://github.com/DamonHolland",
-      "contributions": 3
+      "id": 5297542,
+      "login": "alejandrodnm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5297542?v=4",
+      "htmlUrl": "https://github.com/alejandrodnm",
+      "contributions": 2
     },
     {
       "id": 6426523,

--- a/src/data/project-stats/newrelic-opentelemetry-exporter-go.json
+++ b/src/data/project-stats/newrelic-opentelemetry-exporter-go.json
@@ -1,7 +1,7 @@
 {
   "projectFullName": "newrelic/opentelemetry-exporter-go",
   "issues": {
-    "open": 3
+    "open": 2
   },
   "releases": 7,
   "latestRelease": {
@@ -9,21 +9,14 @@
     "date": "2021-05-26T21:14:28Z"
   },
   "commits": 152,
-  "lastSixMonthsCommitTotal": 65,
+  "lastSixMonthsCommitTotal": 60,
   "contributors": 15,
   "pullRequests": {
-    "open": 3
+    "open": 4
   },
   "searchCategory": "good first issue",
   "cachedIssues": [],
   "cachedContributors": [
-    {
-      "id": 48965776,
-      "login": "jodeev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
-      "htmlUrl": "https://github.com/jodeev",
-      "contributions": 1
-    },
     {
       "id": 52758187,
       "login": "newrelic-eheinlein",
@@ -72,6 +65,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3676547?v=4",
       "htmlUrl": "https://github.com/alanwest",
       "contributions": 11
+    },
+    {
+      "id": 48965776,
+      "login": "jodeev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48965776?v=4",
+      "htmlUrl": "https://github.com/jodeev",
+      "contributions": 1
     },
     {
       "id": 1342804,

--- a/src/data/project-stats/newrelic-papers.json
+++ b/src/data/project-stats/newrelic-papers.json
@@ -18,13 +18,6 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 36873,
-      "login": "davidcelis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/36873?v=4",
-      "htmlUrl": "https://github.com/davidcelis",
-      "contributions": 19
-    },
-    {
       "id": 200663,
       "login": "eknuth",
       "avatarUrl": "https://avatars.githubusercontent.com/u/200663?v=4",
@@ -37,6 +30,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/1449707?v=4",
       "htmlUrl": "https://github.com/theoretick",
       "contributions": 39
+    },
+    {
+      "id": 36873,
+      "login": "davidcelis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36873?v=4",
+      "htmlUrl": "https://github.com/davidcelis",
+      "contributions": 19
     },
     {
       "id": 1725338,

--- a/src/data/project-stats/newrelic-quickstarts-dashboard-library.json
+++ b/src/data/project-stats/newrelic-quickstarts-dashboard-library.json
@@ -8,8 +8,8 @@
     "name": "v1.0",
     "date": "2021-03-26T15:17:50Z"
   },
-  "commits": 173,
-  "lastSixMonthsCommitTotal": 173,
+  "commits": 183,
+  "lastSixMonthsCommitTotal": 183,
   "contributors": 15,
   "pullRequests": {
     "open": 1
@@ -23,6 +23,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/3629903?v=4",
       "htmlUrl": "https://github.com/danifitz",
       "contributions": 9
+    },
+    {
+      "id": 6836095,
+      "login": "kaojiri",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6836095?v=4",
+      "htmlUrl": "https://github.com/kaojiri",
+      "contributions": 2
     },
     {
       "id": 1753821,
@@ -46,13 +53,6 @@
       "contributions": 27
     },
     {
-      "id": 9326772,
-      "login": "Lucy0",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/9326772?v=4",
-      "htmlUrl": "https://github.com/Lucy0",
-      "contributions": 4
-    },
-    {
       "id": 37123078,
       "login": "setamyDG",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37123078?v=4",
@@ -67,18 +67,18 @@
       "contributions": 49
     },
     {
-      "id": 30831476,
-      "login": "thezackm",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
-      "htmlUrl": "https://github.com/thezackm",
-      "contributions": 5
+      "id": 9326772,
+      "login": "Lucy0",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9326772?v=4",
+      "htmlUrl": "https://github.com/Lucy0",
+      "contributions": 4
     },
     {
       "id": 66958286,
       "login": "nrkk-azuma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/66958286?v=4",
       "htmlUrl": "https://github.com/nrkk-azuma",
-      "contributions": 2
+      "contributions": 3
     },
     {
       "id": 8333200,
@@ -102,11 +102,11 @@
       "contributions": 1
     },
     {
-      "id": 6836095,
-      "login": "kaojiri",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6836095?v=4",
-      "htmlUrl": "https://github.com/kaojiri",
-      "contributions": 2
+      "id": 30831476,
+      "login": "thezackm",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30831476?v=4",
+      "htmlUrl": "https://github.com/thezackm",
+      "contributions": 6
     },
     {
       "id": 81187765,
@@ -120,7 +120,7 @@
       "login": "harrykimpel",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2581608?v=4",
       "htmlUrl": "https://github.com/harrykimpel",
-      "contributions": 2
+      "contributions": 5
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-quickstarts-synthetics-library.json
+++ b/src/data/project-stats/newrelic-quickstarts-synthetics-library.json
@@ -22,18 +22,18 @@
       "contributions": 2
     },
     {
+      "id": 184273,
+      "login": "kidk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
+      "htmlUrl": "https://github.com/kidk",
+      "contributions": 11
+    },
+    {
       "id": 24992650,
       "login": "StacySimmons",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24992650?v=4",
       "htmlUrl": "https://github.com/StacySimmons",
       "contributions": 1
-    },
-    {
-      "id": 45947764,
-      "login": "bpeckNR",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
-      "htmlUrl": "https://github.com/bpeckNR",
-      "contributions": 2
     },
     {
       "id": 43244625,
@@ -50,11 +50,11 @@
       "contributions": 1
     },
     {
-      "id": 184273,
-      "login": "kidk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
-      "htmlUrl": "https://github.com/kidk",
-      "contributions": 11
+      "id": 45947764,
+      "login": "bpeckNR",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45947764?v=4",
+      "htmlUrl": "https://github.com/bpeckNR",
+      "contributions": 2
     },
     {
       "id": 42678939,

--- a/src/data/project-stats/newrelic-repolinter-action.json
+++ b/src/data/project-stats/newrelic-repolinter-action.json
@@ -9,7 +9,7 @@
     "date": "2020-12-29T17:24:49Z"
   },
   "commits": 229,
-  "lastSixMonthsCommitTotal": 14,
+  "lastSixMonthsCommitTotal": 0,
   "contributors": 3,
   "pullRequests": {
     "open": 1

--- a/src/data/project-stats/newrelic-rusty-hog.json
+++ b/src/data/project-stats/newrelic-rusty-hog.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 11471197,
-      "login": "EMCain",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11471197?v=4",
-      "htmlUrl": "https://github.com/EMCain",
-      "contributions": 10
+      "id": 10552286,
+      "login": "kevinfealey",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10552286?v=4",
+      "htmlUrl": "https://github.com/kevinfealey",
+      "contributions": 1
     },
     {
       "id": 57361211,
@@ -32,18 +32,18 @@
       "contributions": 1
     },
     {
-      "id": 10552286,
-      "login": "kevinfealey",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10552286?v=4",
-      "htmlUrl": "https://github.com/kevinfealey",
-      "contributions": 1
+      "id": 11471197,
+      "login": "EMCain",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11471197?v=4",
+      "htmlUrl": "https://github.com/EMCain",
+      "contributions": 10
     },
     {
-      "id": 11640472,
-      "login": "nicolasjhampton",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/11640472?v=4",
-      "htmlUrl": "https://github.com/nicolasjhampton",
-      "contributions": 2
+      "id": 49817386,
+      "login": "jeffalder",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
+      "htmlUrl": "https://github.com/jeffalder",
+      "contributions": 1
     },
     {
       "id": 58010132,
@@ -67,11 +67,11 @@
       "contributions": 1
     },
     {
-      "id": 49817386,
-      "login": "jeffalder",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49817386?v=4",
-      "htmlUrl": "https://github.com/jeffalder",
-      "contributions": 1
+      "id": 11640472,
+      "login": "nicolasjhampton",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/11640472?v=4",
+      "htmlUrl": "https://github.com/nicolasjhampton",
+      "contributions": 2
     },
     {
       "id": 15875402,

--- a/src/data/project-stats/newrelic-serverless-newrelic-lambda-layers.json
+++ b/src/data/project-stats/newrelic-serverless-newrelic-lambda-layers.json
@@ -1,16 +1,16 @@
 {
   "projectFullName": "newrelic/serverless-newrelic-lambda-layers",
   "issues": {
-    "open": 5
+    "open": 3
   },
-  "releases": 38,
+  "releases": 39,
   "latestRelease": {
-    "name": "v1.1.7",
-    "date": "2021-06-09T19:03:54Z"
+    "name": "v1.1.8",
+    "date": "2021-07-09T21:06:42Z"
   },
-  "commits": 261,
-  "lastSixMonthsCommitTotal": 85,
-  "contributors": 10,
+  "commits": 262,
+  "lastSixMonthsCommitTotal": 83,
+  "contributors": 11,
   "pullRequests": {
     "open": 1
   },
@@ -25,6 +25,13 @@
       "contributions": 1
     },
     {
+      "id": 658915,
+      "login": "CalMlynarczyk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/658915?v=4",
+      "htmlUrl": "https://github.com/CalMlynarczyk",
+      "contributions": 1
+    },
+    {
       "id": 25364049,
       "login": "vishalraghav94",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25364049?v=4",
@@ -32,18 +39,18 @@
       "contributions": 3
     },
     {
-      "id": 2106178,
-      "login": "kamaz",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2106178?v=4",
-      "htmlUrl": "https://github.com/kamaz",
-      "contributions": 13
-    },
-    {
       "id": 17498,
       "login": "kolanos",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17498?v=4",
       "htmlUrl": "https://github.com/kolanos",
       "contributions": 49
+    },
+    {
+      "id": 2106178,
+      "login": "kamaz",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2106178?v=4",
+      "htmlUrl": "https://github.com/kamaz",
+      "contributions": 13
     },
     {
       "id": 11327,

--- a/src/data/project-stats/newrelic-sidecar.json
+++ b/src/data/project-stats/newrelic-sidecar.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 3952624,
-      "login": "buchowski",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3952624?v=4",
-      "htmlUrl": "https://github.com/buchowski",
-      "contributions": 4
+      "id": 788216,
+      "login": "mihaitodor",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/788216?v=4",
+      "htmlUrl": "https://github.com/mihaitodor",
+      "contributions": 69
     },
     {
       "id": 4752327,
@@ -32,18 +32,11 @@
       "contributions": 5
     },
     {
-      "id": 1864489,
-      "login": "donaladams",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1864489?v=4",
-      "htmlUrl": "https://github.com/donaladams",
-      "contributions": 1
-    },
-    {
-      "id": 788216,
-      "login": "mihaitodor",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/788216?v=4",
-      "htmlUrl": "https://github.com/mihaitodor",
-      "contributions": 69
+      "id": 3952624,
+      "login": "buchowski",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3952624?v=4",
+      "htmlUrl": "https://github.com/buchowski",
+      "contributions": 4
     },
     {
       "id": 25198,
@@ -51,6 +44,13 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/25198?v=4",
       "htmlUrl": "https://github.com/benders",
       "contributions": 2
+    },
+    {
+      "id": 1864489,
+      "login": "donaladams",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1864489?v=4",
+      "htmlUrl": "https://github.com/donaladams",
+      "contributions": 1
     },
     {
       "id": 267761,

--- a/src/data/project-stats/newrelic-terraform-provider-newrelic.json
+++ b/src/data/project-stats/newrelic-terraform-provider-newrelic.json
@@ -1,18 +1,18 @@
 {
   "projectFullName": "newrelic/terraform-provider-newrelic",
   "issues": {
-    "open": 50
+    "open": 53
   },
   "releases": 97,
   "latestRelease": {
     "name": "v2.23.0",
     "date": "2021-06-11T00:45:45Z"
   },
-  "commits": 1555,
-  "lastSixMonthsCommitTotal": 244,
+  "commits": 1587,
+  "lastSixMonthsCommitTotal": 229,
   "contributors": 65,
   "pullRequests": {
-    "open": 13
+    "open": 12
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -77,34 +77,6 @@
       "contributions": 6
     },
     {
-      "id": 25882699,
-      "login": "dbonfigli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/25882699?v=4",
-      "htmlUrl": "https://github.com/dbonfigli",
-      "contributions": 1
-    },
-    {
-      "id": 66635386,
-      "login": "dbonfigli-flowing",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/66635386?v=4",
-      "htmlUrl": "https://github.com/dbonfigli-flowing",
-      "contributions": 1
-    },
-    {
-      "id": 6051117,
-      "login": "sgsiebers",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6051117?v=4",
-      "htmlUrl": "https://github.com/sgsiebers",
-      "contributions": 3
-    },
-    {
-      "id": 4684194,
-      "login": "jamesgoodhouse",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4684194?v=4",
-      "htmlUrl": "https://github.com/jamesgoodhouse",
-      "contributions": 27
-    },
-    {
       "id": 7197435,
       "login": "SowmyaJujjuri",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7197435?v=4",
@@ -112,101 +84,10 @@
       "contributions": 35
     },
     {
-      "id": 328689,
-      "login": "eheydrick",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/328689?v=4",
-      "htmlUrl": "https://github.com/eheydrick",
-      "contributions": 2
-    },
-    {
-      "id": 1706,
-      "login": "meqif",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1706?v=4",
-      "htmlUrl": "https://github.com/meqif",
-      "contributions": 3
-    },
-    {
-      "id": 3082319,
-      "login": "grubernaut",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3082319?v=4",
-      "htmlUrl": "https://github.com/grubernaut",
-      "contributions": 17
-    },
-    {
-      "id": 770778,
-      "login": "xeago",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/770778?v=4",
-      "htmlUrl": "https://github.com/xeago",
-      "contributions": 1
-    },
-    {
-      "id": 422474,
-      "login": "paultyng",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/422474?v=4",
-      "htmlUrl": "https://github.com/paultyng",
-      "contributions": 31
-    },
-    {
-      "id": 2581608,
-      "login": "harrykimpel",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2581608?v=4",
-      "htmlUrl": "https://github.com/harrykimpel",
-      "contributions": 5
-    },
-    {
-      "id": 65650,
-      "login": "founddrama",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/65650?v=4",
-      "htmlUrl": "https://github.com/founddrama",
-      "contributions": 1
-    },
-    {
-      "id": 5388077,
-      "login": "vincentclee",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5388077?v=4",
-      "htmlUrl": "https://github.com/vincentclee",
-      "contributions": 1
-    },
-    {
-      "id": 36832285,
-      "login": "appilon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/36832285?v=4",
-      "htmlUrl": "https://github.com/appilon",
-      "contributions": 1
-    },
-    {
-      "id": 34520049,
-      "login": "link-publisher",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34520049?v=4",
-      "htmlUrl": "https://github.com/link-publisher",
-      "contributions": 2
-    },
-    {
-      "id": 34693931,
-      "login": "timonwalkley",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34693931?v=4",
-      "htmlUrl": "https://github.com/timonwalkley",
-      "contributions": 1
-    },
-    {
-      "id": 27262268,
-      "login": "t0astbandit",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/27262268?v=4",
-      "htmlUrl": "https://github.com/t0astbandit",
-      "contributions": 1
-    },
-    {
-      "id": 24275263,
-      "login": "fredrbl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24275263?v=4",
-      "htmlUrl": "https://github.com/fredrbl",
-      "contributions": 1
-    },
-    {
-      "id": 14220781,
-      "login": "NicoleYson",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14220781?v=4",
-      "htmlUrl": "https://github.com/NicoleYson",
+      "id": 25882699,
+      "login": "dbonfigli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/25882699?v=4",
+      "htmlUrl": "https://github.com/dbonfigli",
       "contributions": 1
     },
     {
@@ -221,21 +102,56 @@
       "login": "kidk",
       "avatarUrl": "https://avatars.githubusercontent.com/u/184273?v=4",
       "htmlUrl": "https://github.com/kidk",
-      "contributions": 16
+      "contributions": 17
     },
     {
-      "id": 3933557,
-      "login": "nejoyer",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3933557?v=4",
-      "htmlUrl": "https://github.com/nejoyer",
+      "id": 770778,
+      "login": "xeago",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/770778?v=4",
+      "htmlUrl": "https://github.com/xeago",
       "contributions": 1
     },
     {
-      "id": 595975,
-      "login": "schmickie",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/595975?v=4",
-      "htmlUrl": "https://github.com/schmickie",
+      "id": 4684194,
+      "login": "jamesgoodhouse",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4684194?v=4",
+      "htmlUrl": "https://github.com/jamesgoodhouse",
+      "contributions": 27
+    },
+    {
+      "id": 12850030,
+      "login": "blckct",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12850030?v=4",
+      "htmlUrl": "https://github.com/blckct",
       "contributions": 1
+    },
+    {
+      "id": 5388077,
+      "login": "vincentclee",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5388077?v=4",
+      "htmlUrl": "https://github.com/vincentclee",
+      "contributions": 1
+    },
+    {
+      "id": 422474,
+      "login": "paultyng",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/422474?v=4",
+      "htmlUrl": "https://github.com/paultyng",
+      "contributions": 31
+    },
+    {
+      "id": 34693931,
+      "login": "timonwalkley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34693931?v=4",
+      "htmlUrl": "https://github.com/timonwalkley",
+      "contributions": 1
+    },
+    {
+      "id": 2581608,
+      "login": "harrykimpel",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2581608?v=4",
+      "htmlUrl": "https://github.com/harrykimpel",
+      "contributions": 5
     },
     {
       "id": 548524,
@@ -245,10 +161,94 @@
       "contributions": 1
     },
     {
+      "id": 65650,
+      "login": "founddrama",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65650?v=4",
+      "htmlUrl": "https://github.com/founddrama",
+      "contributions": 1
+    },
+    {
+      "id": 66635386,
+      "login": "dbonfigli-flowing",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/66635386?v=4",
+      "htmlUrl": "https://github.com/dbonfigli-flowing",
+      "contributions": 1
+    },
+    {
+      "id": 34520049,
+      "login": "link-publisher",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34520049?v=4",
+      "htmlUrl": "https://github.com/link-publisher",
+      "contributions": 2
+    },
+    {
+      "id": 24275263,
+      "login": "fredrbl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24275263?v=4",
+      "htmlUrl": "https://github.com/fredrbl",
+      "contributions": 1
+    },
+    {
+      "id": 27262268,
+      "login": "t0astbandit",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/27262268?v=4",
+      "htmlUrl": "https://github.com/t0astbandit",
+      "contributions": 1
+    },
+    {
+      "id": 3991975,
+      "login": "davidji99",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3991975?v=4",
+      "htmlUrl": "https://github.com/davidji99",
+      "contributions": 1
+    },
+    {
       "id": 4398863,
       "login": "stephendavidmarsh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4398863?v=4",
       "htmlUrl": "https://github.com/stephendavidmarsh",
+      "contributions": 1
+    },
+    {
+      "id": 6051117,
+      "login": "sgsiebers",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6051117?v=4",
+      "htmlUrl": "https://github.com/sgsiebers",
+      "contributions": 3
+    },
+    {
+      "id": 3933557,
+      "login": "nejoyer",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3933557?v=4",
+      "htmlUrl": "https://github.com/nejoyer",
+      "contributions": 1
+    },
+    {
+      "id": 1706,
+      "login": "meqif",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1706?v=4",
+      "htmlUrl": "https://github.com/meqif",
+      "contributions": 3
+    },
+    {
+      "id": 595975,
+      "login": "schmickie",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/595975?v=4",
+      "htmlUrl": "https://github.com/schmickie",
+      "contributions": 1
+    },
+    {
+      "id": 3082319,
+      "login": "grubernaut",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3082319?v=4",
+      "htmlUrl": "https://github.com/grubernaut",
+      "contributions": 17
+    },
+    {
+      "id": 36832285,
+      "login": "appilon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36832285?v=4",
+      "htmlUrl": "https://github.com/appilon",
       "contributions": 1
     },
     {
@@ -263,7 +263,7 @@
       "login": "jaymcgrath",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17018863?v=4",
       "htmlUrl": "https://github.com/jaymcgrath",
-      "contributions": 6
+      "contributions": 7
     },
     {
       "id": 18334612,
@@ -312,20 +312,20 @@
       "login": "ctrombley",
       "avatarUrl": "https://avatars.githubusercontent.com/u/413389?v=4",
       "htmlUrl": "https://github.com/ctrombley",
-      "contributions": 222
+      "contributions": 224
     },
     {
       "id": 1663955,
       "login": "mbazhlekova",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1663955?v=4",
       "htmlUrl": "https://github.com/mbazhlekova",
-      "contributions": 4
+      "contributions": 12
     },
     {
-      "id": 12850030,
-      "login": "blckct",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12850030?v=4",
-      "htmlUrl": "https://github.com/blckct",
+      "id": 14220781,
+      "login": "nicoleyson",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14220781?v=4",
+      "htmlUrl": "https://github.com/nicoleyson",
       "contributions": 1
     },
     {
@@ -333,7 +333,7 @@
       "login": "renovate-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25180681?v=4",
       "htmlUrl": "https://github.com/renovate-bot",
-      "contributions": 111
+      "contributions": 116
     },
     {
       "id": 455419,
@@ -343,11 +343,11 @@
       "contributions": 98
     },
     {
-      "id": 3991975,
-      "login": "davidji99",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3991975?v=4",
-      "htmlUrl": "https://github.com/davidji99",
-      "contributions": 1
+      "id": 328689,
+      "login": "eheydrick",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/328689?v=4",
+      "htmlUrl": "https://github.com/eheydrick",
+      "contributions": 2
     },
     {
       "id": 732724,

--- a/src/data/project-stats/newrelic-tracker-google-publisher-tags-js.json
+++ b/src/data/project-stats/newrelic-tracker-google-publisher-tags-js.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 14294477,
-      "login": "jaguilar87",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14294477?v=4",
-      "htmlUrl": "https://github.com/jaguilar87",
-      "contributions": 8
+      "id": 8813505,
+      "login": "adwetzelnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
+      "htmlUrl": "https://github.com/adwetzelnr",
+      "contributions": 4
     },
     {
       "id": 6130000,
@@ -32,11 +32,11 @@
       "contributions": 43
     },
     {
-      "id": 8813505,
-      "login": "adwetzelnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
-      "htmlUrl": "https://github.com/adwetzelnr",
-      "contributions": 4
+      "id": 14294477,
+      "login": "jaguilar87",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14294477?v=4",
+      "htmlUrl": "https://github.com/jaguilar87",
+      "contributions": 8
     }
   ],
   "languages": [

--- a/src/data/project-stats/newrelic-tutone.json
+++ b/src/data/project-stats/newrelic-tutone.json
@@ -8,11 +8,11 @@
     "name": "v0.8.1",
     "date": "2021-06-15T23:00:09Z"
   },
-  "commits": 432,
+  "commits": 444,
   "lastSixMonthsCommitTotal": 82,
   "contributors": 7,
   "pullRequests": {
-    "open": 3
+    "open": 1
   },
   "searchCategory": "good first issue",
   "cachedIssues": [
@@ -36,18 +36,18 @@
   ],
   "cachedContributors": [
     {
+      "id": 455419,
+      "login": "jthurman42",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
+      "htmlUrl": "https://github.com/jthurman42",
+      "contributions": 76
+    },
+    {
       "id": 7197435,
       "login": "SowmyaJujjuri",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7197435?v=4",
       "htmlUrl": "https://github.com/SowmyaJujjuri",
       "contributions": 2
-    },
-    {
-      "id": 7471617,
-      "login": "Tarliton",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7471617?v=4",
-      "htmlUrl": "https://github.com/Tarliton",
-      "contributions": 1
     },
     {
       "id": 413389,
@@ -61,21 +61,21 @@
       "login": "sanderblue",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2590905?v=4",
       "htmlUrl": "https://github.com/sanderblue",
-      "contributions": 39
+      "contributions": 41
     },
     {
       "id": 25180681,
       "login": "renovate-bot",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25180681?v=4",
       "htmlUrl": "https://github.com/renovate-bot",
-      "contributions": 42
+      "contributions": 46
     },
     {
-      "id": 455419,
-      "login": "jthurman42",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/455419?v=4",
-      "htmlUrl": "https://github.com/jthurman42",
-      "contributions": 76
+      "id": 7471617,
+      "login": "Tarliton",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7471617?v=4",
+      "htmlUrl": "https://github.com/Tarliton",
+      "contributions": 1
     },
     {
       "id": 29264964,

--- a/src/data/project-stats/newrelic-video-agent-android.json
+++ b/src/data/project-stats/newrelic-video-agent-android.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 277,
-  "lastSixMonthsCommitTotal": 60,
+  "lastSixMonthsCommitTotal": 50,
   "contributors": 2,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-video-agent-ios.json
+++ b/src/data/project-stats/newrelic-video-agent-ios.json
@@ -9,7 +9,7 @@
     "date": null
   },
   "commits": 532,
-  "lastSixMonthsCommitTotal": 66,
+  "lastSixMonthsCommitTotal": 58,
   "contributors": 1,
   "pullRequests": {
     "open": 0

--- a/src/data/project-stats/newrelic-video-agent-roku.json
+++ b/src/data/project-stats/newrelic-video-agent-roku.json
@@ -18,6 +18,13 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 56542619,
+      "login": "bchelkowskidazn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/56542619?v=4",
+      "htmlUrl": "https://github.com/bchelkowskidazn",
+      "contributions": 3
+    },
+    {
       "id": 8813505,
       "login": "adwetzelnr",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
@@ -44,13 +51,6 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/1011926?v=4",
       "htmlUrl": "https://github.com/pawelhertman",
       "contributions": 1
-    },
-    {
-      "id": 56542619,
-      "login": "bchelkowskidazn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/56542619?v=4",
-      "htmlUrl": "https://github.com/bchelkowskidazn",
-      "contributions": 3
     },
     {
       "id": 11152170,

--- a/src/data/project-stats/newrelic-video-caf-js.json
+++ b/src/data/project-stats/newrelic-video-caf-js.json
@@ -3,14 +3,14 @@
   "issues": {
     "open": 0
   },
-  "releases": 5,
+  "releases": 6,
   "latestRelease": {
-    "name": "0.5.0",
-    "date": "2021-06-08T11:39:21Z"
+    "name": "v0.6.0",
+    "date": null
   },
-  "commits": 46,
-  "lastSixMonthsCommitTotal": 24,
-  "contributors": 2,
+  "commits": 49,
+  "lastSixMonthsCommitTotal": 27,
+  "contributors": 3,
   "pullRequests": {
     "open": 0
   },
@@ -18,11 +18,18 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
+      "id": 8813505,
+      "login": "adwetzelnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
+      "htmlUrl": "https://github.com/adwetzelnr",
+      "contributions": 1
+    },
+    {
       "id": 6130000,
       "login": "asllop",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6130000?v=4",
       "htmlUrl": "https://github.com/asllop",
-      "contributions": 29
+      "contributions": 31
     },
     {
       "id": 929261,

--- a/src/data/project-stats/newrelic-video-theplatform-js.json
+++ b/src/data/project-stats/newrelic-video-theplatform-js.json
@@ -18,11 +18,11 @@
   "cachedIssues": [],
   "cachedContributors": [
     {
-      "id": 14294477,
-      "login": "jaguilar87",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14294477?v=4",
-      "htmlUrl": "https://github.com/jaguilar87",
-      "contributions": 33
+      "id": 8813505,
+      "login": "adwetzelnr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
+      "htmlUrl": "https://github.com/adwetzelnr",
+      "contributions": 8
     },
     {
       "id": 6130000,
@@ -32,11 +32,11 @@
       "contributions": 5
     },
     {
-      "id": 8813505,
-      "login": "adwetzelnr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8813505?v=4",
-      "htmlUrl": "https://github.com/adwetzelnr",
-      "contributions": 8
+      "id": 14294477,
+      "login": "jaguilar87",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14294477?v=4",
+      "htmlUrl": "https://github.com/jaguilar87",
+      "contributions": 33
     }
   ],
   "languages": [


### PR DESCRIPTION
Avoid merge conflicts for `src/data/project-stats` files when PR-ing `develop` to `main`. `develop` had commits from old workflow before Kris merged his PR that switched that workflow to merge directly to `main`, which is causing conflicts when trying to deploy.