### PR TITLE
Add redirect logic for projects with local redirects

### DIFF
--- a/gatsby/create-pages.js
+++ b/gatsby/create-pages.js
@@ -42,7 +42,7 @@ const createProjectPages = async ({ graphql, actions }) => {
     const component = getProjectComponent(node.projectType);
     const path = `/projects/${node.fullName}`;
     if (node.redirects) {
-      node.redirects.map((redirect) => {
+      node.redirects.forEach((redirect) => {
         // Create redirects for paths with and without a trailing slash
         const pathWithTrailingSlash = appendTrailingSlash(redirect);
         const pathWithoutTrailingSlash = pathWithTrailingSlash.slice(0, -1);

--- a/src/data/projects/newrelic-newrelic-quickstarts.json
+++ b/src/data/projects/newrelic-newrelic-quickstarts.json
@@ -2,6 +2,7 @@
   "name": "newrelic-quickstarts",
   "fullName": "newrelic/newrelic-quickstarts",
   "slug": "newrelic-newrelic-quickstarts",
+  "redirects": ["/projects/newrelic/nr1-quickstarts"],
   "owner": {
     "login": "newrelic",
     "type": "Organization"


### PR DESCRIPTION
This adds logic for redirects within project pages and adds the specific redirect of `/projects/newrelic/nr1-quickstarts` to `/projects/newrelic/newrelic-quickstarts`
Closes https://github.com/newrelic/opensource-website/issues/850
To review:
Both `/projects/newrelic/nr1-quickstarts/` and `/projects/newrelic/nr1-quickstarts` (with and without trailing slash) should redirect to `/projects/newrelic/newrelic-quickstarts`