### PR TITLE
chore: added pino log enricher, updated urls for winston log enricher as they moved to monorepo

### DIFF
--- a/src/data/project-main-content/newrelic-newrelic-pino-logenricher-node.mdx
+++ b/src/data/project-main-content/newrelic-newrelic-pino-logenricher-node.mdx
@@ -1,13 +1,13 @@
 ---
-path: "/projects/newrelic/newrelic-winston-logenricher-node"
+path: "/projects/newrelic/newrelic-pino-logenricher-node"
 date: "05/01/2020"
-title: "New Relic Winston Log Enricher"
-projectConfig: "src/data/projects/newrelic-newrelic-winston-logenricher-node.json"
+title: "New Relic Pino Log Enricher"
+projectConfig: "src/data/projects/newrelic-newrelic-pino-logenricher-node.json"
 ---
 
 ## Getting Started
 
-Go to the project's [README](https://github.com/newrelic/newrelic-node-log-extensions/blob/main/packages/winston-log-enricher/README.md) for setup and usage details.
+Go to the project's [README](https://github.com/newrelic/newrelic-node-log-extensions/blob/main/packages/pino-log-enricher/README.md) for setup and usage details.
 
 <!--
 

--- a/src/data/projects/newrelic-newrelic-pino-logenricher-node.json
+++ b/src/data/projects/newrelic-newrelic-pino-logenricher-node.json
@@ -1,0 +1,27 @@
+{
+  "name": "newrelic-pino-logenricher-node",
+  "fullName": "newrelic/newrelic-pino-logenricher-node",
+  "slug": "newrelic-newrelic-pino-logenricher-node",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic Pino Log Enricher",
+  "supportUrl": "https://discuss.newrelic.com/t/node-log-enrichers-logs-in-context/88806",
+  "githubUrl": "https://github.com/newrelic/newrelic-node-log-extensions",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/newrelic-pino-logenricher-node",
+  "iconUrl": null,
+  "shortDescription": "Log Enricher for the New Relic Node Agent",
+  "description": "New Relic's Pino log enricher for use with the Node Agent",
+  "ossCategory": "community-plus",
+  "primaryLanguage": "JavaScript",
+  "projectTags": [
+    "logging",
+    "exporter"
+  ],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Pino Log Enricher",
+    "url": "https://github.com/newrelic/newrelic-node-log-extensions/tree/main/packages/pino-log-enricher"
+  }
+}

--- a/src/data/projects/newrelic-newrelic-winston-logenricher-node.json
+++ b/src/data/projects/newrelic-newrelic-winston-logenricher-node.json
@@ -8,7 +8,7 @@
   },
   "title": "New Relic Winston Log Enricher",
   "supportUrl": "https://discuss.newrelic.com/t/node-log-enrichers-logs-in-context/88806",
-  "githubUrl": "https://github.com/newrelic/newrelic-winston-logenricher-node",
+  "githubUrl": "https://github.com/newrelic/newrelic-node-log-extensions",
   "permalink": "https://opensource.newrelic.com/projects/newrelic/newrelic-winston-logenricher-node",
   "iconUrl": null,
   "shortDescription": "Log Enricher for the New Relic Node Agent",
@@ -22,6 +22,6 @@
   "acceptsContributions": true,
   "website": {
     "title": "New Relic Winston Log Enricher",
-    "url": "https://github.com/newrelic/newrelic-winston-logenricher-node"
+    "url": "https://github.com/newrelic/newrelic-node-log-extensions/tree/main/packages/winston-log-enricher"
   }
 }


### PR DESCRIPTION
I added a new entry for Pino Log Enricher.  I also updated links to point to the correct monorepo for Winston Log Enricher.  I had a few questions:

 * The pino page lacks repo stats and top contributors, how does this get built and does it not work locally?
 * The top contributors for winston differ locally than they do in production
 * The naming convention suggested for files will not work in a monorepo so I used my best judgement, will this be ok?