### PR TITLE
chore: added next.js instrumentation module

### DIFF
--- a/src/data/project-main-content/newrelic-newrelic-node-nextjs.mdx
+++ b/src/data/project-main-content/newrelic-newrelic-node-nextjs.mdx
@@ -1,0 +1,62 @@
+---
+path: "/projects/newrelic/newrelic-node-nextjs"
+date: "02/24/2022"
+title: "New Relic Next.js (Node.js)"
+projectConfig: "src/data/projects/newrelic-newrelic-node-nextjs.json"
+---
+
+## Getting Started
+
+Go to the project's [README](https://github.com/newrelic/newrelic-node-nextjs#readme) for setup and usage details.
+
+<!--
+
+import { Link } from 'gatsby';
+
+<div className="responsive-video">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/7wnav6Fu9T0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<Link to="/cta">Install</Link>
+
+## [Optional] Features
+
+### [Optional] Feature 1
+
+### [Optional] Feature 2
+
+## [Required] Getting Started
+
+### [Optional] Code example highlighting an extension or customization point
+
+This is how you extend New Relic Node Agent in following way.
+
+```js
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// I'm a comment;
+const aMadeUpFunction = () => {
+if (myArray.length !== 100) {
+  myArray.map((item, i) => item * i);
+} else {
+  return null
+}
+};
+```
+### [Optional] More details about the project
+
+## [Optional] What people are saying
+
+Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+Maecenas faucibus mollis interdum. Lorem ipsum dolor sit amet,
+consectetur adipiscing elit.
+
+> [name="Leslie Webb"] Vitae enim egestas egestas at gravida arcu, amet in. Facilisis at
+massa amet, aliquet dui semper. Sit placerat sed et ornare faucibus
+egestas sit nisl, diam.
+
+> [name="Bildad the Shuhite"] Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+vestibulum. Maecenas faucibus mollis interdum. Maecenas sed diam
+eget risus varius blandit sit amet non magna.
+-->

--- a/src/data/projects/newrelic-newrelic-node-nextjs.json
+++ b/src/data/projects/newrelic-newrelic-node-nextjs.json
@@ -1,0 +1,29 @@
+{
+  "name": "newrelic-node-nextjs",
+  "fullName": "newrelic/newrelic-node-nextjs",
+  "slug": "newrelic-newrelic-node-nextjs",
+  "owner": {
+    "login": "newrelic",
+    "type": "Organization"
+  },
+  "title": "New Relic Next.js(Node.js)",
+  "supportUrl": "https://discuss.newrelic.com/tags/c/telemetry-data-platform/agents/nodeagent",
+  "githubUrl": "https://github.com/newrelic/newrelic-node-nextjs",
+  "permalink": "https://opensource.newrelic.com/projects/newrelic/newrelic-node-nextjs",
+  "iconUrl": null,
+  "shortDescription": "Node.js Agent instumentation for Next.js",
+  "description": "Next.js framework instrumentation for New Relic's Node.js Agent",
+  "ossCategory": "community-plus",
+  "primaryLanguage": "JavaScript",
+  "projectTags": [
+    "agent",
+    "exporter",
+    "lib"
+  ],
+  "acceptsContributions": true,
+  "website": {
+    "title": "New Relic Next.js(Node.js)",
+    "url": "https://github.com/newrelic/newrelic-node-nextjs"
+  },
+  "defaultBranch": "main"
+}


### PR DESCRIPTION
I added a new entry for `@newrelic/next` instrumentation.  This repo is still private and plan on making public early next week.  I just wanted to get this PR in now as it's one of the last items of our MMF.  Closes https://github.com/newrelic/newrelic-node-nextjs/issues/10