### PR TITLE
Codeowners for OSS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# .github directory & its subdirectories
+/.github/ @newrelic/docs-engineering
+
+# all javascript files
+*.js @newrelic/docs-engineering
+
+yarn.lock @newrelic/docs-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 *.js @newrelic/docs-engineering
 
 yarn.lock @newrelic/docs-engineering
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
               required_status_checks: null,
               restrictions: {
                 users: [],
-                teams: ['developer-enablement']
+                teams: ['docs-engineering']
               },
               enforce_admins: true,
               required_pull_request_reviews: {

--- a/docs/Emergency-Runbook.md
+++ b/docs/Emergency-Runbook.md
@@ -1,6 +1,6 @@
 # Emergency Runbook -- opensource.newrelic.com
 
-This site is hosted on [Gatsby Cloud](https://www.gatsbyjs.com/products/cloud/). It is maintained and supported by New Relic's Developer Enablement team. If you have any questions or comments, please reach out to <developer-enablement@newrelic.com>.
+This site is hosted on [Gatsby Cloud](https://www.gatsbyjs.com/products/cloud/). It is maintained and supported by New Relic's Docs Engineering team. If you have any questions or comments, please reach out to <docs-engineering@newrelic.com>.
 
 ## Alerts
 
@@ -22,7 +22,7 @@ First, determine the desired previous build:
 
 Steps to redeploy in Gatsby Cloud:
 
-1. Log into Gatsby Cloud using your GitHub login. 
+1. Log into Gatsby Cloud using your GitHub login.
 2. Select the `opensource-website` site, main branch.
    ![Opensource Sites](./images/screenshot_05.png)
 3. Click the `View production history` button to see all the previous builds that have run.


### PR DESCRIPTION
## Summary

### Github:
- Created new [Docs Engineering Team](https://github.com/orgs/newrelic/teams/docs-engineering/)
- Added team as Admin to [OSS](https://github.com/newrelic/opensource-website)

### Repo
- Added `CODEOWNERS` file
- Remove references to `Developer Enablement` and updated to `Docs Engineering`

Resolves https://github.com/newrelic/docs-website/issues/6562