### PR TITLE
Filter for newrelic projects differently

### DIFF
--- a/src/pages/collection.js
+++ b/src/pages/collection.js
@@ -12,7 +12,7 @@ export const query = graphql`
   query CollectionProjects {
     allProjects(
       filter: {
-        projectType: { eq: "newrelic" }
+        projectType: { ne: "external" }
         projectTags: { elemMatch: { slug: { eq: "agent" } } }
       }
     ) {

--- a/src/pages/collections.js
+++ b/src/pages/collections.js
@@ -14,7 +14,7 @@ export const query = graphql`
   query allCollections($path: String) {
     instrumentation: allProjects(
       filter: {
-        projectType: { eq: "newrelic" }
+        projectType: { ne: "external" }
         projectTags: {
           elemMatch: {
             slug: { in: ["exporter", "nri", "agent", "sdk", "cli"] }
@@ -31,7 +31,7 @@ export const query = graphql`
 
     nerdpacks: allProjects(
       filter: {
-        projectType: { eq: "newrelic" }
+        projectType: { ne: "external" }
         projectTags: { elemMatch: { slug: { eq: "nr1-app" } } }
       } # sort: { fields: stats___lastSixMonthsCommitTotal, order: DESC }
     ) {

--- a/src/pages/explore-projects.js
+++ b/src/pages/explore-projects.js
@@ -19,7 +19,7 @@ import * as styles from './explore-projects.module.scss';
 
 export const query = graphql`
   query ExploreProjects($path: String) {
-    allProjects(filter: { projectType: { eq: "newrelic" } }) {
+    allProjects(filter: { projectType: { ne: "external" } }) {
       edges {
         node {
           ...exploreProjectsFields

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,7 +12,7 @@ import * as styles from './home-page.module.scss';
 
 export const query = graphql`
   query HomePageQuery($path: String) {
-    topProjects: allProjects(filter: { projectType: { eq: "newrelic" } }) {
+    topProjects: allProjects(filter: { projectType: { ne: "external" } }) {
       edges {
         node {
           ...projectFields
@@ -21,7 +21,7 @@ export const query = graphql`
     }
     instrumentation: allProjects(
       filter: {
-        projectType: { eq: "newrelic" }
+        projectType: { ne: "external" }
         projectTags: {
           elemMatch: {
             slug: { in: ["exporter", "nri", "agent", "sdk", "cli"] }

--- a/src/pages/instrumentation.js
+++ b/src/pages/instrumentation.js
@@ -12,7 +12,7 @@ export const query = graphql`
   query InstrumentationProjects($path: String) {
     allProjects(
       filter: {
-        projectType: { eq: "newrelic" }
+        projectType: { ne: "external" }
         projectTags: {
           elemMatch: {
             slug: { in: ["exporter", "nri", "agent", "sdk", "cli"] }

--- a/src/pages/nerdpacks.js
+++ b/src/pages/nerdpacks.js
@@ -12,7 +12,7 @@ export const query = graphql`
   query NerdpackProjects($path: String) {
     allProjects(
       filter: {
-        projectType: { eq: "newrelic" }
+        projectType: { ne: "external" }
         projectTags: { elemMatch: { slug: { eq: "nr1-app" } } }
       }
     ) {

--- a/src/templates/project-page.js
+++ b/src/templates/project-page.js
@@ -43,7 +43,7 @@ export const query = graphql`
       }
     }
     project: allProjects(
-      filter: { slug: { eq: $slug }, projectType: { eq: "newrelic" } }
+      filter: { slug: { eq: $slug }, projectType: { ne: "external" } }
     ) {
       nodes {
         ...projectFields


### PR DESCRIPTION
Something about gatsby 4 has changed the way some of the node logic worked. Previously nodes without a projectType were given a fallback of 'newrelic' but that stopped working. This means all queries filtering by projectType 'newrelic' were coming back empty. For the time being I removed that filter and instead check not equal to 'external' which is the only other projectType