### PR TITLE
fix: Search input no longer sets darkMode to undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
-    "@newrelic/gatsby-theme-newrelic": "^6.19.1",
+    "@newrelic/gatsby-theme-newrelic": "^7.0.4",
     "@splitsoftware/splitio-react": "^1.2.4",
     "date-fns": "^2.17.0",
     "feather-icons": "^4.28.0",

--- a/src/components/__tests__/__snapshots__/ProjectSearchInput.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/ProjectSearchInput.spec.js.snap
@@ -258,6 +258,7 @@ exports[`ProjectSearchInput Renders correctly 1`] = `
         >
           <div
             className="emotion-6"
+            href={false}
             onClick={[Function]}
           >
             All Categories
@@ -291,6 +292,7 @@ exports[`ProjectSearchInput Renders correctly 1`] = `
         >
           <div
             className="emotion-6"
+            href={false}
             onClick={[Function]}
           >
             All Project Tags
@@ -324,6 +326,7 @@ exports[`ProjectSearchInput Renders correctly 1`] = `
         >
           <div
             className="emotion-6"
+            href={false}
             onClick={[Function]}
           >
             All Language Types

--- a/src/components/withDarkMode.js
+++ b/src/components/withDarkMode.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import useDarkMode from 'use-dark-mode';
+import { useDarkMode } from '@newrelic/gatsby-theme-newrelic';
 import isLocalStorageAvailable from '../utils/isLocalStorageAvailable';
 
 const withDarkMode = (ComponentToWrap) => (props) => {
@@ -9,16 +9,8 @@ const withDarkMode = (ComponentToWrap) => (props) => {
   }, []);
   const isDarkDefault = false;
   const checkLocalStorage = isLocalStorageAvailable();
-  const darkMode = () => {
-    if (checkLocalStorage) {
-      const localStorageTheme = localStorage.getItem('darkMode');
-      if (localStorageTheme === 'true' || localStorageTheme === 'false') {
-        return JSON.parse(localStorageTheme);
-      }
-    } else {
-      return useDarkMode(isDarkDefault, { storageProvider: false });
-    }
-  };
+  const darkModeOptions = checkLocalStorage ? {} : { storageProvider: false };
+  const darkMode = useDarkMode(isDarkDefault, darkModeOptions);
 
   if (!isClient) {
     return null;

--- a/src/components/withDarkMode.js
+++ b/src/components/withDarkMode.js
@@ -9,8 +9,16 @@ const withDarkMode = (ComponentToWrap) => (props) => {
   }, []);
   const isDarkDefault = false;
   const checkLocalStorage = isLocalStorageAvailable();
-  const darkModeOptions = checkLocalStorage ? {} : { storageProvider: false };
-  const darkMode = useDarkMode(isDarkDefault, darkModeOptions);
+  const darkMode = () => {
+    if (checkLocalStorage) {
+      const localStorageTheme = localStorage.getItem('darkMode');
+      if (localStorageTheme === 'true' || localStorageTheme === 'false') {
+        return JSON.parse(localStorageTheme);
+      }
+    } else {
+      return useDarkMode(isDarkDefault, { storageProvider: false });
+    }
+  };
 
   if (!isClient) {
     return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,10 +2647,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^6.19.1":
-  version "6.19.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.19.2.tgz#14e07a23ecbf4ca65a0709895630066232f29e29"
-  integrity sha512-wZvZ28zic/OOkVJwGvA0I7u8lOqMgBju1KagSNN+5T7xATbpfoCeA5n8P2vI5l9G4skJZLiNY3W/CYKwyQWvzA==
+"@newrelic/gatsby-theme-newrelic@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-7.0.4.tgz#771be9c145345e0257b2fd7431094a41b17261e7"
+  integrity sha512-SHiXc0u6Wn1YPDYQg874iJI0zhLyWCYUT0fku02RWkM1j7yAiP/oR0hRlkcJn6nrLuztNeZsQZ8q9fmAZHZARA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
Use-dark-mode was setting a default darkMode key in localStorage and overriding it to undefined when the search input was used breaking the page. This seems to resolve that from what I could tell. 