### PR TITLE
fix: remove lorem ipsum from collection page

### DIFF
--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -1334,28 +1334,6 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
     className="emotion-101"
   >
     <div>
-      <div
-        className="responsive-video"
-      >
-        <iframe
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen={true}
-          frameBorder="0"
-          height="328.125"
-          src="https://www.youtube.com/embed/g00AeKlECZA?controls=0"
-          width="578"
-        />
-      </div>
-    </div>
-    <section>
-      <h5>
-        Duis mollis, est non commodo luctus
-      </h5>
-      <p>
-        Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec ullamcorper ult nulla non metus auctor fringilla. Duis mollis, est non commodo luctus, eu nisi erat porttitor ligula, eget lacinia odio sem nec elit. Lorem ipsum Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum
-      </p>
-    </section>
-    <div>
       <header>
         <h4>
           Our Agents

--- a/src/pages/collection.js
+++ b/src/pages/collection.js
@@ -35,37 +35,7 @@ const CollectionPage = ({ data, pageContext }) => {
       editLink={pageContext.fileRelativePath}
     >
       <SEO title="Open source projects to which New Relic contributes" />
-      <PageHeading
-        title="New Relic Agents"
-        subheader="Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Cras mattis consectetur purus sit amet fermentum."
-      />
-      <div className={styles.featuredVideoContainer}>
-        <div className="responsive-video">
-          <iframe
-            width="578"
-            height="328.125"
-            src="https://www.youtube.com/embed/g00AeKlECZA?controls=0"
-            frameBorder="0"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          />
-        </div>
-      </div>
-      <section className={styles.primaryBodyCopy}>
-        <h5 className={styles.primaryBodyCopyHeader}>
-          Duis mollis, est non commodo luctus
-        </h5>
-        <p className={styles.primaryBodyCopyDescription}>
-          Etiam porta sem malesuada magna mollis euismod. Praesent commodo
-          cursus magna, vel scelerisque nisl consectetur et. Donec ullamcorper
-          ult nulla non metus auctor fringilla. Duis mollis, est non commodo
-          luctus, eu nisi erat porttitor ligula, eget lacinia odio sem nec elit.
-          Lorem ipsum Fusce dapibus, tellus ac cursus commodo, tortor mauris
-          condimentum nibh, ut fermentum massa justo sit amet risus. Integer
-          posuere erat a ante venenatis dapibus posuere velit aliquet. Aenean eu
-          leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum
-        </p>
-      </section>
+      <PageHeading title="New Relic Agents" />
       <div className={styles.collectionListingContainer}>
         <header className={styles.collectionListingHeaderSection}>
           <h4 className={styles.collectionListingHeaderSectionHeading}>


### PR DESCRIPTION
## Description

Removes what looks to be placeholder lorem ipsum on the `/collection` page. Not 100% sure what that page is intended to be, so leaving rest as is.

Came into help channel as hero request by someone who noticed it.

## Screenshot(s)

Before
![2023-06-02_10-04-03](https://github.com/newrelic/opensource-website/assets/2952843/436972a1-bd9b-4a54-9838-1a5bdcf6c241)

After
![2023-06-02_10-03-18](https://github.com/newrelic/opensource-website/assets/2952843/a7ec0715-2321-4e1a-993b-e0dc73c7ee6c)

