### PR TITLE
Clark/cls troubleshooting

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -13,11 +13,6 @@ const Image = (props) => {
   const [currentSrc, setCurrentSrc] = useState(props.src);
   const [errored, setErrored] = useState(false);
 
-  const [isClient, setIsClient] = useState(false);
-  React.useEffect(() => {
-    setIsClient(true);
-  }, []);
-
   React.useEffect(() => {
     if (errored) {
       setCurrentSrc(props.fallbackSrc);
@@ -32,10 +27,6 @@ const Image = (props) => {
   };
 
   const { src, fallbackSrc, ...remainingProps } = props;
-
-  if (!isClient) {
-    return null;
-  }
 
   return (
     <>

--- a/src/components/PageHeading.js
+++ b/src/components/PageHeading.js
@@ -112,4 +112,4 @@ PageHeading.propTypes = {
   className: PropTypes.string,
 };
 
-export default withDarkMode(PageHeading);
+export default PageHeading;

--- a/src/components/PageHeading.js
+++ b/src/components/PageHeading.js
@@ -58,8 +58,6 @@ const PageHeading = (props) => {
     }
   };
 
-  console.log('hasIcon', hasIcon(), props);
-
   return (
     <div
       className={`${styles.pageHeadingContainer} ${
@@ -78,11 +76,7 @@ const PageHeading = (props) => {
           />
         </div>
       )}
-      {props.title ? (
-        <h1 className={styles.pageTitle}>{props.title} this is a test</h1>
-      ) : (
-        ''
-      )}
+      {props.title ? <h1 className={styles.pageTitle}>{props.title}</h1> : ''}
       {props.subheader ? (
         <p className={styles.pageSubheader}>{props.subheader}</p>
       ) : (

--- a/src/components/PageHeading.js
+++ b/src/components/PageHeading.js
@@ -4,7 +4,6 @@ import { startCase } from 'lodash';
 import Image from './Image';
 
 import * as styles from './PageHeading.module.scss';
-import withDarkMode from './withDarkMode';
 
 const PageHeading = (props) => {
   const { project } = props;

--- a/src/components/PageHeading.js
+++ b/src/components/PageHeading.js
@@ -58,6 +58,8 @@ const PageHeading = (props) => {
     }
   };
 
+  console.log('hasIcon', hasIcon(), props);
+
   return (
     <div
       className={`${styles.pageHeadingContainer} ${
@@ -76,7 +78,11 @@ const PageHeading = (props) => {
           />
         </div>
       )}
-      {props.title ? <h1 className={styles.pageTitle}>{props.title}</h1> : ''}
+      {props.title ? (
+        <h1 className={styles.pageTitle}>{props.title} this is a test</h1>
+      ) : (
+        ''
+      )}
       {props.subheader ? (
         <p className={styles.pageSubheader}>{props.subheader}</p>
       ) : (

--- a/src/pages/__tests__/__snapshots__/collection.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/collection.spec.js.snap
@@ -1333,6 +1333,16 @@ exports[`Data Collection Agents Page Renders correctly 1`] = `
   <main
     className="emotion-101"
   >
+    <div
+      className="undefined     
+      "
+    >
+      <h1>
+        New Relic Agents
+      </h1>
+      
+      
+    </div>
     <div>
       <header>
         <h4>

--- a/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/external-projects.spec.js.snap
@@ -1333,6 +1333,18 @@ exports[`External Projects Page Renders correctly 1`] = `
   <main
     className="emotion-101"
   >
+    <div
+      className="undefined     
+      "
+    >
+      <h1>
+        Projects we support
+      </h1>
+      <p>
+        Making it easier for everyone to instrument everything and build better software together.
+      </p>
+      
+    </div>
     <div />
   </main>
   <footer

--- a/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
+++ b/src/pages/__tests__/__snapshots__/oss-category.spec.js.snap
@@ -1337,6 +1337,18 @@ exports[`OSS Category Page Renders correctly 1`] = `
     className="emotion-102"
   >
     <div
+      className="undefined     
+      "
+    >
+      <h1>
+        New Relic Open Source Categories
+      </h1>
+      <p>
+        Every public repository in the New Relic and New Relic Experimental GitHub organizations leverages one of the following categories
+      </p>
+      
+    </div>
+    <div
       className="primary-content"
     >
       <aside

--- a/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
+++ b/src/templates/__tests__/__snapshots__/external-project-page.spec.js.snap
@@ -1412,6 +1412,25 @@ exports[`Adopt OpenJDK Renders correctly 1`] = `
     className="emotion-107"
   >
     <div
+      className="undefined undefined   undefined 
+      "
+    >
+      <div>
+        <img
+          alt="Icon for Adopt OpenJDK"
+          onError={[Function]}
+          src="../images/adopt-open-jdk-icon.jpg"
+        />
+      </div>
+      <h1>
+        Adopt OpenJDK
+      </h1>
+      <p>
+        The Community and code behind the Build Farm which produces high quality, FREE OpenJDK (Java) binaries.
+      </p>
+      
+    </div>
+    <div
       className="primary-content"
     >
       <main
@@ -2993,6 +3012,25 @@ exports[`Open Telemetry Page Renders correctly 1`] = `
   <main
     className="emotion-107"
   >
+    <div
+      className="undefined undefined   undefined 
+      "
+    >
+      <div>
+        <img
+          alt="Icon for Adopt OpenJDK"
+          onError={[Function]}
+          src="../images/adopt-open-jdk-icon.jpg"
+        />
+      </div>
+      <h1>
+        Adopt OpenJDK
+      </h1>
+      <p>
+        The Community and code behind the Build Farm which produces high quality, FREE OpenJDK (Java) binaries.
+      </p>
+      
+    </div>
     <div
       className="primary-content"
     >


### PR DESCRIPTION
Updates the PageHeader component to no longer use a Higher Order Component during its rendering, this was causing it to render last during page load and was potentially causing a high CLS.  I was only able to test this via a local build in the React Profiler, so this PR will test that theory on a Gatsby Cloud build.