### PR TITLE
chore: update nrjmx support tier

### DIFF
--- a/src/data/projects/newrelic-nrjmx.json
+++ b/src/data/projects/newrelic-nrjmx.json
@@ -13,7 +13,7 @@
   "iconUrl": null,
   "shortDescription": "JMX CLI for New Relic",
   "description": "Command line tool to connect to a JMX server and retrieve the MBeans it exposes",
-  "ossCategory": "new-relic-experimental",
+  "ossCategory": "community-plus",
   "primaryLanguage": "Java",
   "projectTags": ["tools", "cli"],
   "acceptsContributions": true,


### PR DESCRIPTION
Update support tier to Community Plus, based on current readme at https://github.com/newrelic/nrjmx#readme
