### PR TITLE
`OPENSOURCE_STATS_TOKEN` -> `DEVEX_OPENSOURCE_BOT_TOKEN`

### DIFF
--- a/.github/workflows/project-stats.yml
+++ b/.github/workflows/project-stats.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           # runs queries against GitHub API; must have push access to repos for stats queries to work
           # this token is _only_ used for this GH action
-          github-token: ${{ secrets.OPENSOURCE_STATS_TOKEN }}
+          github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           project-stats: true
 
       - name: Commit data files


### PR DESCRIPTION
removing `OPENSOURCE_STATS_TOKEN` and just using `DEVEX_OPENSOURCE_BOT_TOKEN`. not sure why this existed originally but the DEVEX token should work fine