### PR TITLE
`DEVEX_OPENSOURCE_BOT_TOKEN` -> `OPENSOURCE_STATS_TOKEN`

### DIFF
--- a/.github/workflows/project-stats.yml
+++ b/.github/workflows/project-stats.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
+          token: ${{ secrets.OPENSOURCE_STATS_TOKEN }}
 
       - name: Install dependencies
         run: cd .github/actions/sync-data && npm install


### PR DESCRIPTION
`DEVEX_OPENSOURCE_BOT_TOKEN` only has permissions to docs-eng specific repos, so we had to create a new token with read access to all repos for `OPENSOURCE_STATS_TOKEN`
